### PR TITLE
Create order submission views

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -8,4 +8,5 @@ $govuk-page-width: $moj-page-width;
 @import "@ministryofjustice/frontend/moj/all";
 
 @import './components/header-bar';
+@import './components/panel';
 @import './local';

--- a/assets/scss/components/_panel.scss
+++ b/assets/scss/components/_panel.scss
@@ -1,0 +1,4 @@
+.govuk-panel--error {
+  background-color: #AA2A16;
+  color: #FFF;
+}

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -5,6 +5,9 @@ const paths = {
     DELETE_FAILED: '/order/delete/failed',
     DELETE_SUCCESS: '/order/delete/success',
     SUMMARY: '/order/:orderId/summary',
+    SUBMIT: '/order/:orderId/submit',
+    SUBMIT_FAILED: '/order/submit/failed',
+    SUBMIT_SUCCESS: '/order/submit/success',
   },
 
   ABOUT_THE_DEVICE_WEARER: {

--- a/server/controllers/orderController.test.ts
+++ b/server/controllers/orderController.test.ts
@@ -223,4 +223,66 @@ describe('OrderController', () => {
       expect(res.render).toHaveBeenCalledWith('pages/order/delete-success')
     })
   })
+
+  describe('submit', () => {
+    it('should submit the order and redirect to a success page for a draft order', async () => {
+      // Given
+      const mockOrder = createMockOrder(OrderStatusEnum.Enum.IN_PROGRESS)
+      const req = createMockRequest(mockOrder)
+      const res = createMockResponse()
+      const next = jest.fn()
+
+      // When
+      await orderController.submit(req, res, next)
+
+      // Then
+      expect(mockOrderService.submitOrder).toHaveBeenCalledWith(mockOrder.id)
+      expect(res.redirect).toHaveBeenCalledWith('/order/submit/success')
+    })
+
+    it('should not submit the order and redirect to a failed page for a submitted order', async () => {
+      // Given
+      const mockOrder = createMockOrder(OrderStatusEnum.Enum.SUBMITTED)
+      const req = createMockRequest(mockOrder)
+      const res = createMockResponse()
+      const next = jest.fn()
+
+      // When
+      await orderController.submit(req, res, next)
+
+      // Then
+      expect(mockOrderService.submitOrder).toHaveBeenCalledTimes(0)
+      expect(res.redirect).toHaveBeenCalledWith('/order/submit/failed')
+    })
+  })
+
+  describe('submitFailed', () => {
+    it('should render the failed view', async () => {
+      // Given
+      const req = createMockRequest()
+      const res = createMockResponse()
+      const next = jest.fn()
+
+      // When
+      await orderController.submitFailed(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/order/submit-failed')
+    })
+  })
+
+  describe('submitSuccess', () => {
+    it('should render the success view', async () => {
+      // Given
+      const req = createMockRequest()
+      const res = createMockResponse()
+      const next = jest.fn()
+
+      // When
+      await orderController.submitSuccess(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/order/submit-success')
+    })
+  })
 })

--- a/server/controllers/orderController.ts
+++ b/server/controllers/orderController.ts
@@ -49,4 +49,23 @@ export default class OrderController {
   deleteSuccess: RequestHandler = async (req: Request, res: Response) => {
     res.render('pages/order/delete-success')
   }
+
+  submit: RequestHandler = async (req: Request, res: Response) => {
+    const order = req.order!
+
+    if (order.status === 'SUBMITTED') {
+      res.redirect('/order/submit/failed')
+    } else {
+      await this.orderService.submitOrder(order.id)
+      res.redirect('/order/submit/success')
+    }
+  }
+
+  submitFailed: RequestHandler = async (req: Request, res: Response) => {
+    res.render('pages/order/submit-failed')
+  }
+
+  submitSuccess: RequestHandler = async (req: Request, res: Response) => {
+    res.render('pages/order/submit-success')
+  }
 }

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -240,6 +240,26 @@ describe('authorised user', () => {
         })
     })
   })
