### PR TITLE
Allow NOs to add alcohol monitoring conditions

### DIFF
--- a/integration_tests/e2e/order/monitoring-conditions/alcoholMonitoring.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/alcoholMonitoring.cy.ts
@@ -1,9 +1,9 @@
 import { v4 as uuidv4 } from 'uuid'
 import { mockApiOrder } from '../../../mockApis/cemo'
 import ErrorPage from '../../../pages/error'
-import AlcoholMonitoringPage from '../../../pages/order/alcoholMonitoring'
-import OrderTasksPage from '../../../pages/order/summary'
+import AlcoholMonitoringPage from '../../../pages/order/monitoring-conditions/alcoholMonitoring'
 import Page from '../../../pages/page'
+import CurfewConditionsPage from '../../../pages/order/curfewConditions'
 
 const mockOrderId = uuidv4()
 
@@ -13,15 +13,9 @@ const mockSubmittedAlcoholMonitoring = {
     monitoringType: 'ALCOHOL_ABSTINENCE',
     startDate: '2024-03-27T00:00:00.000Z',
     endDate: '2025-04-28T00:00:00.000Z',
-    installationLocation: 'AGREED_LOCATION',
-    installationName: 'Installation Name',
-    agreedAddressLine1: '19 Strawberry Fields',
-    agreedAddressLine2: 'Liverpool',
-    agreedAddressLine3: 'Line 3',
-    agreedAddressLine4: 'Line 4',
-    agreedAddressPostcode: 'LV3 4DG',
-    probationName: 'Probation Name',
-    prisonName: 'Prison Name',
+    installationLocation: 'INSTALLATION',
+    probationOfficeName: null,
+    prisonName: null,
   },
   id: mockOrderId,
 }
@@ -33,21 +27,10 @@ const mockEmptyAlcoholMonitoring = {
     startDate: null,
     endDate: null,
     installationLocation: null,
-    installationName: null,
-    agreedAddressLine1: null,
-    agreedAddressLine2: null,
-    agreedAddressLine3: null,
-    agreedAddressLine4: null,
-    agreedAddressPostcode: null,
-    probationName: null,
     prisonName: null,
+    probationOfficeName: null,
   },
   id: mockOrderId,
