### PR TITLE
Make conditional order fields required and nullable

### DIFF
--- a/integration_tests/e2e/order/monitoringConditions/trailMonitoring.cy.ts
+++ b/integration_tests/e2e/order/monitoringConditions/trailMonitoring.cy.ts
@@ -123,8 +123,7 @@ context('Trail monitoring', () => {
       cy.get('#endDate-error').should('contain', 'You must enter a valid date')
     })
 
-    // eslint-disable-next-line no-only-tests/no-only-tests
-    it.only('should correctly submit the data to the CEMO API and move to the next selected page', () => {
+    it('should correctly submit the data to the CEMO API and move to the next selected page', () => {
       cy.task('stubCemoSubmitOrder', {
         httpStatus: 200,
         id: mockOrderId,

--- a/integration_tests/mockApis/cemo.ts
+++ b/integration_tests/mockApis/cemo.ts
@@ -57,6 +57,7 @@ export const mockApiOrder = (status = 'IN_PROGRESS') => ({
     alcohol: null,
     devicesRequired: null,
   },
+  monitoringConditionsTrail: null,
 })
 
 const listOrders = (httpStatus = 200): SuperAgentRequest =>

--- a/integration_tests/mockApis/cemo.ts
+++ b/integration_tests/mockApis/cemo.ts
@@ -37,6 +37,7 @@ export const mockApiOrder = (status = 'IN_PROGRESS') => ({
     gender: null,
     disabilities: null,
   },
+  deviceWearerResponsibleAdult: null,
   contactDetails: {
     contactNumber: null,
   },

--- a/server/controllers/monitoringConditions/trailMonitoringController.ts
+++ b/server/controllers/monitoringConditions/trailMonitoringController.ts
@@ -41,7 +41,7 @@ export default class TrailMonitoringController {
   ) {}
 
   private constructViewModel(
-    trailMonitoring: TrailMonitoring | undefined,
+    trailMonitoring: TrailMonitoring,
     validationErrors: ValidationResult,
     formData: [TrailMonitoringFormData],
     formAction: string,
@@ -54,7 +54,7 @@ export default class TrailMonitoringController {
   }
 
   private createViewModelFromTrailMonitoring(
-    trailMonitoring: TrailMonitoring | undefined,
+    trailMonitoring: TrailMonitoring,
     orderId: string,
   ): TrailMonitoringViewModel {
     const [startDateYear, startDateMonth, startDateDay] = deserialiseDate(trailMonitoring?.startDate)
@@ -99,7 +99,15 @@ export default class TrailMonitoringController {
     const { monitoringConditionsTrail, monitoringConditions } = req.order!
     const errors = req.flash('validationErrors')
     const formData = req.flash('formData')
-    const viewModel = this.constructViewModel(monitoringConditionsTrail, errors as never, formData as never, orderId)
+    const viewModel = this.constructViewModel(
+      monitoringConditionsTrail ?? {
+        startDate: null,
+        endDate: null,
+      },
+      errors as never,
+      formData as never,
+      orderId,
+    )
 
     if (!monitoringConditions.trail) {
       res.redirect(paths.MONITORING_CONDITIONS.BASE_URL.replace(':orderId', orderId))

--- a/server/models/Order.ts
+++ b/server/models/Order.ts
@@ -21,7 +21,7 @@ const OrderModel = z.object({
   enforcementZoneConditions: z.array(EnforcementZoneModel),
   additionalDocuments: z.array(AttachmentModel),
   monitoringConditions: MonitoringConditionsModel,
-  monitoringConditionsTrail: TrailMonitoringModel.optional(),
+  monitoringConditionsTrail: TrailMonitoringModel.nullable(),
   monitoringConditionsAttendance: z.array(AttendanceMonitoringModel).optional(),
 })
 

--- a/server/models/Order.ts
+++ b/server/models/Order.ts
@@ -16,7 +16,7 @@ const OrderModel = z.object({
   status: OrderStatusEnum,
   deviceWearer: DeviceWearerModel,
   deviceWearerAddresses: z.array(AddressModel),
-  deviceWearerResponsibleAdult: DeviceWearerResponsibleAdultModel.optional().nullable(),
+  deviceWearerResponsibleAdult: DeviceWearerResponsibleAdultModel.nullable(),
   deviceWearerContactDetails: DeviceWearerContactDetailsModel,
   enforcementZoneConditions: z.array(EnforcementZoneModel),
   additionalDocuments: z.array(AttachmentModel),

--- a/test/mocks/mockOrder.ts
+++ b/test/mocks/mockOrder.ts
@@ -23,6 +23,7 @@ export const getMockOrder = (options?: MockOrderOptions): Order => ({
     gender: null,
     disabilities: [],
   },
+  deviceWearerResponsibleAdult: null,
   deviceWearerContactDetails: {
     contactNumber: '',
   },

--- a/test/mocks/mockOrder.ts
+++ b/test/mocks/mockOrder.ts
@@ -40,6 +40,7 @@ export const getMockOrder = (options?: MockOrderOptions): Order => ({
     alcohol: null,
     devicesRequired: null,
   },
+  monitoringConditionsTrail: null,
 })
 
 export const getMockSubmittedOrder = (options?: MockOrderOptions) => ({


### PR DESCRIPTION
### Context
Because the order service of the order API creates a corresponding null trail monitoring conditions on creation of an order, trail monitoring conditions cannot be optional and must be nullable.
