### PR TITLE
Allow the user to search their orders

### DIFF
--- a/integration_tests/e2e/index.cy.ts
+++ b/integration_tests/e2e/index.cy.ts
@@ -1,53 +1,74 @@
 import IndexPage from '../pages/index'
 import Page from '../pages/page'
 
-context('Sign In', () => {
-  beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+context('Index', () => {
+  context('Health backend', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+      cy.task('stubCemoListOrders')
+    })
+
+    it('User name visible in header', () => {
+      cy.signIn()
+      const indexPage = Page.verifyOnPage(IndexPage)
+      indexPage.headerUserName().should('contain.text', 'J. Smith')
+    })
+
+    it('Phase banner visible in header', () => {
+      cy.signIn()
+      const indexPage = Page.verifyOnPage(IndexPage)
+      indexPage.headerPhaseBanner().should('contain.text', 'dev')
+    })
+
+    it('Create new form should exist', () => {
+      cy.signIn()
+      const indexPage = Page.verifyOnPage(IndexPage)
+      indexPage.newOrderForm().should('exist')
+    })
+
+    it('Create new form button redirects user to new form page', () => {
+      cy.signIn()
+      const indexPage = Page.verifyOnPage(IndexPage)
+      indexPage.newOrderFormButton().click()
+      cy.url().should('to.match', /order\/create$/)
+    })
+
+    it('Should display search results to the user', () => {
+      cy.signIn()
+
+      const indexPage = Page.verifyOnPage(IndexPage)
+      indexPage.ordersList().should('exist')
+      indexPage.ordersListItems().should('exist').should('have.length', 2)
+      indexPage
+        .ordersListItems()
+        .eq(0)
+        .find('.govuk-tag')
+        .should('have.class', 'govuk-tag--green')
+        .should('contain', 'Submitted')
+      indexPage
+        .ordersListItems()
+        .eq(1)
+        .find('.govuk-tag')
+        .should('have.class', 'govuk-tag--grey')
+        .should('contain', 'Draft')
+    })
   })
 
-  it('User name visible in header', () => {
-    cy.signIn()
-    const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.headerUserName().should('contain.text', 'J. Smith')
+  context('Unhealthy backend', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+      cy.task('stubCemoListOrders', 500)
+    })
+
+    it('Should indicate to the user that there were no results', () => {
+      cy.signIn()
+
+      const indexPage = Page.verifyOnPage(IndexPage)
+      indexPage.ordersList().should('exist')
+      indexPage.ordersListItems().should('exist').should('have.length', 1)
+      indexPage.ordersListItems().eq(0).should('contain', 'No existing forms found.')
+    })
   })
-
-  it('Phase banner visible in header', () => {
-    cy.signIn()
-    const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.headerPhaseBanner().should('contain.text', 'dev')
-  })
-
-  it('Create new form should exist', () => {
-    cy.signIn()
-    const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.newOrderForm().should('exist')
-  })
-
-  it('Create new form button redirects user to new form page', () => {
-    cy.signIn()
-    const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.newOrderFormButton().click()
-    cy.url().should('to.match', /order\/create$/)
-  })
-
-  it('Search input and button should exist', () => {
-    cy.signIn()
-    const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.searchInput().should('exist')
-    indexPage.searchButton().should('exist')
-  })
-
-  // TODO: test search function working
-
-  it('Form list should exist', () => {
-    cy.signIn()
-    const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.formTable().should('exist')
-    indexPage.formRow().should('exist')
-  })
-  // TODO: test form link
-
-  // TODO: test pagination
 })