-}
-
-const mockInProgressAlcoholMonitoring = {
-  ...mockSubmittedAlcoholMonitoring,
-  status: 'IN_PROGRESS',
 }
 
 context('Alcohol monitoring', () => {
@@ -56,6 +39,7 @@ context('Alcohol monitoring', () => {
     cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
     cy.task('stubCemoListOrders')
   })
+
   context('Draft order', () => {
     beforeEach(() => {
       cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
@@ -70,31 +54,13 @@ context('Alcohol monitoring', () => {
   })
 
   context('Submitted Order', () => {
-    it('Should correctly display the submitted data in disabled fields (agreed location)', () => {
+    beforeEach(() => {
       cy.task('stubCemoGetOrder', {
         httpStatus: 200,
         id: mockOrderId,
         status: 'SUBMITTED',
         order: mockSubmittedAlcoholMonitoring,
       })
-      cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/alcohol`)
-      const page = Page.verifyOnPage(AlcoholMonitoringPage)
-      page.submittedBanner().should('contain', 'You are viewing a submitted order.')
-      cy.get('input[type="radio"]').each($el => {
-        cy.wrap($el).should('be.disabled')
-      })
-      cy.get('input[type="text"]').each($el => {
-        cy.wrap($el).should('be.disabled')
-      })
-      cy.get('input[type="radio"][value="AGREED_LOCATION"]').should('be.checked')
-      cy.get('input[name="agreedAddressLine1"]').should('have.value', '19 Strawberry Fields')
-      cy.get('input[name="agreedAddressLine2"]').should('have.value', 'Liverpool')
-      cy.get('input[name="agreedAddressLine3"]').should('have.value', 'Line 3')
-      cy.get('input[name="agreedAddressLine4"]').should('have.value', 'Line 4')
-      cy.get('input[name="agreedAddressPostcode"]').should('have.value', 'LV3 4DG')
-      page.saveAndContinueButton().should('not.exist')
-      page.saveAndReturnButton().should('not.exist')
-      page.backToSummaryButton().should('exist').should('have.attr', 'href', `/order/${mockOrderId}/summary`)
     })
 
     it('Should correctly display the submitted data in disabled fields (probation office)', () => {
@@ -106,6 +72,7 @@ context('Alcohol monitoring', () => {
           monitoringConditionsAlcohol: {
             ...mockSubmittedAlcoholMonitoring.monitoringConditionsAlcohol,
             installationLocation: 'PROBATION_OFFICE',
+            probationOfficeName: 'Probation Office',
           },
         },
       })
@@ -119,7 +86,7 @@ context('Alcohol monitoring', () => {
         cy.wrap($el).should('be.disabled')
       })
       cy.get('input[type="radio"][value="PROBATION_OFFICE"]').should('be.checked')
-      cy.get('input[name="probationName"]').should('have.value', 'Probation Name')
+      cy.get('input[name="probationOfficeName"]').should('have.value', 'Probation Office')
       page.saveAndContinueButton().should('not.exist')
       page.saveAndReturnButton().should('not.exist')
       page.backToSummaryButton().should('exist').should('have.attr', 'href', `/order/${mockOrderId}/summary`)
@@ -134,6 +101,7 @@ context('Alcohol monitoring', () => {
           monitoringConditionsAlcohol: {
             ...mockSubmittedAlcoholMonitoring.monitoringConditionsAlcohol,
             installationLocation: 'PRISON',
+            prisonName: 'Prison Name',
           },
         },
       })
@@ -155,33 +123,7 @@ context('Alcohol monitoring', () => {
   })
 
   context('Unsubmitted Order', () => {
-    it('Should correctly display the data in enabled fields (agreed location)', () => {
-      cy.task('stubCemoGetOrder', {
-        httpStatus: 200,
-        id: mockOrderId,
-        status: 'IN_PROGRESS',
-        order: mockInProgressAlcoholMonitoring,
-      })
-      cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/alcohol`)
-      const page = Page.verifyOnPage(AlcoholMonitoringPage)
-      cy.root().should('not.contain', 'You are viewing a submitted order.')
-      cy.get('input[type="radio"]').each($el => {
-        cy.wrap($el).should('not.be.disabled')
-      })
-      cy.get('input[type="text"]').each($el => {
-        cy.wrap($el).should('not.be.disabled')
-      })
-      cy.get('input[type="radio"][value="AGREED_LOCATION"]').should('be.checked')
-      cy.get('input[name="agreedAddressLine1"]').should('have.value', '19 Strawberry Fields')
-      cy.get('input[name="agreedAddressLine2"]').should('have.value', 'Liverpool')
-      cy.get('input[name="agreedAddressLine3"]').should('have.value', 'Line 3')
-      cy.get('input[name="agreedAddressLine4"]').should('have.value', 'Line 4')
-      cy.get('input[name="agreedAddressPostcode"]').should('have.value', 'LV3 4DG')
-      page.saveAndContinueButton().should('exist')
-      page.saveAndReturnButton().should('exist')
-    })
-
-    it('Should correctly display the submitted data in disabled fields (probation office)', () => {
+    it('Should correctly display the submitted data in fields (probation office)', () => {
       cy.task('stubCemoGetOrder', {
         httpStatus: 200,
         id: mockOrderId,
@@ -190,25 +132,23 @@ context('Alcohol monitoring', () => {
           monitoringConditionsAlcohol: {
             ...mockSubmittedAlcoholMonitoring.monitoringConditionsAlcohol,
             installationLocation: 'PROBATION_OFFICE',
+            probationOfficeName: 'Probation Office',
           },
         },
       })
       cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/alcohol`)
       const page = Page.verifyOnPage(AlcoholMonitoringPage)
       cy.root().should('not.contain', 'You are viewing a submitted order.')
-      cy.get('input[type="radio"]').each($el => {
-        cy.wrap($el).should('not.be.disabled')
-      })
       cy.get('input[type="text"]').each($el => {
         cy.wrap($el).should('not.be.disabled')
       })
       cy.get('input[type="radio"][value="PROBATION_OFFICE"]').should('be.checked')
-      cy.get('input[name="probationName"]').should('have.value', 'Probation Name')
+      cy.get('input[name="probationOfficeName"]').should('have.value', 'Probation Office')
       page.saveAndContinueButton().should('exist')
       page.saveAndReturnButton().should('exist')
     })
 
-    it('Should correctly display the submitted data in disabled fields (prison)', () => {
+    it('Should correctly display the submitted data in fields (prison)', () => {
       cy.task('stubCemoGetOrder', {
         httpStatus: 200,
         id: mockOrderId,
@@ -217,15 +157,13 @@ context('Alcohol monitoring', () => {
           monitoringConditionsAlcohol: {
             ...mockSubmittedAlcoholMonitoring.monitoringConditionsAlcohol,
             installationLocation: 'PRISON',
+            prisonName: 'Prison Name',
           },
         },
       })
       cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/alcohol`)
       const page = Page.verifyOnPage(AlcoholMonitoringPage)
       cy.root().should('not.contain', 'You are viewing a submitted order.')
-      cy.get('input[type="radio"]').each($el => {
-        cy.wrap($el).should('not.be.disabled')
-      })
       cy.get('input[type="text"]').each($el => {
         cy.wrap($el).should('not.be.disabled')
       })
@@ -246,52 +184,34 @@ context('Alcohol monitoring', () => {
       })
     })
 
-    it('should show errors with agreed location selected', () => {
-      cy.task('stubCemoSubmitOrder', {
-        httpStatus: 400,
-        id: mockOrderId,
-        subPath: '/monitoring-conditions-alcohol',
-        response: [
-          { field: 'monitoringType', error: 'You must select an option' },
-          { field: 'startDate', error: 'You must enter a valid date' },
-          { field: 'endDate', error: 'You must enter a valid date' },
-          { field: 'installationLocation', error: 'You must select an option' },
-          { field: 'agreedAddress', error: 'You must enter a valid address' },
-        ],
-      })
-      cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/alcohol`)
-      const page = Page.verifyOnPage(AlcoholMonitoringPage)
-      cy.get('input[type="radio"][value="AGREED_LOCATION"]').check()
-      page.saveAndContinueButton().click()
-      cy.get('#monitoringType-error').should('contain', 'You must select an option')
-      cy.get('#startDate-error').should('contain', 'You must enter a valid date')
-      cy.get('#endDate-error').should('contain', 'You must enter a valid date')
-      cy.get('#installationLocation-error').should('contain', 'You must select an option')
-      cy.get('#agreedAddress-error').should('contain', 'You must enter a valid address')
-    })
-
     it('should show errors with probation office selected', () => {
       cy.task('stubCemoSubmitOrder', {
         httpStatus: 400,
         id: mockOrderId,
         subPath: '/monitoring-conditions-alcohol',
         response: [
-          { field: 'monitoringType', error: 'You must select an option' },
-          { field: 'startDate', error: 'You must enter a valid date' },
-          { field: 'endDate', error: 'You must enter a valid date' },
-          { field: 'installationLocation', error: 'You must select an option' },
-          { field: 'probationName', error: 'You must enter a valid name' },
+          { field: 'monitoringType', error: 'Monitoring type is required' },
+          { field: 'startDate', error: 'Start date is required' },
+          { field: 'endDate', error: 'End date is required' },
+          { field: 'installationLocation', error: 'Installation location is required' },
+          {
+            field: 'probationOfficeName',
+            error: 'You must enter a probation office name if the installation location is a probation office',
+          },
         ],
       })
       cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/alcohol`)
       const page = Page.verifyOnPage(AlcoholMonitoringPage)
       cy.get('input[type="radio"][value="PROBATION_OFFICE"]').check()
       page.saveAndContinueButton().click()
-      cy.get('#monitoringType-error').should('contain', 'You must select an option')
-      cy.get('#startDate-error').should('contain', 'You must enter a valid date')
-      cy.get('#endDate-error').should('contain', 'You must enter a valid date')
-      cy.get('#installationLocation-error').should('contain', 'You must select an option')
-      cy.get('#probationName-error').should('contain', 'You must enter a valid name')
+      cy.get('#monitoringType-error').should('contain', 'Monitoring type is required')
+      cy.get('#startDate-error').should('contain', 'Start date is required')
+      cy.get('#endDate-error').should('contain', 'End date is required')
+      cy.get('#installationLocation-error').should('contain', 'Installation location is required')
+      cy.get('#probationOfficeName-error').should(
+        'contain',
+        'You must enter a probation office name if the installation location is a probation office',
+      )
     })
 
     it('should show errors with prison selected', () => {
@@ -300,22 +220,25 @@ context('Alcohol monitoring', () => {
         id: mockOrderId,
         subPath: '/monitoring-conditions-alcohol',
         response: [
-          { field: 'monitoringType', error: 'You must select an option' },
-          { field: 'startDate', error: 'You must enter a valid date' },
-          { field: 'endDate', error: 'You must enter a valid date' },
-          { field: 'installationLocation', error: 'You must select an option' },
-          { field: 'prisonName', error: 'You must enter a valid name' },
+          { field: 'monitoringType', error: 'Monitoring type is required' },
+          { field: 'startDate', error: 'Start date is required' },
+          { field: 'endDate', error: 'End date is required' },
+          { field: 'installationLocation', error: 'Installation location is required' },
+          { field: 'prisonName', error: 'You must enter a prison name if the installation location is a prison' },
         ],
       })
       cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/alcohol`)
       const page = Page.verifyOnPage(AlcoholMonitoringPage)
       cy.get('input[type="radio"][value="PRISON"]').check()
       page.saveAndContinueButton().click()
-      cy.get('#monitoringType-error').should('contain', 'You must select an option')
-      cy.get('#startDate-error').should('contain', 'You must enter a valid date')
-      cy.get('#endDate-error').should('contain', 'You must enter a valid date')
-      cy.get('#installationLocation-error').should('contain', 'You must select an option')
-      cy.get('#prisonName-error').should('contain', 'You must enter a valid name')
+      cy.get('#monitoringType-error').should('contain', 'Monitoring type is required')
+      cy.get('#startDate-error').should('contain', 'Start date is required')
+      cy.get('#endDate-error').should('contain', 'End date is required')
+      cy.get('#installationLocation-error').should('contain', 'Installation location is required')
+      cy.get('#prisonName-error').should(
+        'contain',
+        'You must enter a prison name if the installation location is a prison',
+      )
     })
 
     const baseExpectedApiRequest = {
@@ -323,40 +246,9 @@ context('Alcohol monitoring', () => {
       startDate: '2024-03-27T00:00:00.000Z',
       endDate: '2025-04-28T00:00:00.000Z',
       installationLocation: null,
-      agreedAddressLine1: null,
-      agreedAddressLine2: null,
-      agreedAddressLine3: null,
-      agreedAddressLine4: null,
-      agreedAddressPostcode: null,
       prisonName: null,
-      probationName: null,
+      probationOfficeName: null,
     }
-
-    it('should correctly submit the data to the CEMO API and move to the next page (agreed location)', () => {
-      cy.task('stubCemoSubmitOrder', {
-        httpStatus: 200,
-        id: mockOrderId,
-        subPath: '/monitoring-conditions-alcohol',
-        response: mockEmptyAlcoholMonitoring.monitoringConditionsAlcohol,
-      })
-      cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/alcohol`)
-      const page = Page.verifyOnPage(AlcoholMonitoringPage)
-      page.fillInForm('agreedLocation')
-      page.saveAndContinueButton().click()
-      cy.task('getStubbedRequest', `/orders/${mockOrderId}/monitoring-conditions-alcohol`).then(requests => {
-        expect(requests).to.have.lengthOf(1)
-        expect(requests[0]).to.deep.equal({
-          ...baseExpectedApiRequest,
-          installationLocation: 'AGREED_LOCATION',
-          agreedAddressLine1: 'Address line 1',
-          agreedAddressLine2: 'Address line 2',
-          agreedAddressLine3: 'Address line 3',
-          agreedAddressLine4: 'Address line 4',
-          agreedAddressPostcode: 'Postcode',
-        })
-      })
-      Page.verifyOnPage(OrderTasksPage)
-    })
 
     it('should correctly submit the data to the CEMO API and move to the next page (probation office)', () => {
       cy.task('stubCemoSubmitOrder', {
@@ -374,10 +266,10 @@ context('Alcohol monitoring', () => {
         expect(requests[0]).to.deep.equal({
           ...baseExpectedApiRequest,
           installationLocation: 'PROBATION_OFFICE',
-          probationName: 'Probation Office',
+          probationOfficeName: 'Probation Office',
         })
       })
-      Page.verifyOnPage(OrderTasksPage)
+      Page.verifyOnPage(CurfewConditionsPage)
     })
 
     it('should correctly submit the data to the CEMO API and move to the next page (prison)', () => {
@@ -399,7 +291,7 @@ context('Alcohol monitoring', () => {
           prisonName: 'Prison Name',
         })
       })
-      Page.verifyOnPage(OrderTasksPage)
+      Page.verifyOnPage(CurfewConditionsPage)
     })
   })
 

--- a/integration_tests/e2e/order/monitoring-conditions/attendanceMonitoring.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/attendanceMonitoring.cy.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 import { mockApiOrder } from '../../../mockApis/cemo'
 import ErrorPage from '../../../pages/error'
-import AlcoholMonitoringPage from '../../../pages/order/alcoholMonitoring'
+import AlcoholMonitoringPage from '../../../pages/order/monitoring-conditions/alcoholMonitoring'
 import AttendanceMonitoringPage from '../../../pages/order/monitoring-conditions/attendance-monitoring'
 import TrailMonitoringPage from '../../../pages/order/trailMonitoring'
 import Page from '../../../pages/page'

--- a/integration_tests/e2e/order/monitoring-conditions/installation-address.submission.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/installation-address.submission.cy.ts
@@ -4,7 +4,7 @@ import OrderSummaryPage from '../../../pages/order/summary'
 import InstallationAddressPage from '../../../pages/order/monitoring-conditions/installation-address'
 import CurfewReleaseDatePage from '../../../pages/order/curfewReleaseDate'
 import TrailMonitoringPage from '../../../pages/order/trailMonitoring'
-import AlcoholMonitoringPage from '../../../pages/order/alcoholMonitoring'
+import AlcoholMonitoringPage from '../../../pages/order/monitoring-conditions/alcoholMonitoring'
 import EnforcementZonePage from '../../../pages/order/monitoring-conditions/enforcement-zone'
 import AttendanceMonitoringPage from '../../../pages/order/monitoring-conditions/attendance-monitoring'
 

--- a/integration_tests/e2e/order/monitoring-conditions/trailMonitoring.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/trailMonitoring.cy.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import ErrorPage from '../../../pages/error'
-import AlcoholMonitoringPage from '../../../pages/order/alcoholMonitoring'
+import AlcoholMonitoringPage from '../../../pages/order/monitoring-conditions/alcoholMonitoring'
 import TrailMonitoringPage from '../../../pages/order/trailMonitoring'
 import Page from '../../../pages/page'
 

--- a/integration_tests/mockApis/cemo.ts
+++ b/integration_tests/mockApis/cemo.ts
@@ -60,6 +60,7 @@ export const mockApiOrder = (status: string = 'IN_PROGRESS') => ({
     devicesRequired: null,
   },
   monitoringConditionsTrail: null,
+  monitoringConditionsAlcohol: null,
 })
 
 type ListOrdersStubOptions = {

--- a/integration_tests/pages/order/monitoring-conditions/alcoholMonitoring.ts
+++ b/integration_tests/pages/order/monitoring-conditions/alcoholMonitoring.ts
@@ -1,5 +1,5 @@
-import AppPage from '../appPage'
-import { PageElement } from '../page'
+import AppPage from '../../appPage'
+import { PageElement } from '../../page'
 
 export default class AlcoholMonitoringPage extends AppPage {
   constructor() {
@@ -25,16 +25,9 @@ export default class AlcoholMonitoringPage extends AppPage {
     cy.get('#endDate-month').type('4')
     cy.get('#endDate-year').type('2025')
 
-    if (type === 'agreedLocation') {
-      cy.get('input[type="radio"][value="AGREED_LOCATION"]').check()
-      cy.get('#agreedAddress-line1').type('Address line 1')
-      cy.get('#agreedAddress-line2').type('Address line 2')
-      cy.get('#agreedAddress-line3').type('Address line 3')
-      cy.get('#agreedAddress-line4').type('Address line 4')
-      cy.get('#agreedAddress-postcode').type('Postcode')
-    } else if (type === 'probationOffice') {
+    if (type === 'probationOffice') {
       cy.get('input[type="radio"][value="PROBATION_OFFICE"]').check()
-      cy.get('#probationName').type('Probation Office')
+      cy.get('#probationOfficeName').type('Probation Office')
     } else if (type === 'prison') {
       cy.get('input[type="radio"][value="PRISON"]').check()
       cy.get('#prisonName').type('Prison Name')

--- a/package-lock.json
+++ b/package-lock.json
@@ -12463,7 +12463,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.0.tgz",
       "integrity": "sha512-34wkUTh3SxTClfoHB3pQ7bIMvw9dpFU1audQQeZG837fmHfHpr14n/AELVDoOYVDW2h5RDWU78tFjkD+erSBsw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.7.0",
         "pg-pool": "^3.7.0",

--- a/server/controllers/monitoringConditions/alcoholMonitoringController.test.ts
+++ b/server/controllers/monitoringConditions/alcoholMonitoringController.test.ts
@@ -5,7 +5,6 @@ import AlcoholMonitoringController from './alcoholMonitoringController'
 import RestClient from '../../data/restClient'
 import { createMockRequest, createMockResponse } from '../../../test/mocks/mockExpress'
 import { getMockOrder } from '../../../test/mocks/mockOrder'
-import { AlcoholMonitoringTypeEnum, InstallationAddressTypeEnum } from '../../models/AlcoholMonitoring'
 import { AddressTypeEnum } from '../../models/Address'
 
 jest.mock('../../services/auditService')
@@ -17,12 +16,12 @@ jest.mock('../../data/restClient')
 const createMockOrder = (startDate: string | null = null, prisonName = null, probationOfficeName = null) =>
   getMockOrder({
     monitoringConditionsAlcohol: {
-      monitoringType: AlcoholMonitoringTypeEnum.Enum.ABSTINENCE,
+      monitoringType: 'ALCOHOL_ABSTINENCE',
       startDate,
       endDate: '2027-02-15',
       prisonName,
       probationOfficeName,
-      installationAddressType: InstallationAddressTypeEnum.Enum.PRIMARY,
+      installationLocation: 'PRIMARY',
     },
     addresses: [
       {
@@ -76,12 +75,12 @@ describe('AlcoholMonitoringController', () => {
       expect(res.render).toHaveBeenCalledWith(
         'pages/order/monitoring-conditions/alcohol-monitoring',
         expect.objectContaining({
-          monitoringType: { value: 'ABSTINENCE' },
+          monitoringType: { value: 'ALCOHOL_ABSTINENCE' },
           startDate: { value: { day: '15', month: '2', year: '2026' } },
           endDate: { value: { day: '15', month: '2', year: '2027' } },
           prisonName: { value: '' },
           probationOfficeName: { value: '' },
-          installationAddressType: { value: 'PRIMARY' },
+          installationLocation: { value: 'PRIMARY' },
           primaryAddressView: { value: '1 Mock Street, Mock City, Mock Postcode' },
           secondaryAddressView: { value: '' },
           tertiaryAddressView: { value: '' },
@@ -101,7 +100,7 @@ describe('AlcoholMonitoringController', () => {
         .mockReturnValueOnce([{ error: 'Start date is required', field: 'startDate' }])
         .mockReturnValueOnce([
           {
-            monitoringType: 'ABSTINENCE',
+            monitoringType: 'ALCOHOL_ABSTINENCE',
             'startDate-day': '',
             'startDate-month': '',
             'startDate-year': '',
@@ -110,7 +109,7 @@ describe('AlcoholMonitoringController', () => {
             'endDate-year': '2027',
             prisonName: '',
             probationOfficeName: '',
-            installationAddressType: 'PRIMARY',
+            installationLocation: 'PRIMARY',
             primaryAddressView: '1 Mock Street, Mock City, Mock Postcode',
             secondaryAddressView: '',
             tertiaryAddressView: '',
@@ -125,7 +124,7 @@ describe('AlcoholMonitoringController', () => {
       expect(res.render).toHaveBeenCalledWith(
         'pages/order/monitoring-conditions/alcohol-monitoring',
         expect.objectContaining({
-          monitoringType: { value: 'ABSTINENCE' },
+          monitoringType: { value: 'ALCOHOL_ABSTINENCE' },
           startDate: { value: { day: '', month: '', year: '' }, error: { text: 'Start date is required' } },
           endDate: { value: { day: '15', month: '02', year: '2027' } },
           prisonName: { value: '' },
@@ -134,7 +133,7 @@ describe('AlcoholMonitoringController', () => {
           secondaryAddressView: { value: '' },
           tertiaryAddressView: { value: '' },
           installationAddressView: { value: '' },
-          installationAddressType: { value: 'PRIMARY' },
+          installationLocation: { value: 'PRIMARY' },
         }),
       )
     })
@@ -156,7 +155,7 @@ describe('AlcoholMonitoringController', () => {
         'endDate-day': '30',
         'endDate-month': '12',
         'endDate-year': '2027',
-        installationAddressType: 'PRIMARY',
+        installationLocation: 'PRIMARY',
         prisonName: '',
         probationOfficeName: '',
       }
@@ -178,7 +177,7 @@ describe('AlcoholMonitoringController', () => {
         'endDate-day': '30',
         'endDate-month': '12',
         'endDate-year': '2027',
-        installationAddressType: 'PRIMARY',
+        installationLocation: 'PRIMARY',
         prisonName: '',
         probationOfficeName: '',
       })
@@ -199,22 +198,22 @@ describe('AlcoholMonitoringController', () => {
       req.flash = jest.fn()
       req.body = {
         action: 'continue',
-        monitoringType: 'ABSTINENCE',
+        monitoringType: 'ALCOHOL_ABSTINENCE',
         'startDate-day': '30',
         'startDate-month': '12',
         'startDate-year': '2026',
         'endDate-day': '30',
         'endDate-month': '12',
         'endDate-year': '2027',
-        installationAddressType: 'PRIMARY',
+        installationLocation: 'PRIMARY',
         prisonName: '',
         probationOfficeName: '',
       }
       mockAlcoholMonitoringService.update.mockResolvedValue({
-        monitoringType: 'ABSTINENCE',
+        monitoringType: 'ALCOHOL_ABSTINENCE',
         startDate: '2026-12-30',
         endDate: '2027-12-30',
-        installationAddressType: 'PRIMARY',
+        installationLocation: 'PRIMARY',
         prisonName: '',
         probationOfficeName: '',
       })
@@ -236,22 +235,22 @@ describe('AlcoholMonitoringController', () => {
     req.flash = jest.fn()
     req.body = {
       action: 'back',
-      monitoringType: 'ABSTINENCE',
+      monitoringType: 'ALCOHOL_ABSTINENCE',
       'startDate-day': '30',
       'startDate-month': '12',
       'startDate-year': '2026',
       'endDate-day': '30',
       'endDate-month': '12',
       'endDate-year': '2027',
-      installationAddressType: 'PRIMARY',
+      installationLocation: 'PRIMARY',
       prisonName: '',
       probationOfficeName: '',
     }
     mockAlcoholMonitoringService.update.mockResolvedValue({
-      monitoringType: 'ABSTINENCE',
+      monitoringType: 'ALCOHOL_ABSTINENCE',
       startDate: '2026-12-30',
       endDate: '2027-12-30',
-      installationAddressType: 'PRIMARY',
+      installationLocation: 'PRIMARY',
       prisonName: '',
       probationOfficeName: '',
     })

--- a/server/controllers/monitoringConditions/alcoholMonitoringController.test.ts
+++ b/server/controllers/monitoringConditions/alcoholMonitoringController.test.ts
@@ -1,0 +1,266 @@
+import AuditService from '../../services/auditService'
+import AlcoholMonitoringService from '../../services/alcoholMonitoringService'
+import HmppsAuditClient from '../../data/hmppsAuditClient'
+import AlcoholMonitoringController from './alcoholMonitoringController'
+import RestClient from '../../data/restClient'
+import { createMockRequest, createMockResponse } from '../../../test/mocks/mockExpress'
+import { getMockOrder } from '../../../test/mocks/mockOrder'
+import { AlcoholMonitoringTypeEnum, InstallationAddressTypeEnum } from '../../models/AlcoholMonitoring'
+import { AddressTypeEnum } from '../../models/Address'
+
+jest.mock('../../services/auditService')
+jest.mock('../../services/orderService')
+jest.mock('../../services/alcoholMonitoringService')
+jest.mock('../../data/hmppsAuditClient')
+jest.mock('../../data/restClient')
+
+const createMockOrder = (startDate: string | null = null, prisonName = null, probationOfficeName = null) =>
+  getMockOrder({
+    monitoringConditionsAlcohol: {
+      monitoringType: AlcoholMonitoringTypeEnum.Enum.ABSTINENCE,
+      startDate,
+      endDate: '2027-02-15',
+      prisonName,
+      probationOfficeName,
+      installationAddressType: InstallationAddressTypeEnum.Enum.PRIMARY,
+    },
+    addresses: [
+      {
+        addressType: AddressTypeEnum.Enum.PRIMARY,
+        addressLine1: '1 Mock Street',
+        addressLine2: 'Mock City',
+        addressLine3: '',
+        addressLine4: '',
+        postcode: 'Mock Postcode',
+      },
+    ],
+  })
+
+describe('AlcoholMonitoringController', () => {
+  let mockRestClient: jest.Mocked<RestClient>
+  let mockAuditClient: jest.Mocked<HmppsAuditClient>
+  let mockAuditService: jest.Mocked<AuditService>
+  let mockAlcoholMonitoringService: jest.Mocked<AlcoholMonitoringService>
+  let alcoholMonitoringController: AlcoholMonitoringController
+
+  beforeEach(() => {
+    mockAuditClient = new HmppsAuditClient({
+      queueUrl: '',
+      enabled: true,
+      region: '',
+      serviceName: '',
+    }) as jest.Mocked<HmppsAuditClient>
+    mockRestClient = new RestClient('cemoApi', {
+      url: '',
+      timeout: { response: 0, deadline: 0 },
+      agent: { timeout: 0 },
+    }) as jest.Mocked<RestClient>
+    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
+    mockAlcoholMonitoringService = new AlcoholMonitoringService(mockRestClient) as jest.Mocked<AlcoholMonitoringService>
+    alcoholMonitoringController = new AlcoholMonitoringController(mockAuditService, mockAlcoholMonitoringService)
+  })
+
+  describe('view', () => {
+    it('should render the form using the saved alcohol monitoring and address data', async () => {
+      // Given
+      const mockOrder = createMockOrder('2026-02-15')
+      const req = createMockRequest({ order: mockOrder })
+      const res = createMockResponse()
+      const next = jest.fn()
+      req.flash = jest.fn().mockReturnValue([])
+
+      // When
+      await alcoholMonitoringController.view(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/order/monitoring-conditions/alcohol-monitoring',
+        expect.objectContaining({
+          monitoringType: { value: 'ABSTINENCE' },
+          startDate: { value: { day: '15', month: '2', year: '2026' } },
+          endDate: { value: { day: '15', month: '2', year: '2027' } },
+          prisonName: { value: '' },
+          probationOfficeName: { value: '' },
+          installationAddressType: { value: 'PRIMARY' },
+          primaryAddressView: { value: '1 Mock Street, Mock City, Mock Postcode' },
+          secondaryAddressView: { value: '' },
+          tertiaryAddressView: { value: '' },
+          installationAddressView: { value: '' },
+        }),
+      )
+    })
+
+    it('should render the form using submitted data when there are validation errors', async () => {
+      // Given
+      const mockOrder = createMockOrder()
+      const req = createMockRequest({ order: mockOrder })
+      const res = createMockResponse()
+      const next = jest.fn()
+      req.flash = jest
+        .fn()
+        .mockReturnValueOnce([{ error: 'Start date is required', field: 'startDate' }])
+        .mockReturnValueOnce([
+          {
+            monitoringType: 'ABSTINENCE',
+            'startDate-day': '',
+            'startDate-month': '',
+            'startDate-year': '',
+            'endDate-day': '15',
+            'endDate-month': '02',
+            'endDate-year': '2027',
+            prisonName: '',
+            probationOfficeName: '',
+            installationAddressType: 'PRIMARY',
+            primaryAddressView: '1 Mock Street, Mock City, Mock Postcode',
+            secondaryAddressView: '',
+            tertiaryAddressView: '',
+            installationAddressView: '',
+          },
+        ])
+
+      // When
+      await alcoholMonitoringController.view(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/order/monitoring-conditions/alcohol-monitoring',
+        expect.objectContaining({
+          monitoringType: { value: 'ABSTINENCE' },
+          startDate: { value: { day: '', month: '', year: '' }, error: { text: 'Start date is required' } },
+          endDate: { value: { day: '15', month: '02', year: '2027' } },
+          prisonName: { value: '' },
+          probationOfficeName: { value: '' },
+          primaryAddressView: { value: '1 Mock Street, Mock City, Mock Postcode' },
+          secondaryAddressView: { value: '' },
+          tertiaryAddressView: { value: '' },
+          installationAddressView: { value: '' },
+          installationAddressType: { value: 'PRIMARY' },
+        }),
+      )
+    })
+  })
+
+  describe('update', () => {
+    it('should persist data and redirect to the form when the user submits invalid values', async () => {
+      // Given
+      const req = createMockRequest()
+      const res = createMockResponse()
+      const next = jest.fn()
+      req.flash = jest.fn()
+      req.body = {
+        action: 'continue',
+        monitoringType: '',
+        'startDate-day': '30',
+        'startDate-month': '12',
+        'startDate-year': '2026',
+        'endDate-day': '30',
+        'endDate-month': '12',
+        'endDate-year': '2027',
+        installationAddressType: 'PRIMARY',
+        prisonName: '',
+        probationOfficeName: '',
+      }
+      mockAlcoholMonitoringService.update.mockResolvedValue([
+        { error: 'Monitoring type is required', field: 'monitoringType' },
+      ])
+
+      // When
+      await alcoholMonitoringController.update(req, res, next)
+
+      // Then
+      expect(req.flash).toHaveBeenCalledTimes(2)
+      expect(req.flash).toHaveBeenNthCalledWith(1, 'formData', {
+        action: 'continue',
+        monitoringType: '',
+        'startDate-day': '30',
+        'startDate-month': '12',
+        'startDate-year': '2026',
+        'endDate-day': '30',
+        'endDate-month': '12',
+        'endDate-year': '2027',
+        installationAddressType: 'PRIMARY',
+        prisonName: '',
+        probationOfficeName: '',
+      })
+      expect(req.flash).toHaveBeenNthCalledWith(2, 'validationErrors', [
+        {
+          error: 'Monitoring type is required',
+          field: 'monitoringType',
+        },
+      ])
+      expect(res.redirect).toHaveBeenCalledWith('/order/123456789/monitoring-conditions/alcohol')
+    })
+
+    it('should save and redirect to the contact details page', async () => {
+      // Given
+      const req = createMockRequest()
+      const res = createMockResponse()
+      const next = jest.fn()
+      req.flash = jest.fn()
+      req.body = {
+        action: 'continue',
+        monitoringType: 'ABSTINENCE',
+        'startDate-day': '30',
+        'startDate-month': '12',
+        'startDate-year': '2026',
+        'endDate-day': '30',
+        'endDate-month': '12',
+        'endDate-year': '2027',
+        installationAddressType: 'PRIMARY',
+        prisonName: '',
+        probationOfficeName: '',
+      }
+      mockAlcoholMonitoringService.update.mockResolvedValue({
+        monitoringType: 'ABSTINENCE',
+        startDate: '2026-12-30',
+        endDate: '2027-12-30',
+        installationAddressType: 'PRIMARY',
+        prisonName: '',
+        probationOfficeName: '',
+      })
+
+      // When
+      await alcoholMonitoringController.update(req, res, next)
+
+      // Then
+      expect(req.flash).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith('/order/123456789/monitoring-conditions/curfew/conditions')
+    })
+  })
+
+  it('should save and redirect to the order summary page if the user chooses', async () => {
+    // Given
+    const req = createMockRequest()
+    const res = createMockResponse()
+    const next = jest.fn()
+    req.flash = jest.fn()
+    req.body = {
+      action: 'back',
+      monitoringType: 'ABSTINENCE',
+      'startDate-day': '30',
+      'startDate-month': '12',
+      'startDate-year': '2026',
+      'endDate-day': '30',
+      'endDate-month': '12',
+      'endDate-year': '2027',
+      installationAddressType: 'PRIMARY',
+      prisonName: '',
+      probationOfficeName: '',
+    }
+    mockAlcoholMonitoringService.update.mockResolvedValue({
+      monitoringType: 'ABSTINENCE',
+      startDate: '2026-12-30',
+      endDate: '2027-12-30',
+      installationAddressType: 'PRIMARY',
+      prisonName: '',
+      probationOfficeName: '',
+    })
+
+    // When
+    await alcoholMonitoringController.update(req, res, next)
+
+    // Then
+    expect(req.flash).not.toHaveBeenCalled()
+    expect(res.redirect).toHaveBeenCalledWith('/order/123456789/summary')
+  })
+})

--- a/server/models/AlcoholMonitoring.ts
+++ b/server/models/AlcoholMonitoring.ts
@@ -1,18 +1,21 @@
 import { z } from 'zod'
-import { AddressTypeEnum } from './Address'
 
-export const InstallationAddressTypeEnum = z.enum(['PRIMARY', 'SECONDARY', 'TERTIARY', 'INSTALLATION'])
-export const AlcoholMonitoringTypeEnum = z.enum(['ALCOHOL_LEVEL', 'ABSTINENCE'])
+export const AlcoholMonitoringTypeEnum = z.enum(['ALCOHOL_LEVEL', 'ALCOHOL_ABSTINENCE']).nullable()
+export const InstallationLocationEnum = z
+  .enum(['PRIMARY', 'SECONDARY', 'TERTIARY', 'INSTALLATION', 'PRISON', 'PROBATION_OFFICE'])
+  .nullable()
 
 const AlcoholMonitoringModel = z.object({
-  monitoringType: AlcoholMonitoringTypeEnum.nullable(),
+  monitoringType: AlcoholMonitoringTypeEnum,
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
-  installationAddressType: InstallationAddressTypeEnum.nullable(),
+  installationLocation: InstallationLocationEnum,
   prisonName: z.string().nullable(),
   probationOfficeName: z.string().nullable(),
 })
 
 export type AlcoholMonitoring = z.infer<typeof AlcoholMonitoringModel>
+export type InstallationLocationType = z.infer<typeof InstallationLocationEnum>
+export type AlcoholMonitoringType = z.infer<typeof AlcoholMonitoringTypeEnum>
 
 export default AlcoholMonitoringModel

--- a/server/models/AlcoholMonitoring.ts
+++ b/server/models/AlcoholMonitoring.ts
@@ -1,17 +1,16 @@
 import { z } from 'zod'
+import { AddressTypeEnum } from './Address'
+
+export const InstallationAddressTypeEnum = z.enum(['PRIMARY', 'SECONDARY', 'TERTIARY', 'INSTALLATION'])
+export const AlcoholMonitoringTypeEnum = z.enum(['ALCOHOL_LEVEL', 'ABSTINENCE'])
 
 const AlcoholMonitoringModel = z.object({
-  monitoringType: z.string().nullable(),
+  monitoringType: AlcoholMonitoringTypeEnum.nullable(),
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
-  installationLocation: z.string().nullable(),
-  agreedAddressLine1: z.string().nullable(),
-  agreedAddressLine2: z.string().nullable(),
-  agreedAddressLine3: z.string().nullable(),
-  agreedAddressLine4: z.string().nullable(),
-  agreedAddressPostcode: z.string().nullable(),
-  probationName: z.string().nullable(),
+  installationAddressType: InstallationAddressTypeEnum.nullable(),
   prisonName: z.string().nullable(),
+  probationOfficeName: z.string().nullable(),
 })
 
 export type AlcoholMonitoring = z.infer<typeof AlcoholMonitoringModel>

--- a/server/models/Order.ts
+++ b/server/models/Order.ts
@@ -30,7 +30,7 @@ const OrderModel = z.object({
   monitoringConditions: MonitoringConditionsModel,
   monitoringConditionsTrail: TrailMonitoringModel.nullable(),
   monitoringConditionsAttendance: z.array(AttendanceMonitoringModel).optional(),
-  monitoringConditionsAlcohol: AlcoholMonitoringModel.optional(),
+  monitoringConditionsAlcohol: AlcoholMonitoringModel.nullable(),
   monitoringConditionsCurfewReleaseDate: CurfewReleaseDateModel.optional(),
   monitoringConditionsCurfewConditions: CurfewConditionsModel.optional(),
   curfewTimeTable: CurfewTimetableModel.optional(),

--- a/server/views/pages/order/monitoring-conditions/alcohol-monitoring.njk
+++ b/server/views/pages/order/monitoring-conditions/alcohol-monitoring.njk
@@ -149,16 +149,16 @@
 
     {% set probationHtml %}
       {{ govukInput({
-        id: "probationName",
-        name: "probationName",
+        id: "probationOfficeName",
+        name: "probationOfficeName",
         type: "text",
         classes: "govuk-!-width-one-third",
         label: {
           text: "Enter name"
         },
         disabled: not isOrderEditable,
-        value: probationName.value,
-        errorMessage: probationName.error
+        value: probationOfficeName.value,
+        errorMessage: probationOfficeName.error
       }) }}
     {% endset -%}
 
@@ -177,16 +177,6 @@
       }) }}
     {% endset -%}
 
-    {% set agreedHtml %}
-      {{ addressInput({
-        id: "agreedAddress",
-        name: "agreedAddress",
-        value: agreedAddress.value,
-        errorMessage: agreedAddress.error,
-        disabled: not isOrderEditable
-      }) }}
-    {% endset -%}
-
     {{ govukRadios({
         name: "installationLocation",
         fieldset: {
@@ -199,34 +189,26 @@
         hint: {
             text: "Select one option"
         },
-        items: [
+        items: [        
           {
-            value: "INSTALLATION_ADDRESS",
-            text: "at [installation address]",
-            disabled: not isOrderEditable
+            value: "INSTALLATION",
+            text: "at Installation Address (not provided)" if not installationAddressView.value else "at Installation Address: "+installationAddressView.value,
+            disabled: not isOrderEditable or not installationAddressView.value
           },
           {
-            value: "PRIMARY_ADDRESS",
-            text: "at [primary address]",
-            disabled: not isOrderEditable
+            value: "PRIMARY",
+            text: "at Primary Address (not provided)" if not primaryAddressView.value else "at Primary Address: "+primaryAddressView.value,
+            disabled: not isOrderEditable or not primaryAddressView.value
           },
           {
-            value: "SECONDARY_ADDRESS",
-            text: "at [secondary address]",
-            disabled: not isOrderEditable
+            value: "SECONDARY",
+            text: "at Secondary Address (not provided)" if not secondaryAddressView.value else "at Secondary Address: "+secondaryAddressView.value,
+            disabled: not isOrderEditable or not secondaryAddressView.value
           },
           {
-            value: "TERTARY_ADDRESS",
-            text: "at [third address]",
-            disabled: not isOrderEditable
-          },
-          {
-            value: "AGREED_LOCATION",
-            text: "at an agreed location",
-            disabled: not isOrderEditable,
-            conditional: {
-              html: agreedHtml
-            }
+            value: "TERTIARY",
+            text: "at Tertiary Address (not provided)" if not tertiaryAddressView.value else "at Tertiary Address: "+tertiaryAddressView.value,
+            disabled: not isOrderEditable or not tertiaryAddressView.value
           },
           {
             value: "PROBATION_OFFICE",

--- a/test/mocks/mockOrder.ts
+++ b/test/mocks/mockOrder.ts
@@ -39,6 +39,7 @@ export const getMockOrder = (overrideProperties?: Partial<Order>): Order => ({
     devicesRequired: null,
   },
   monitoringConditionsTrail: null,
+  monitoringConditionsAlcohol: null,
   ...overrideProperties,
 })
 


### PR DESCRIPTION
This PR updates the alcohol monitoring page with changes made following discussions related to addresses.

It is worth noting that this implementation differs from assumptions that might be made by the designs, disabling the radios boxes for addresses not provided earlier in the user journey. If this implementation is not preferred, it can be updated.

https://github.com/user-attachments/assets/49f87245-ceb0-49c0-a1a8-13de4c220366



