### PR TITLE
Add logic to copy Monday's timetable entry across all of the timetable

### DIFF
--- a/integration_tests/e2e/order/monitoring-conditions/curfew-timetable/page.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/curfew-timetable/page.cy.ts
@@ -20,11 +20,13 @@ context('Monitoring conditions - Curfew timetable', () => {
 
     it('Should display the user name visible in header', () => {
       const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
+
       page.header.userName().should('contain.text', 'J. Smith')
     })
 
     it('Should display the phase banner in header', () => {
       const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
+
       page.header.phaseBanner().should('contain.text', 'dev')
     })
 
@@ -45,11 +47,13 @@ context('Monitoring conditions - Curfew timetable', () => {
     it('Should display the timetable form', () => {
       const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
 
+      page.form.shouldBeDisplayed()
       page.form.shouldBeEmpty()
     })
 
     it('Should be accessible', () => {
       const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
+
       page.checkIsAccessible()
     })
   })

--- a/integration_tests/e2e/order/monitoring-conditions/curfew-timetable/submission.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/curfew-timetable/submission.cy.ts
@@ -535,6 +535,107 @@ context('Monitoring conditions - Curfew timetable', () => {
     })
   })
 
+  context('when the user chooses to auto-populate the other days', () => {
+    it('copies the monday entry to all empty days', () => {
+      const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
+
+      page.form.fillInWith([
+        {
+          day: 'Monday',
+          startTime: '19:00:00',
+          endTime: '10:00:00',
+          addresses: ['Primary address'],
+        },
+      ])
+
+      page.form.autoPopulateTimetable()
+      page.form.saveAndContinueButton.click()
+
+      cy.task('stubCemoVerifyRequestReceived', {
+        uri: `/orders/${mockOrderId}${apiPath}`,
+        body: expectations.allDays(mockOrderId, '19:00:00', '10:00:00', 'PRIMARY_ADDRESS'),
+      }).should('be.true')
+    })
+
+    it('copies the monday entry over all filled days', () => {
+      const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
+
+      page.form.fillInWith([
+        {
+          day: 'Monday',
+          startTime: '19:00:00',
+          endTime: '07:00:00',
+          addresses: ['Primary address'],
+        },
+        {
+          day: 'Wednesday',
+          startTime: '07:00:00',
+          endTime: '10:00:00',
+          addresses: ['Secondary address'],
+        },
+        {
+          day: 'Friday',
+          startTime: '21:00:00',
+          endTime: '07:00:00',
+          addresses: ['Primary address', 'Secondary address'],
+        },
+      ])
+
+      page.form.autoPopulateTimetable()
+      page.form.saveAndContinueButton.click()
+
+      cy.task('stubCemoVerifyRequestReceived', {
+        uri: `/orders/${mockOrderId}${apiPath}`,
+        body: expectations.allDays(mockOrderId, '19:00:00', '07:00:00', 'PRIMARY_ADDRESS'),
+      }).should('be.true')
+    })
+
+    it('copies the monday entry over all days and removes additional entries', () => {
+      const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
+
+      page.form.fillInWith([
+        {
+          day: 'Monday',
+          startTime: '16:00:00',
+          endTime: '04:00:00',
+          addresses: ['Primary address'],
+        },
+        {
+          day: 'Tuesday',
+          startTime: '22:00:00',
+          endTime: '23:59:00',
+          addresses: ['Secondary address'],
+        },
+        {
+          day: 'Tuesday',
+          startTime: '00:00:00',
+          endTime: '10:00:00',
+          addresses: ['Secondary address'],
+        },
+        {
+          day: 'Thursday',
+          startTime: '19:00:00',
+          endTime: '23:59:00',
+          addresses: ['Primary address', 'Secondary address'],
+        },
+        {
+          day: 'Thursday',
+          startTime: '00:00:00',
+          endTime: '07:00:00',
+          addresses: ['Primary address', 'Secondary address'],
+        },
+      ])
+
+      page.form.autoPopulateTimetable()
+      page.form.saveAndContinueButton.click()
+
+      cy.task('stubCemoVerifyRequestReceived', {
+        uri: `/orders/${mockOrderId}${apiPath}`,
+        body: expectations.allDays(mockOrderId, '16:00:00', '04:00:00', 'PRIMARY_ADDRESS'),
+      }).should('be.true')
+    })
+  })
+
   // context('when other orders indicated', () => {})
   //   it('should return to the summary page', () => {})
 