--- a/integration_tests/mockApis/cemo.ts
+++ b/integration_tests/mockApis/cemo.ts
@@ -1,17 +1,45 @@
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 
+const ping = (httpStatus = 200) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/cemo/health',
+    },
+    response: {
+      status: httpStatus,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: { status: httpStatus === 200 ? 'UP' : 'DOWN' },
+    },
+  })
+
+const listOrders = (httpStatus = 200): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/cemo/api/ListForms',
+    },
+    response: {
+      status: httpStatus,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody:
+        httpStatus === 200
+          ? [
+              {
+                id: '8138066f-717d-40d7-bd46-9ed08c68364c',
+                status: 'SUBMITTED',
+              },
+              {
+                id: '8138066f-717d-40d7-bd46-9ed08c68364c',
+                status: 'IN_PROGRESS',
+              },
+            ]
+          : null,
+    },
+  })
+
 export default {
-  stubCemoPing: (httpStatus = 200): SuperAgentRequest =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: '/cemo/health',
-      },
-      response: {
-        status: httpStatus,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: { status: httpStatus === 200 ? 'UP' : 'DOWN' },
-      },
-    }),
+  stubCemoPing: ping,
+  stubCemoListOrders: listOrders,
 }

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -2,7 +2,7 @@ import Page, { PageElement } from './page'
 
 export default class IndexPage extends Page {
   constructor() {
-    super('Electronic Monitoring Order')
+    super('Electronic Monitoring Application Forms')
   }
 
   headerUserName = (): PageElement => cy.get('[data-qa=header-user-name]')
@@ -17,7 +17,7 @@ export default class IndexPage extends Page {
 
   searchButton = (): PageElement => cy.get('button:contains("Search")')
 
-  formTable = (): PageElement => cy.get('#formList')
+  ordersList = (): PageElement => cy.get('#ordersList')
 
-  formRow = (): PageElement => cy.get('.govuk-task-list').find('.govuk-task-list__item')
+  ordersListItems = (): PageElement => cy.get('#ordersList ul li')
 }

--- a/server/controllers/orderSearchController.ts
+++ b/server/controllers/orderSearchController.ts
@@ -14,7 +14,10 @@ export default class OrderSearchController {
       correlationId: req.id,
     })
 