+
+  describe('POST /order/:orderId/submit', () => {
+    it('should submit a draft order and redirect to the success page', () => {
+      orderService.getOrder.mockResolvedValue(mockDraftOrder)
+
+      return request(app)
+        .post(`/order/${mockDraftOrder.id}/submit`)
+        .expect(302)
+        .expect('Location', '/order/submit/success')
+    })
+
+    it('should not submit an already submitted order and redirect to the failed page', () => {
+      orderService.getOrder.mockResolvedValue(mockSubmittedOrder)
+
+      return request(app)
+        .post(`/order/${mockSubmittedOrder.id}/submit`)
+        .expect(302)
+        .expect('Location', '/order/submit/failed')
+    })
+  })
 })
 
 describe('Order Not Found', () => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -50,9 +50,9 @@ export default function routes({
   get(paths.ORDER.SUMMARY, orderController.summary)
   get(paths.ORDER.DELETE, orderController.confirmDelete)
   post(paths.ORDER.DELETE, orderController.delete)
-  post('/order/:orderId/submit', orderController.submit)
-  get('/order/submit/success', orderController.submitSuccess)
-  get('/order/submit/failed', orderController.submitFailed)
+  post(paths.ORDER.SUBMIT, orderController.submit)
+  get(paths.ORDER.SUBMIT_SUCCESS, orderController.submitSuccess)
+  get(paths.ORDER.SUBMIT_FAILED, orderController.submitFailed)
 
   // Device Wearer
   get(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER, deviceWearerController.view)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -50,6 +50,9 @@ export default function routes({
   get(paths.ORDER.SUMMARY, orderController.summary)
   get(paths.ORDER.DELETE, orderController.confirmDelete)
   post(paths.ORDER.DELETE, orderController.delete)
+  post('/order/:orderId/submit', orderController.submit)
+  get('/order/submit/success', orderController.submitSuccess)
+  get('/order/submit/failed', orderController.submitFailed)
 
   // Device Wearer
   get(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER, deviceWearerController.view)

--- a/server/services/orderService.ts
+++ b/server/services/orderService.ts
@@ -38,4 +38,15 @@ export default class OrderService {
     // Do nothing for now
     return Promise.resolve()
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async submitOrder(id: string) {
+    // Do nothing for now
+    // Will call API endpoint(s):
+    //  - Updating order status to SUBMITTED in CEMO DB
+    //  - Submitting order to Serco
+    //  - Returning reference number from Serco
+    //  - Generating a PDF of form to download (and eventually emailing to user)
+    return Promise.resolve()
+  }
 }

--- a/server/views/pages/order/submit-failed.njk
+++ b/server/views/pages/order/submit-failed.njk
@@ -1,0 +1,30 @@
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Form Details" %}
+{% set mainClasses = "app-container govuk-body" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% block content %}
+
+{{ govukBackLink({
+  text: "Back",
+  href: "/"
+}) }}
+
+{{ govukPanel({
+  titleText: "Application submission failed",
+  html: "Your reference number<br><strong>EXAMPLE</strong>",
+  classes: "govuk-panel--error"
+}) }}
+
+<div class="govuk-button-group">
+    {{ govukButton({
+        text: "Back to your applications",
+        href: "/"
+    }) }}
+</div>
+
+{% endblock %}

--- a/server/views/pages/order/submit-success.njk
+++ b/server/views/pages/order/submit-success.njk
@@ -1,0 +1,32 @@
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Form Details" %}
+{% set mainClasses = "app-container govuk-body" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+
+{{ govukBackLink({
+  text: "Back",
+  href: "/"
+}) }}
+
+{{ govukPanel({
+  titleText: "Application successfully submitted",
+  html: "Your reference number<br><strong>EXAMPLE</strong>",
+  attributes: {
+    "data-qa": "confirmation-panel"
+  }
+}) }}
+
+
+<div class="govuk-button-group">
+      {{ govukButton({
+          text: "Back to your applications",
+          href: "/"
+      }) }}
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
## Changes proposed in this PR
- This PR adds order submitted pages on success or failure to submit an order. 
- No tests for the service as not yet implemented.

## Next steps
- Add API endpoint(s) for order submission (including updating the order status to submitted, generating a PDF from the form data, and submitting the data to Serco (returning a reference ID))
- Data validation
- Update front end to call relevant endpoint(s)