--- a/server/controllers/monitoringConditions/CurfewReleaseDateController.test.ts
+++ b/server/controllers/monitoringConditions/CurfewReleaseDateController.test.ts
@@ -87,7 +87,7 @@ describe('CurfewReleaseDateController', () => {
         { field: 'startTime', error: 'mock start time Error' },
       ]
       const mockFormData = {
-        action: 'next',
+        action: 'continue',
         address: 'PRIMARY',
         releaseDateDay: '11',
         releaseDateMonth: '09',
@@ -165,7 +165,7 @@ describe('CurfewReleaseDateController', () => {
   describe('Update curfew release date', () => {
     it('Should redirect to view and save form and validation error flash when service return validation error', async () => {
       req.body = {
-        action: 'next',
+        action: 'continue',
         address: 'PRIMARY',
         releaseDateDay: '11',
         releaseDateMonth: '09',
@@ -190,8 +190,9 @@ describe('CurfewReleaseDateController', () => {
       )
     })
 
-    it('Shoud redirect to curfew condition page', async () => {
+    it('Should redirect to curfew condition page', async () => {
       req.order = getMockOrder({
+        id: mockId,
         monitoringConditions: {
           acquisitiveCrime: false,
           alcohol: false,
@@ -209,7 +210,7 @@ describe('CurfewReleaseDateController', () => {
         },
       })
       req.body = {
-        action: 'next',
+        action: 'continue',
         address: 'PRIMARY',
         releaseDateDay: '11',
         releaseDateMonth: '09',
@@ -223,7 +224,44 @@ describe('CurfewReleaseDateController', () => {
 
       await controller.update(req, res, next)
 
-      expect(res.redirect).toHaveBeenCalledWith(`/order/${req.order.id}/monitoring-conditions/curfew/conditions`)
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${mockId}/monitoring-conditions/curfew/conditions`)
+    })
+
+    it('Should redirect back to summary page', async () => {
+      req.order = getMockOrder({
+        id: mockId,
+        monitoringConditions: {
+          acquisitiveCrime: false,
+          alcohol: false,
+          dapol: false,
+          devicesRequired: [],
+          exclusionZone: false,
+          mandatoryAttendance: false,
+          orderType: '',
+          trail: false,
+          curfew: true,
+          conditionType: '',
+          endDate: '',
+          orderTypeDescription: '',
+          startDate: '',
+        },
+      })
+      req.body = {
+        action: 'back',
+        address: 'PRIMARY',
+        releaseDateDay: '11',
+        releaseDateMonth: '09',
+        releaseDateYear: '2025',
+        curfewTimesStartHours: '19',
+        curfewTimesStartMinutes: '00',
+        curfewTimesEndHours: '23',
+        curfewTimesEndMinutes: '59',
+      }
+      mockCurfewReleaseDateService.update = jest.fn().mockResolvedValue(undefined)
+
+      await controller.update(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${mockId}/summary`)
     })
   })
 })

--- a/server/controllers/monitoringConditions/curfewConditionsController.test.ts
+++ b/server/controllers/monitoringConditions/curfewConditionsController.test.ts
@@ -87,7 +87,7 @@ describe('CurfewConditionsController', () => {
         { field: 'startDate', error: 'mock start date Error' },
       ]
       const mockFormData = {
-        action: 'next',
+        action: 'continue',
         addresses: ['PRIMARY', 'SECONDARY'],
         'startDate-day': '11',
         'startDate-month': '09',
@@ -162,7 +162,7 @@ describe('CurfewConditionsController', () => {
   describe('Update curfew conditions', () => {
     it('Should redirect to view and save form and validation error flash when service return validation error', async () => {
       req.body = {
-        action: 'next',
+        action: 'continue',
         addresses: ['PRIMARY', 'SECONDARY'],
         'startDate-day': '11',
         'startDate-month': '09',
@@ -186,8 +186,9 @@ describe('CurfewConditionsController', () => {
       )
     })
 
-    it('Shoud redirect to curfew condition page', async () => {
+    it('Should redirect to curfew condition page', async () => {
       req.order = getMockOrder({
+        id: mockId,
         monitoringConditions: {
           acquisitiveCrime: false,
           alcohol: false,
@@ -205,7 +206,7 @@ describe('CurfewConditionsController', () => {
         },
       })
       req.body = {
-        action: 'next',
+        action: 'continue',
         address: ['PRIMARY', 'SECONDARY'],
         'startDate-day': '11',
         'startDate-month': '09',
@@ -218,7 +219,43 @@ describe('CurfewConditionsController', () => {
 
       await controller.update(req, res, next)
 
-      expect(res.redirect).toHaveBeenCalledWith(`/order/${req.order.id}/monitoring-conditions/curfew/timetable`)
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${mockId}/monitoring-conditions/curfew/timetable`)
+    })
+
+    it('Should redirect back to summary page', async () => {
+      req.order = getMockOrder({
+        id: mockId,
+        monitoringConditions: {
+          acquisitiveCrime: false,
+          alcohol: false,
+          dapol: false,
+          devicesRequired: [],
+          exclusionZone: false,
+          mandatoryAttendance: false,
+          orderType: '',
+          trail: false,
+          curfew: true,
+          conditionType: '',
+          endDate: '',
+          orderTypeDescription: '',
+          startDate: '',
+        },
+      })
+      req.body = {
+        action: 'back',
+        address: ['PRIMARY', 'SECONDARY'],
+        'startDate-day': '11',
+        'startDate-month': '09',
+        'startDate-year': '2024',
+        'endDate-day': '11',
+        'endDate-month': '09',
+        'endDate-year': '2025',
+      }
+      mockCurfewReleaseDateService.update = jest.fn().mockResolvedValue(undefined)
+
+      await controller.update(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${mockId}/summary`)
     })
   })
 })

--- a/server/controllers/monitoringConditions/curfewConditionsController.ts
+++ b/server/controllers/monitoringConditions/curfewConditionsController.ts
@@ -38,8 +38,14 @@ export default class CurfewConditionsController {
       req.flash('validationErrors', updateResult)
 
       res.redirect(paths.MONITORING_CONDITIONS.CURFEW_CONDITIONS.replace(':orderId', orderId))
-    } else {
-      res.redirect(this.taskListService.getNextPage('CURFEW_CONDITIONS', req.order!))
+      return
     }
+
+    if (formData.action === 'continue') {
+      res.redirect(this.taskListService.getNextPage('CURFEW_CONDITIONS', req.order!))
+      return
+    }
+
+    res.redirect(paths.ORDER.SUMMARY.replace(':orderId', orderId))
   }
 }

--- a/server/controllers/monitoringConditions/curfewReleaseDateController.ts
+++ b/server/controllers/monitoringConditions/curfewReleaseDateController.ts
@@ -38,8 +38,14 @@ export default class CurfewReleaseDateController {
       req.flash('validationErrors', updateResult)
 
       res.redirect(paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE.replace(':orderId', orderId))
-    } else {
-      res.redirect(this.taskListService.getNextPage('CURFEW_RELEASE_DATE', req.order!))
+      return
     }
+
+    if (formData.action === 'continue') {
+      res.redirect(this.taskListService.getNextPage('CURFEW_RELEASE_DATE', req.order!))
+      return
+    }
+
+    res.redirect(paths.ORDER.SUMMARY.replace(':orderId', orderId))
   }
 }

--- a/server/controllers/monitoringConditions/curfewTimetableController.test.ts
+++ b/server/controllers/monitoringConditions/curfewTimetableController.test.ts
@@ -508,7 +508,6 @@ describe('CurfewTimetableController', () => {
       await controller.update(req, res, next)
 
       expect(req.flash).toHaveBeenCalledWith('formData', {
-        action: 'add-time-monday',
         curfewTimetable: {
           monday: [
             {
@@ -616,7 +615,6 @@ describe('CurfewTimetableController', () => {
       await controller.update(req, res, next)
 
       expect(req.flash).toHaveBeenCalledWith('formData', {
-        action: 'remove-time-monday-0',
         curfewTimetable: {
           monday: [
             {
@@ -689,8 +687,12 @@ describe('CurfewTimetableController', () => {
     })
 
     it('Should redirect view with validation error, when service return validation error', async () => {
+      const validationErrors = [
+        { index: 0, errors: [{ field: 'startTime', error: 'Mock Start Time Error' }] },
+        { index: 3, errors: [{ field: 'curfewAddress', error: 'Mock Address Error' }] },
+      ]
       const formData: { curfewTimetable: { [k: string]: [object] }; action: string } = {
-        action: '',
+        action: 'continue',
         curfewTimetable: {},
       }
       days.forEach(day => {
@@ -706,77 +708,64 @@ describe('CurfewTimetableController', () => {
       })
       req.body = formData
 
-      mockCurfewTimetableService.update = jest.fn().mockReturnValueOnce([
-        { index: 0, errors: [{ field: 'startTime', error: 'Mock Start Time Error' }] },
-        { index: 3, errors: [{ field: 'curfewAddress', error: 'Mock Address Error' }] },
-      ])
+      mockCurfewTimetableService.update = jest.fn().mockReturnValueOnce(validationErrors)
       await controller.update(req, res, next)
 
       expect(req.flash).toHaveBeenCalledWith('validationErrors', [
         {
           dayOfWeek: 'MONDAY',
-          orderId: mockId,
-          curfewAddress: 'PRIMARY_ADDRESS',
           startTime: '19:00:00',
           endTime: '23:59:00',
-          errors: [
-            {
-              field: 'startTime',
-              error: 'Mock Start Time Error',
-            },
-          ],
+          curfewAddress: 'PRIMARY_ADDRESS',
+          orderId: mockId,
+          errors: [{ field: 'startTime', error: 'Mock Start Time Error' }],
         },
         {
           dayOfWeek: 'TUESDAY',
-          orderId: mockId,
-          curfewAddress: 'PRIMARY_ADDRESS',
           startTime: '19:00:00',
           endTime: '23:59:00',
+          curfewAddress: 'PRIMARY_ADDRESS',
+          orderId: mockId,
           errors: [],
         },
         {
           dayOfWeek: 'WEDNESDAY',
-          orderId: mockId,
-          curfewAddress: 'PRIMARY_ADDRESS',
           startTime: '19:00:00',
           endTime: '23:59:00',
+          curfewAddress: 'PRIMARY_ADDRESS',
+          orderId: mockId,
           errors: [],
         },
         {
           dayOfWeek: 'THURSDAY',
-          orderId: mockId,
-          curfewAddress: 'PRIMARY_ADDRESS',
           startTime: '19:00:00',
           endTime: '23:59:00',
-          errors: [
-            {
-              field: 'curfewAddress',
-              error: 'Mock Address Error',
-            },
-          ],
+          curfewAddress: 'PRIMARY_ADDRESS',
+          orderId: mockId,
+          errors: [{ field: 'curfewAddress', error: 'Mock Address Error' }],
         },
         {
           dayOfWeek: 'FRIDAY',
-          orderId: mockId,
-          curfewAddress: 'PRIMARY_ADDRESS',
           startTime: '19:00:00',
           endTime: '23:59:00',
+          curfewAddress: 'PRIMARY_ADDRESS',
+          orderId: mockId,
           errors: [],
         },
         {
           dayOfWeek: 'SATURDAY',
-          orderId: mockId,
-          curfewAddress: 'PRIMARY_ADDRESS',
           startTime: '19:00:00',
           endTime: '23:59:00',
+          curfewAddress: 'PRIMARY_ADDRESS',
+          orderId: mockId,
           errors: [],
         },
         {
           dayOfWeek: 'SUNDAY',
-          orderId: mockId,
-          curfewAddress: 'PRIMARY_ADDRESS',
           startTime: '19:00:00',
           endTime: '23:59:00',
+          curfewAddress: 'PRIMARY_ADDRESS',
+          orderId: mockId,
           errors: [],
         },
       ])
@@ -787,7 +776,7 @@ describe('CurfewTimetableController', () => {
 
     it('Should redirect to next page', async () => {
       const formData: { curfewTimetable: { [k: string]: [object] }; action: string } = {
-        action: '',
+        action: 'continue',
         curfewTimetable: {},
       }
       days.forEach(day => {
@@ -808,6 +797,31 @@ describe('CurfewTimetableController', () => {
       await controller.update(req, res, next)
 
       expect(res.redirect).toHaveBeenCalledWith(`/order/${mockId}/attachments`)
+    })
+
+    it('Should redirect back to summary page', async () => {
+      const formData: { curfewTimetable: { [k: string]: [object] }; action: string } = {
+        action: 'back',
+        curfewTimetable: {},
+      }
+      days.forEach(day => {
+        formData.curfewTimetable[day] = [
+          {
+            timeStartHours: '19',
+            timeStartMinutes: '00',
+            timeEndHours: '23',
+            timeEndMinutes: '59',
+            addresses: ['PRIMARY_ADDRESS'],
+          },
+        ]
+      })
+      req.body = formData
+
+      mockCurfewTimetableService.update = jest.fn().mockReturnValueOnce([{ dayOfWeek: 'Monday' }])
+
+      await controller.update(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${mockId}/summary`)
     })
   })
 })

--- a/server/controllers/monitoringConditions/curfewTimetableController.ts
+++ b/server/controllers/monitoringConditions/curfewTimetableController.ts
@@ -1,60 +1,44 @@
 import { Request, RequestHandler, Response } from 'express'
-import { z } from 'zod'
+
 import paths from '../../constants/paths'
-import { CurfewTimetable } from '../../models/CurfewTimetable'
-import { isValidationListResult, ValidationErrorModel } from '../../models/Validation'
-import { MultipleChoiceField, TimeSpanField } from '../../models/view-models/utils'
+import { isValidationListResult } from '../../models/Validation'
 import { AuditService, CurfewTimetableService } from '../../services'
-import { deserialiseTime, getError, getErrors, serialiseTime } from '../../utils/utils'
 import TaskListService from '../../services/taskListService'
+import { CurfewTimetable } from '../../models/CurfewTimetable'
+import CurfewTimetableFormDataModel, { CurfewTimetableDataModel } from '../../models/form-data/curfewTimetable'
+import curfewTimetableViewModel from '../../models/view-models/curfewTimetable'
+import { serialiseTime } from '../../utils/utils'
 
-const timetableForm = z.object({
-  timeStartHours: z.string(),
-  timeStartMinutes: z.string(),
-  timeEndHours: z.string(),
-  timeEndMinutes: z.string(),
-  addresses: z.array(z.string()).default([]),
-})
-const timetable = z.object({
-  monday: z.array(timetableForm),
-  tuesday: z.array(timetableForm),
-  wednesday: z.array(timetableForm),
-  thursday: z.array(timetableForm),
-  friday: z.array(timetableForm),
-  saturday: z.array(timetableForm),
-  sunday: z.array(timetableForm),
-})
-const curfewTimetableFormDataModel = z.object({
-  action: z.string().default('continue'),
-  curfewTimetable: timetable,
-})
-
-type CurfewTimetableFormDataItem = z.infer<typeof timetableForm>
-
-type CurfewTimetableFormData = z.infer<typeof curfewTimetableFormDataModel>
-
-type Timetable = {
-  timeSpan: TimeSpanField
-  addresses: MultipleChoiceField
+const createApiModelFromFormData = (curfewTimetable: CurfewTimetableDataModel, orderId: string): CurfewTimetable => {
+  return Object.entries(curfewTimetable).flatMap(([day, timetables]) =>
+    timetables.map(t => ({
+      dayOfWeek: day.toUpperCase(),
+      orderId,
+      curfewAddress: t.addresses.join(','),
+      startTime: serialiseTime(t.timeStartHours, t.timeStartMinutes) || '',
+      endTime: serialiseTime(t.timeEndHours, t.timeEndMinutes) || '',
+    })),
+  )
 }
-const curfewTimetableApiDto = z.object({
-  dayOfWeek: z.string(),
-  startTime: z.string(),
-  endTime: z.string(),
-  curfewAddress: z.string(),
-  errors: z.array(ValidationErrorModel),
-})
-type CurfewTimetableApiDto = z.infer<typeof curfewTimetableApiDto>
-type CurfewTimetableViewModel = {
-  curfewTimetable: {
-    monday: Timetable[]
-    tuesday: Timetable[]
-    wednesday: Timetable[]
-    thursday: Timetable[]
-    friday: Timetable[]
-    saturday: Timetable[]
-    sunday: Timetable[]
+
+const parseAction = (action?: string): [verb: string | undefined, options: { day: string; index: number }] => {
+  if (!action) {
+    return ['view', { day: '', index: 0 }]
   }
+
+  if (action?.startsWith('add-time-')) {
+    const [, , day] = action.split('-')
+    return ['add-time', { day, index: 0 }]
+  }
+
+  if (action?.startsWith('remove-time-')) {
+    const [, , day, indexString] = action.split('-')
+    const index = Number.parseInt(indexString, 10)
+
+    return ['remove-time', { day, index }]
+  }
+
+  return [action, { day: '', index: 0 }]
 }
 
 export default class CurfewTimetableController {
@@ -64,110 +48,11 @@ export default class CurfewTimetableController {
     private readonly taskListService: TaskListService,
   ) {}
 
-  private constructViewModel(
-    curfewTimetable: CurfewTimetable | undefined,
-    apiDto: CurfewTimetableApiDto[],
-    formData: [CurfewTimetableFormData],
-  ): CurfewTimetableViewModel {
-    if (formData?.length > 0) {
-      return this.createViewModelFromFormData(formData[0])
-    }
-
-    if (!apiDto || apiDto.length === 0) {
-      const curfewTimetableAsApiDto =
-        curfewTimetable?.map(item => {
-          return {
-            ...item,
-            errors: [],
-          }
-        }) ?? []
-      return this.createViewModelFromApiDto(curfewTimetableAsApiDto)
-    }
-    return this.createViewModelFromApiDto(apiDto)
-  }
-
-  private createViewModelFromApiDto(validationErrors: CurfewTimetableApiDto[]): CurfewTimetableViewModel {
-    const getTimetablesForDay = (day: string, timetables?: CurfewTimetableApiDto[]): Timetable[] =>
-      timetables
-        ?.filter(t => t.dayOfWeek === day)
-        .map(t => {
-          const [startHours, startMinutes] = deserialiseTime(t.startTime)
-          const [endHours, endMinutes] = deserialiseTime(t.endTime)
-          return {
-            timeSpan: {
-              value: { startHours, startMinutes, endHours, endMinutes },
-              error: getErrors(t.errors, [`startTime`, `endTime`]),
-            },
-            addresses: { values: t.curfewAddress.split(','), error: getError(t.errors, `curfewAddress`) },
-          }
-        }) ?? []
-
-    return {
-      curfewTimetable: {
-        monday: getTimetablesForDay('MONDAY', validationErrors),
-        tuesday: getTimetablesForDay('TUESDAY', validationErrors),
-        wednesday: getTimetablesForDay('WEDNESDAY', validationErrors),
-        thursday: getTimetablesForDay('THURSDAY', validationErrors),
-        friday: getTimetablesForDay('FRIDAY', validationErrors),
-        saturday: getTimetablesForDay('SATURDAY', validationErrors),
-        sunday: getTimetablesForDay('SUNDAY', validationErrors),
-      },
-    }
-  }
-
-  private createViewModelFromFormData(formData: CurfewTimetableFormData): CurfewTimetableViewModel {
-    const getTimetablesForDay = (day: string, timetables: CurfewTimetableFormDataItem[]): Timetable[] =>
-      timetables.map(t => {
-        return {
-          timeSpan: {
-            value: {
-              startHours: t.timeStartHours,
-              startMinutes: t.timeStartMinutes,
-              endHours: t.timeEndHours,
-              endMinutes: t.timeEndMinutes,
-            },
-          },
-          addresses: { values: t.addresses },
-        }
-      }) ?? []
-
-    return {
-      curfewTimetable: {
-        monday: getTimetablesForDay('monday', formData.curfewTimetable.monday),
-        tuesday: getTimetablesForDay('tuesday', formData.curfewTimetable.tuesday),
-        wednesday: getTimetablesForDay('wednesday', formData.curfewTimetable.wednesday),
-        thursday: getTimetablesForDay('thursday', formData.curfewTimetable.thursday),
-        friday: getTimetablesForDay('friday', formData.curfewTimetable.friday),
-        saturday: getTimetablesForDay('saturday', formData.curfewTimetable.saturday),
-        sunday: getTimetablesForDay('sunday', formData.curfewTimetable.sunday),
-      },
-    }
-  }
-
-  private createApiModelFromFormData(formData: CurfewTimetableFormData, orderId: string): CurfewTimetable {
-    return Object.entries(formData.curfewTimetable).flatMap(([day, timetables]) =>
-      timetables.map(t => ({
-        dayOfWeek: day.toUpperCase(),
-        orderId,
-        curfewAddress: t.addresses.join(','),
-        startTime: serialiseTime(t.timeStartHours, t.timeStartMinutes) || '',
-        endTime: serialiseTime(t.timeEndHours, t.timeEndMinutes) || '',
-      })),
-    )
-  }
-
-  view: RequestHandler = async (req: Request, res: Response) => {
-    const { curfewTimeTable: curfewTimetable } = req.order!
-    const errors = req.flash('validationErrors')
-    const formData = req.flash('formData')
-    const viewModel = this.constructViewModel(curfewTimetable, errors as never, formData as never)
-    res.render(`pages/order/monitoring-conditions/curfew-timetable`, viewModel)
-  }
-
-  private addTimeToCurfewDay(req: Request, res: Response, formData: CurfewTimetableFormData, orderId: string) {
-    const day = formData.action.split('-').pop()!
-    const curfewDay = formData.curfewTimetable[day as keyof typeof formData.curfewTimetable]
-
+  private addTimeToCurfewDay(
+    curfewTimetable: CurfewTimetableDataModel,
+    options: { day: string },
+  ): CurfewTimetableDataModel {
+    const curfewDay = curfewTimetable[options.day as keyof CurfewTimetableDataModel]
     curfewDay.push({
       timeStartHours: '',
       timeStartMinutes: '',
@@ -175,71 +60,98 @@ export default class CurfewTimetableController {
       timeEndMinutes: '',
       addresses: [],
     })
-    req.flash('formData', formData)
-    res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
+
+    return curfewTimetable
   }
 
-  private removeTimeFromCurfewDay(req: Request, res: Response, formData: CurfewTimetableFormData, orderId: string) {
-    const action = formData.action.split('-')
-    const day = action[2]
-    const index = Number.parseInt(action[3], 10)
-    const curfewDay = formData.curfewTimetable[day as keyof typeof formData.curfewTimetable]
+  private removeTimeFromCurfewDay(
+    curfewTimetable: CurfewTimetableDataModel,
+    options: { day: string; index: number },
+  ): CurfewTimetableDataModel {
+    const curfewDay = curfewTimetable[options.day as keyof CurfewTimetableDataModel]
+    curfewDay.splice(options.index, 1)
 
-    curfewDay.splice(index, 1)
-    req.flash('formData', formData)
-    res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
+    return curfewTimetable
   }
 
-  private copyTimeAcrossCurfewDays(req: Request, res: Response, formData: CurfewTimetableFormData, orderId: string) {
-    const sourceDay = formData.curfewTimetable.monday
+  private copyTimeAcrossCurfewDays(curfewTimetable: CurfewTimetableDataModel): CurfewTimetableDataModel {
+    const sourceDay = curfewTimetable.monday
 
-    req.flash('formData', {
-      action: formData.action,
-      curfewTimetable: {
-        monday: sourceDay,
-        tuesday: sourceDay,
-        wednesday: sourceDay,
-        thursday: sourceDay,
-        friday: sourceDay,
-        saturday: sourceDay,
-        sunday: sourceDay,
-      },
-    })
+    return {
+      monday: sourceDay,
+      tuesday: sourceDay,
+      wednesday: sourceDay,
+      thursday: sourceDay,
+      friday: sourceDay,
+      saturday: sourceDay,
+      sunday: sourceDay,
+    }
+  }
 
-    res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
+  view: RequestHandler = async (req: Request, res: Response) => {
+    const { curfewTimeTable } = req.order!
+    const errors = req.flash('validationErrors')
+    const formData = req.flash('formData')
+    const viewModel = curfewTimetableViewModel.construct(curfewTimeTable ?? [], errors as never, formData as never)
+
+    res.render(`pages/order/monitoring-conditions/curfew-timetable`, viewModel)
   }
 
   update: RequestHandler = async (req: Request, res: Response) => {
     const { orderId } = req.params
+    const { action, ...formData } = CurfewTimetableFormDataModel.parse(req.body)
+    const [act, options] = parseAction(action)
 
-    const formData = curfewTimetableFormDataModel.parse(req.body)
-    if (formData.action.startsWith('add-time-')) {
-      this.addTimeToCurfewDay(req, res, formData, orderId)
-    } else if (formData.action.startsWith('remove-time-')) {
-      this.removeTimeFromCurfewDay(req, res, formData, orderId)
-    } else if (formData.action === 'copy-times') {
-      this.copyTimeAcrossCurfewDays(req, res, formData, orderId)
-    } else {
-      const apiModel = this.createApiModelFromFormData(formData, orderId)
-      const updateResult = await this.curfewTimetableService.update({
-        accessToken: res.locals.user.token,
-        orderId,
-        data: apiModel.filter(t => t.curfewAddress + t.startTime + t.endTime !== ''),
-      })
+    if (act === 'add-time') {
+      formData.curfewTimetable = this.addTimeToCurfewDay(formData.curfewTimetable, options)
 
-      if (isValidationListResult(updateResult)) {
-        const validationResult = apiModel.map((item, index) => {
-          return {
-            ...item,
-            errors: updateResult.filter(it => it.index === index).at(0)?.errors ?? [],
-          }
-        })
-        req.flash('validationErrors', validationResult)
-
-        res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
-      } else {
-        res.redirect(this.taskListService.getNextPage('CURFEW_TIMETABLE', req.order!))
-      }
+      req.flash('formData', formData)
+      res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
+      return
     }
+
+    if (act === 'remove-time') {
+      formData.curfewTimetable = this.removeTimeFromCurfewDay(formData.curfewTimetable, options)
+
+      req.flash('formData', formData)
+      res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
+      return
+    }
+
+    if (act === 'copy-times') {
+      formData.curfewTimetable = this.copyTimeAcrossCurfewDays(formData.curfewTimetable)
+
+      req.flash('formData', formData)
+      res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
+      return
+    }
+
+    const apiModel = createApiModelFromFormData(formData.curfewTimetable, orderId)
+    const updateResult = await this.curfewTimetableService.update({
+      accessToken: res.locals.user.token,
+      orderId,
+      data: apiModel.filter(t => t.curfewAddress + t.startTime + t.endTime !== ''),
+    })
+
+    if (isValidationListResult(updateResult)) {
+      const validationResult = apiModel.map((item, index) => {
+        return {
+          ...item,
+          errors: updateResult.filter(it => it.index === index).at(0)?.errors ?? [],
+        }
+      })
+      req.flash('validationErrors', validationResult)
+      req.flash('formData', formData)
+
+      res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
+      return
+    }
+
+    if (action === 'continue') {
+      res.redirect(this.taskListService.getNextPage('CURFEW_TIMETABLE', req.order!))
+      return
+    }
+
+    res.redirect(paths.ORDER.SUMMARY.replace(':orderId', orderId))
   }
 }

--- a/server/controllers/monitoringConditions/curfewTimetableController.ts
+++ b/server/controllers/monitoringConditions/curfewTimetableController.ts
@@ -179,7 +179,7 @@ export default class CurfewTimetableController {
     res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
   }
 
-  private removeTimeToCurfewDay(req: Request, res: Response, formData: CurfewTimetableFormData, orderId: string) {
+  private removeTimeFromCurfewDay(req: Request, res: Response, formData: CurfewTimetableFormData, orderId: string) {
     const action = formData.action.split('-')
     const day = action[2]
     const index = Number.parseInt(action[3], 10)
@@ -190,6 +190,25 @@ export default class CurfewTimetableController {
     res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
   }
 
+  private copyTimeAcrossCurfewDays(req: Request, res: Response, formData: CurfewTimetableFormData, orderId: string) {
+    const sourceDay = formData.curfewTimetable.monday
+
+    req.flash('formData', {
+      action: formData.action,
+      curfewTimetable: {
+        monday: sourceDay,
+        tuesday: sourceDay,
+        wednesday: sourceDay,
+        thursday: sourceDay,
+        friday: sourceDay,
+        saturday: sourceDay,
+        sunday: sourceDay,
+      },
+    })
+
+    res.redirect(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', orderId))
+  }
+
   update: RequestHandler = async (req: Request, res: Response) => {
     const { orderId } = req.params
 
@@ -197,7 +216,9 @@ export default class CurfewTimetableController {
     if (formData.action.startsWith('add-time-')) {
       this.addTimeToCurfewDay(req, res, formData, orderId)
     } else if (formData.action.startsWith('remove-time-')) {
-      this.removeTimeToCurfewDay(req, res, formData, orderId)
+      this.removeTimeFromCurfewDay(req, res, formData, orderId)
+    } else if (formData.action === 'copy-times') {
+      this.copyTimeAcrossCurfewDays(req, res, formData, orderId)
     } else {
       const apiModel = this.createApiModelFromFormData(formData, orderId)
       const updateResult = await this.curfewTimetableService.update({

--- a/server/models/Validation.ts
+++ b/server/models/Validation.ts
@@ -5,7 +5,7 @@ export const ValidationErrorModel = z.object({
   error: z.string(),
 })
 
-export const ListItemvalidationErrorModel = z.object({
+export const ListItemValidationErrorModel = z.object({
   errors: z.array(ValidationErrorModel),
   index: z.number().int(),
 })
@@ -16,9 +16,9 @@ export type ValidationError = z.infer<typeof ValidationErrorModel>
 
 export type ValidationResult = z.infer<typeof ValidationResultModel>
 
-export const ListValidationResultModel = z.array(ListItemvalidationErrorModel)
+export const ListValidationResultModel = z.array(ListItemValidationErrorModel)
 
-export type ListItemvalidationError = z.infer<typeof ListItemvalidationErrorModel>
+export type ListItemValidationError = z.infer<typeof ListItemValidationErrorModel>
 
 export type ListValidationResult = z.infer<typeof ListValidationResultModel>
 
@@ -34,7 +34,7 @@ export const isValidationListResult = (result: unknown): result is ListValidatio
   return (
     Array.isArray(result) &&
     result.every(
-      r => (r as ListItemvalidationError).errors !== undefined && (r as ListItemvalidationError).index !== undefined,
+      r => (r as ListItemValidationError).errors !== undefined && (r as ListItemValidationError).index !== undefined,
     )
   )
 }

--- a/server/models/form-data/curfewTimetable.ts
+++ b/server/models/form-data/curfewTimetable.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+const CurfewTimetableEntryModel = z.object({
+  timeStartHours: z.string(),
+  timeStartMinutes: z.string(),
+  timeEndHours: z.string(),
+  timeEndMinutes: z.string(),
+  addresses: z.array(z.string()).default([]),
+})
+
+const curfewTimetableDataModel = z.object({
+  monday: z.array(CurfewTimetableEntryModel),
+  tuesday: z.array(CurfewTimetableEntryModel),
+  wednesday: z.array(CurfewTimetableEntryModel),
+  thursday: z.array(CurfewTimetableEntryModel),
+  friday: z.array(CurfewTimetableEntryModel),
+  saturday: z.array(CurfewTimetableEntryModel),
+  sunday: z.array(CurfewTimetableEntryModel),
+})
+
+const CurfewTimetableFormDataModel = z.object({
+  action: z.string().default('continue'),
+  curfewTimetable: curfewTimetableDataModel,
+})
+
+export type curfewTimetableFormDataItem = z.infer<typeof CurfewTimetableEntryModel>
+export type CurfewTimetableDataModel = z.infer<typeof curfewTimetableDataModel>
+export type CurfewTimetableFormData = z.infer<typeof CurfewTimetableFormDataModel>
+
+export default CurfewTimetableFormDataModel

--- a/server/models/view-models/curfewTimetable.ts
+++ b/server/models/view-models/curfewTimetable.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod'
+
+import { deserialiseTime, getErrors, getError } from '../../utils/utils'
+import { MultipleChoiceField, TimeSpanField } from './utils'
+
+import { CurfewTimetable } from '../CurfewTimetable'
+import { CurfewTimetableFormData, curfewTimetableFormDataItem } from '../form-data/curfewTimetable'
+
+import { ValidationErrorModel } from '../Validation'
+
+export type Timetable = {
+  timeSpan: TimeSpanField
+  addresses: MultipleChoiceField
+}
+
+export type CurfewTimetableViewModel = {
+  curfewTimetable: {
+    monday: Timetable[]
+    tuesday: Timetable[]
+    wednesday: Timetable[]
+    thursday: Timetable[]
+    friday: Timetable[]
+    saturday: Timetable[]
+    sunday: Timetable[]
+  }
+}
+
+const curfewTimetableApiDto = z.object({
+  dayOfWeek: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  curfewAddress: z.string(),
+  errors: z.array(ValidationErrorModel),
+})
+
+type CurfewTimetableApiDto = z.infer<typeof curfewTimetableApiDto>
+
+const createViewModelFromApiDto = (validationErrors: CurfewTimetableApiDto[]): CurfewTimetableViewModel => {
+  const getTimetablesForDay = (day: string, timetables?: CurfewTimetableApiDto[]): Timetable[] =>
+    timetables
+      ?.filter(t => t.dayOfWeek === day)
+      .map(t => {
+        const [startHours, startMinutes] = deserialiseTime(t.startTime)
+        const [endHours, endMinutes] = deserialiseTime(t.endTime)
+        return {
+          timeSpan: {
+            value: { startHours, startMinutes, endHours, endMinutes },
+            error: getErrors(t.errors, [`startTime`, `endTime`]),
+          },
+          addresses: { values: t.curfewAddress.split(','), error: getError(t.errors, `curfewAddress`) },
+        }
+      }) ?? []
+
+  return {
+    curfewTimetable: {
+      monday: getTimetablesForDay('MONDAY', validationErrors),
+      tuesday: getTimetablesForDay('TUESDAY', validationErrors),
+      wednesday: getTimetablesForDay('WEDNESDAY', validationErrors),
+      thursday: getTimetablesForDay('THURSDAY', validationErrors),
+      friday: getTimetablesForDay('FRIDAY', validationErrors),
+      saturday: getTimetablesForDay('SATURDAY', validationErrors),
+      sunday: getTimetablesForDay('SUNDAY', validationErrors),
+    },
+  }
+}
+
+const createViewModelFromFormData = (formData: CurfewTimetableFormData): CurfewTimetableViewModel => {
+  const getTimetablesForDay = (day: string, timetables: curfewTimetableFormDataItem[]): Timetable[] =>
+    timetables.map(t => {
+      return {
+        timeSpan: {
+          value: {
+            startHours: t.timeStartHours,
+            startMinutes: t.timeStartMinutes,
+            endHours: t.timeEndHours,
+            endMinutes: t.timeEndMinutes,
+          },
+        },
+        addresses: { values: t.addresses },
+      }
+    }) ?? []
+
+  return {
+    curfewTimetable: {
+      monday: getTimetablesForDay('monday', formData.curfewTimetable.monday),
+      tuesday: getTimetablesForDay('tuesday', formData.curfewTimetable.tuesday),
+      wednesday: getTimetablesForDay('wednesday', formData.curfewTimetable.wednesday),
+      thursday: getTimetablesForDay('thursday', formData.curfewTimetable.thursday),
+      friday: getTimetablesForDay('friday', formData.curfewTimetable.friday),
+      saturday: getTimetablesForDay('saturday', formData.curfewTimetable.saturday),
+      sunday: getTimetablesForDay('sunday', formData.curfewTimetable.sunday),
+    },
+  }
+}
+
+const construct = (
+  curfewTimetable: CurfewTimetable | undefined,
+  apiDto: CurfewTimetableApiDto[],
+  formData: [CurfewTimetableFormData],
+): CurfewTimetableViewModel => {
+  if (!apiDto || apiDto.length === 0) {
+    if (formData?.length > 0) {
+      return createViewModelFromFormData(formData[0])
+    }
+
+    const curfewTimetableAsApiDto =
+      curfewTimetable?.map(item => {
+        return {
+          ...item,
+          errors: [],
+        }
+      }) ?? []
+    return createViewModelFromApiDto(curfewTimetableAsApiDto)
+  }
+
+  return createViewModelFromApiDto(apiDto)
+}
+
+export default {
+  construct,
+}

--- a/server/views/pages/order/monitoring-conditions/curfew-timetable.njk
+++ b/server/views/pages/order/monitoring-conditions/curfew-timetable.njk
@@ -8,17 +8,16 @@
 {% from "../../../partials/timeTable.njk" import timeTable %}
 
 {% block formInputs %}
-
   {% call govukFieldset({
     legend: {
-      text: 'Enter curfew hours and address for each day.',
-      classes: "govuk-fieldset__legend--xs",
+      text: 'Enter curfew hours and addresses for each day.',
+      classes: "govuk-fieldset__legend--m",
       isPageHeading: false
     }
   }) %}
-    <span class="govuk-hint">For example from 09:30 to 18:00</span>
+    <span class="govuk-hint">For example entering a curfew 19:00 to 07:00 on Monday
+      for a curfew spanning Monday 19:00 to Tuesday 07:00</span>
 
     {{ timeTable(curfewTimetable, not isOrderEditable) }}
   {% endcall %}
-
 {% endblock %}

--- a/server/views/partials/timeTable.njk
+++ b/server/views/partials/timeTable.njk
@@ -57,7 +57,7 @@
       }
     }) %}
       {% if dayData | length === 0 %}
-        {{ timeTableDay(day, 0, {}, disabled)}}
+        {{ timeTableDay(day, 0, {}, disabled) }}
       {% else %}
         {% for timetable in dayData %}
           {{ timeTableDay(day, loop.index0, timetable, disabled, dayData.length !== 1 ) }}
@@ -66,11 +66,20 @@
 
       {% if not disabled %}
         {{ govukButton({
-            text: "Add another time",
+          text: "Add another time",
+          classes: "govuk-button--secondary",
+          name: "action",
+          value: "add-time-" + day
+        }) }}
+
+        {% if day == "monday" %}
+          {{ govukButton({
+            text: "Auto populate the other days with the same curfew hours",
             classes: "govuk-button--secondary",
             name: "action",
-            value: "add-time-" + day
-        }) }}
+            value: "copy-times"
+          }) }}
+        {% endif %}
       {% endif %}
     {% endcall %}
   {% endfor %}


### PR DESCRIPTION
### Context

We need a mechanism to populate the 7 day curfew with the same setup

### Changes proposed in this pull request

- add a button to trigger the copy action to the Monday day entry
- add logic to react to the button submitting the form
- copy mondays entry over all other days when actioned
- ensure tests cover copy requirements
- refactor timetable functions into timetable service and models
- add tests for timetable service
