### PR TITLE
Allow user to check answers for about the device wearer section

### DIFF
--- a/server/controllers/deviceWearerCheckAnswersController.test.ts
+++ b/server/controllers/deviceWearerCheckAnswersController.test.ts
@@ -1,0 +1,128 @@
+import type { Request, Response } from 'express'
+import { v4 as uuidv4 } from 'uuid'
+import AuditService from '../services/auditService'
+import HmppsAuditClient from '../data/hmppsAuditClient'
+import { Order, OrderStatus, OrderStatusEnum } from '../models/Order'
+import DeviceWearerCheckAnswersController from './deviceWearersCheckAnswersController'
+
+jest.mock('../services/auditService')
+jest.mock('../services/orderService')
+jest.mock('../services/deviceWearerService')
+jest.mock('../data/hmppsAuditClient')
+jest.mock('../data/restClient')
+
+const createMockRequest = (order?: Order): Request => {
+  return {
+    // @ts-expect-error stubbing session
+    session: {},
+    query: {},
+    params: {
+      orderId: '123456789',
+    },
+    user: {
+      username: '',
+      token: '',
+      authSource: '',
+    },
+    order,
+  }
+}
+
+const createMockResponse = (): Response => {
+  // @ts-expect-error stubbing res.render
+  return {
+    locals: {
+      user: {
+        username: 'fakeUserName',
+        token: 'fakeUserToken',
+        authSource: 'nomis',
+        userId: 'fakeId',
+        name: 'fake user',
+        displayName: 'fuser',
+        userRoles: ['fakeRole'],
+        staffId: 123,
+      },
+    },
+    redirect: jest.fn(),
+    render: jest.fn(),
+    set: jest.fn(),
+    send: jest.fn(),
+  }
+}
+
+const createMockOrder = (status: OrderStatus): Order => {
+  return {
+    id: uuidv4(),
+    status,
+    deviceWearer: {
+      nomisId: null,
+      pncId: null,
+      deliusId: null,
+      prisonNumber: null,
+      firstName: 'tester',
+      lastName: 'testington',
+      alias: 'test',
+      dateOfBirth: '1980-01-01T00:00:00.000Z',
+      adultAtTimeOfInstallation: false,
+      sex: 'male',
+      gender: 'male',
+      disabilities: 'Vision,Mobilitiy',
+    },
+    deviceWearerContactDetails: {
+      contactNumber: null,
+    },
+    additionalDocuments: [],
+  }
+}
+
+describe('DeviceWearerCheckAnswersController', () => {
+  let deviceWearerCheckAnswersController: DeviceWearerCheckAnswersController
+  let mockAuditClient: jest.Mocked<HmppsAuditClient>
+  let mockAuditService: jest.Mocked<AuditService>
+
+  beforeEach(() => {
+    mockAuditClient = new HmppsAuditClient({
+      queueUrl: '',
+      enabled: true,
+      region: '',
+      serviceName: '',
+    }) as jest.Mocked<HmppsAuditClient>
+    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
+    deviceWearerCheckAnswersController = new DeviceWearerCheckAnswersController(mockAuditService)
+  })
+
+  it('should render the page using the saved device wearer data', async () => {
+    // Given
+    const mockOrder = createMockOrder(OrderStatusEnum.Enum.IN_PROGRESS)
+    const req = createMockRequest(mockOrder)
+    const res = createMockResponse()
+    const next = jest.fn()
+
+    // When
+    await deviceWearerCheckAnswersController.view(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith(
+      'pages/order/about-the-device-wearer/check-your-answers',
+      expect.objectContaining({
+        aboutTheDeviceWearerUri: '/order/123456789/about-the-device-wearer',
+        orderSummaryUri: '/order/123456789/summary',
+        nomisId: { value: '' },
+        pncId: { value: '' },
+        deliusId: { value: '' },
+        prisonNumber: { value: '' },
+        firstName: { value: 'tester' },
+        lastName: { value: 'testington' },
+        alias: { value: 'test' },
+        dateOfBirth_day: { value: '1' },
+        dateOfBirth_month: { value: '1' },
+        dateOfBirth_year: { value: '1980' },
+        dateOfBirth: { value: '' },
+        adultAtTimeOfInstallation: { value: 'false' },
+        sex: { value: 'male' },
+        gender: { value: 'male' },
+        disabilities: { values: ['Vision', 'Mobilitiy'] },
+      }),
+    )
+  })
+})

--- a/server/controllers/deviceWearersCheckAnswersController.ts
+++ b/server/controllers/deviceWearersCheckAnswersController.ts
@@ -1,10 +1,72 @@
 import { Request, RequestHandler, Response } from 'express'
+import paths from '../constants/paths'
 import { AuditService } from '../services'
+import { DeviceWearer } from '../models/DeviceWearer'
+import { deserialiseDate } from '../utils/utils'
+import { FormField } from '../interfaces/formData'
+
+type DeviceWearerCheckAnswersViewModel = {
+  aboutTheDeviceWearerUri: string
+  orderSummaryUri: string
+  nomisId: FormField
+  pncId: FormField
+  deliusId: FormField
+  prisonNumber: FormField
+  firstName: FormField
+  lastName: FormField
+  alias: FormField
+  dateOfBirth_day: FormField
+  dateOfBirth_month: FormField
+  dateOfBirth_year: FormField
+  dateOfBirth: FormField
+  adultAtTimeOfInstallation: FormField
+  sex: FormField
+  gender: FormField
+  disabilities: FormField
+}
 
 export default class DeviceWearerCheckAnswersController {
   constructor(private readonly auditService: AuditService) {}
 
+  private createViewModelFromDeviceWearer(
+    deviceWearer: DeviceWearer,
+    orderId: string,
+  ): DeviceWearerCheckAnswersViewModel {
+    const [year, month, day] = deserialiseDate(deviceWearer.dateOfBirth || '')
+
+    return {
+      aboutTheDeviceWearerUri: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', orderId),
+      orderSummaryUri: paths.ORDER.SUMMARY.replace(':orderId', orderId),
+      nomisId: { value: deviceWearer.nomisId || '' },
+      pncId: { value: deviceWearer.pncId || '' },
+      deliusId: { value: deviceWearer.deliusId || '' },
+      prisonNumber: { value: deviceWearer.prisonNumber || '' },
+      firstName: { value: deviceWearer.firstName || '' },
+      lastName: { value: deviceWearer.lastName || '' },
+      alias: { value: deviceWearer.alias || '' },
+      dateOfBirth_day: { value: day },
+      dateOfBirth_month: { value: month },
+      dateOfBirth_year: { value: year },
+      dateOfBirth: {
+        value: '',
+      },
+      adultAtTimeOfInstallation: { value: String(deviceWearer.adultAtTimeOfInstallation) },
+      sex: { value: deviceWearer.sex || '' },
+      gender: { value: deviceWearer.gender || '' },
+      disabilities: { values: (deviceWearer.disabilities || '').split(',') },
+    }
+  }
+
+  private constructViewModel(deviceWearer: DeviceWearer, formAction: string): DeviceWearerCheckAnswersViewModel {
+    return this.createViewModelFromDeviceWearer(deviceWearer, formAction)
+  }
+
   view: RequestHandler = async (req: Request, res: Response) => {
-    res.render(`pages/order/about-the-device-wearer/check-your-answers`)
+    const { orderId } = req.params
+    const { deviceWearer } = req.order!
+
+    const viewModel = this.constructViewModel(deviceWearer, orderId)
+
+    res.render(`pages/order/about-the-device-wearer/check-your-answers`, viewModel)
   }
 }

--- a/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
+++ b/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
@@ -37,19 +37,89 @@
 
   <h2 class="govuk-heading-l">Check your answers</h2>
 
+  <h3 class="govuk-heading-m">About the device wearer</h3>
+
   {{ govukSummaryList({
     rows: [
+      {
+          key: {
+              text: "NOMIS ID"
+          },
+          value: {
+              text: firstName.value
+          },
+          actions: {
+              items: [
+              {
+                  href: aboutTheDeviceWearerUri,
+                  text: "Change",
+                  visuallyHiddenText: "name"
+              }
+              ]
+          }
+        },
+        {
+            key: {
+                text: "PNC ID"
+            },
+            value: {
+                text: pncId.value
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "DELIUS ID"
+            },
+            value: {
+                text: deliusId.value
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Prison number"
+            },
+            value: {
+                text: prisonNumber.value
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+                ]
+            }
+        },
         {
             key: {
                 text: "First name"
             },
             value: {
-                text: "Placeholder"
+                text: firstName.value
             },
             actions: {
                 items: [
                 {
-                    href: "#",
+                    href: aboutTheDeviceWearerUri,
                     text: "Change",
                     visuallyHiddenText: "name"
                 }
@@ -61,12 +131,114 @@
                 text: "Last name"
             },
             value: {
-                text: "Placeholder"
+                text: lastName.value
             },
             actions: {
                 items: [
                 {
-                    href: "#",
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Alias (optional)"
+            },
+            value: {
+                text: alias.value
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Date of birth"
+            },
+            value: {
+                html: dateOfBirth_day.value+"/"+dateOfBirth_month.value+"/"+dateOfBirth_year.value
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Will the device wearer be 18 years old when the device is installed?"
+            },
+            value: {
+                text: adultAtTimeOfInstallation.value
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Sex"
+            },
+            value: {
+                text: sex.value
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Gender"
+            },
+            value: {
+                text: gender.value
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Disabilities"
+            },
+            value: {
+                text: disabilities.values
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
                     text: "Change",
                     visuallyHiddenText: "name"
                 }
@@ -79,11 +251,11 @@
   <div class="govuk-button-group">
     {% if isOrderEditable %}
       {{ govukButton({
-        text: "Continue",
+        text: "Save and continue",
         href: orderSummaryUri
       }) }}
       {{ govukButton({
-        text: "Return back to to form section menu",
+        text: "Return back to form section menu",
         href: orderSummaryUri
       }) }}
     {% else %}


### PR DESCRIPTION
This PR adds an initial 'check your answers' page for the 'About the device wearer' section of the order journey. 

## Next steps
- Add cypress UI tests
- Add additional sections after they're completed (contact details, responsible officer, etc) and relevant logic for display
- Make some small presentation adjustments, e.g., adding spacing between items in the list of disabilities