-    const orders = await this.orderSearchService.searchOrders({
+    const { user } = res.locals
+    const { token } = user
+
+    const orders = await this.orderSearchService.searchOrders(token, {
       searchTerm: '',
     })
 

--- a/server/controllers/orderSearchController.ts
+++ b/server/controllers/orderSearchController.ts
@@ -14,13 +14,17 @@ export default class OrderSearchController {
       correlationId: req.id,
     })
 
-    const { user } = res.locals
-    const { token } = user
+    try {
+      const { user } = res.locals
+      const { token } = user
 
-    const orders = await this.orderSearchService.searchOrders(token, {
-      searchTerm: '',
-    })
+      const orders = await this.orderSearchService.searchOrders(token, {
+        searchTerm: '',
+      })
 
-    res.render('pages/index', { orderList: orders })
+      res.render('pages/index', { orderList: orders })
+    } catch (e) {
+      res.render('pages/index', { orderList: [] })
+    }
   }
 }

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -55,7 +55,7 @@ export default class RestClient {
     raw = false,
     token,
   }: Request): Promise<Response> {
-    logger.info(`${this.name} GET: ${path}`)
+    logger.info(`${this.name} GET: ${this.apiUrl()}${path}`)
     try {
       const result = await superagent
         .get(`${this.apiUrl()}${path}`)

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -55,7 +55,7 @@ export default class RestClient {
     raw = false,
     token,
   }: Request): Promise<Response> {
-    logger.info(`${this.name} GET: ${this.apiUrl()}${path}`)
+    logger.info(`${this.name} GET: ${path}`)
     try {
       const result = await superagent
         .get(`${this.apiUrl()}${path}`)

--- a/server/models/OrderList.ts
+++ b/server/models/OrderList.ts
@@ -1,0 +1,8 @@
+import z from 'zod'
+import OrderModel from './Order'
+
+const OrderListModel = z.array(OrderModel)
+
+export type OrderList = z.infer<typeof OrderListModel>
+
+export default OrderListModel

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -9,7 +9,7 @@ export const services = () => {
 
   const auditService = new AuditService(hmppsAuditClient)
   const orderService = new OrderService(cemoApiClient)
-  const orderSearchService = new OrderSearchService()
+  const orderSearchService = new OrderSearchService(cemoApiClient)
   const deviceWearerService = new DeviceWearerService()
 
   return {

--- a/server/services/orderSearchService.test.ts
+++ b/server/services/orderSearchService.test.ts
@@ -1,0 +1,73 @@
+import { v4 as uuidv4 } from 'uuid'
+import OrderSearchService from './orderSearchService'
+import RestClient from '../data/restClient'
+import { SanitisedError } from '../sanitisedError'
+
+jest.mock('../data/restClient')
+
+const mockNewOrder = {
+  id: uuidv4(),
+  status: 'IN_PROGRESS',
+}
+
+const mock500Error: SanitisedError = {
+  message: 'Internal Server Error',
+  name: 'InternalServerError',
+  stack: '',
+  status: 500,
+}
+
+describe('Order Search Service', () => {
+  let mockRestClient: jest.Mocked<RestClient>
+
+  beforeEach(() => {
+    mockRestClient = new RestClient('cemoApi', {
+      url: '',
+      timeout: { response: 0, deadline: 0 },
+      agent: { timeout: 0 },
+    }) as jest.Mocked<RestClient>
+  })
+
+  describe('searchOrders', () => {
+    it('should get orders from the api', async () => {
+      mockRestClient.get.mockResolvedValue([mockNewOrder])
+
+      const orderService = new OrderSearchService(mockRestClient)
+      const orders = await orderService.searchOrders('', { searchTerm: '' })
+
+      expect(mockRestClient.get).toHaveBeenCalledWith({
+        path: '/api/ListForms',
+        token: '',
+      })
+      expect(orders).toEqual([mockNewOrder])
+    })
+
+    it('should throw an error if the api returns an invalid object', async () => {
+      expect.assertions(1)
+
+      mockRestClient.get.mockResolvedValue({
+        ...mockNewOrder,
+        status: 'INVALID_STATUS',
+      })
+
+      try {
+        const orderService = new OrderSearchService(mockRestClient)
+        await orderService.searchOrders('', { searchTerm: '' })
+      } catch (e) {
+        expect((e as Error).name).toEqual('ZodError')
+      }
+    })
+
+    it('should propagate errors from the api', async () => {
+      mockRestClient.get.mockRejectedValue(mock500Error)
+
+      try {
+        const orderService = new OrderSearchService(mockRestClient)
+        await orderService.searchOrders('', { searchTerm: '' })
+      } catch (e) {
+        expect((e as SanitisedError).status).toEqual(500)
+        expect((e as SanitisedError).message).toEqual('Internal Server Error')
+      }
+    })
+  })
+})

--- a/server/services/orderSearchService.ts
+++ b/server/services/orderSearchService.ts
@@ -1,4 +1,3 @@
-import { getOrders } from '../data/inMemoryDatabase'
 import RestClient from '../data/restClient'
 import OrderListModel, { OrderList } from '../models/OrderList'
 
@@ -16,7 +15,7 @@ export default class OrderSearchService {
       token: accessToken,
     })
 
-    const orders = OrderListModel.parse(result);
+    const orders = OrderListModel.parse(result)
 
     return orders
   }

--- a/server/services/orderSearchService.ts
+++ b/server/services/orderSearchService.ts
@@ -1,12 +1,23 @@
 import { getOrders } from '../data/inMemoryDatabase'
+import RestClient from '../data/restClient'
+import OrderListModel, { OrderList } from '../models/OrderList'
 
 export interface OrderSearchInput {
   searchTerm: string
 }
 
-export default class InMemoryOrderSearchService {
+export default class OrderSearchService {
+  constructor(private readonly apiClient: RestClient) {}
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async searchOrders(input: OrderSearchInput) {
-    return Promise.resolve(getOrders())
+  async searchOrders(accessToken: string, input: OrderSearchInput): Promise<OrderList> {
+    const result = await this.apiClient.get({
+      path: '/api/ListForms',
+      token: accessToken,
+    })
+
+    const orders = OrderListModel.parse(result);
+
+    return orders
   }
 }

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -11,7 +11,7 @@
 <div class="homepage-content">
   {{ mojPageHeaderActions({
   heading: {
-    text: 'Electronic Monitoring Order'
+    text: 'Electronic Monitoring Application Forms'
   } }) }}
 
 <form action="/order/create" method="post">
@@ -24,7 +24,7 @@
 </form>
 
 </div>
-{{ mojSearch({
+{# {{ mojSearch({
     action: '#',
     method: 'get',
     input: {
@@ -45,7 +45,7 @@
  
  {% if previous != 0 %}
   {% set previousButton = { text: 'Previous', href:'' } %}
-{% endif %}
+{% endif %} #}
 
 {% if next != 0 %}
   {% set nextButton = { text: 'Next', href: ''} %}
@@ -87,8 +87,7 @@
 }) }}
 {% endset %}
 
-<br /> 
-<br /> 
+<h2>Existing Forms</h2>
 
 <div id="formList">
     <ul class="govuk-task-list">
@@ -96,7 +95,7 @@
     <li class="govuk-task-list__item govuk-task-list__item--with-link">
       <div class="govuk-task-list__name-and-hint">
         <a class="govuk-link govuk-task-list__link" href="/order/{{order.id}}/summary" aria-describedby="company-details-1-status">
-          {{order.title}}
+          {{order.title}} {{order.id}}
         </a>
       </div>
       {% if order.status == 'SUBMITTED' %}
@@ -120,5 +119,5 @@
   </div>
 
 
-  {{ pagination | safe }}
+  {# {{ pagination | safe }} #}
 {% endblock %}

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -89,30 +89,35 @@
 
 <h2>Existing Forms</h2>
 
-<div id="formList">
-    <ul class="govuk-task-list">
+<div id="ordersList">
+  <ul class="govuk-task-list">
+    {% if orderList.length == 0 %}
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        No existing forms found.
+      </li>
+    {% endif %}
+
     {% for order in orderList %}
-    <li class="govuk-task-list__item govuk-task-list__item--with-link">
-      <div class="govuk-task-list__name-and-hint">
-        <a class="govuk-link govuk-task-list__link" href="/order/{{order.id}}/summary" aria-describedby="company-details-1-status">
-          {{order.title}} {{order.id}}
-        </a>
-      </div>
-      {% if order.status == 'SUBMITTED' %}
-        <div class="govuk-task-list__status">
-          <strong class="govuk-tag govuk-tag--green">
-            Submitted
-          </strong>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="/order/{{order.id}}/summary" aria-describedby="company-details-1-status">
+            {{ order.id }}
+          </a>
         </div>
-      {% else %}               
-        <div class="govuk-task-list__status" >
-           <strong class="govuk-tag govuk-tag--grey">
-            Draft
-          </strong>
-        </div>
-      {% endif %}
-      
-    </li>
+        {% if order.status == 'SUBMITTED' %}
+          <div class="govuk-task-list__status">
+            <strong class="govuk-tag govuk-tag--green">
+              Submitted
+            </strong>
+          </div>
+        {% else %}               
+          <div class="govuk-task-list__status" >
+            <strong class="govuk-tag govuk-tag--grey">
+              Draft
+            </strong>
+          </div>
+        {% endif %}
+      </li>
     {% endfor %}
   </ul>
   


### PR DESCRIPTION
Connects to the endpoint created in https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order-api/pull/9 to allow the user to view their existing draft or submitted orders