### PR TITLE
Display completion status and state of tasks on the summary page

### DIFF
--- a/server/controllers/contact-information/addressController.test.ts
+++ b/server/controllers/contact-information/addressController.test.ts
@@ -3,7 +3,7 @@ import RestClient from '../../data/restClient'
 import AuditService from '../../services/auditService'
 import AddressService from '../../services/addressService'
 import { createMockRequest, createMockResponse } from '../../../test/mocks/mockExpress'
-import { getMockOrder } from '../../../test/mocks/mockOrder'
+import { createDeviceWearer, getMockOrder } from '../../../test/mocks/mockOrder'
 import AddressController from './addressController'
 import { AddressTypeEnum } from '../../models/Address'
 import TaskListService from '../../services/taskListService'
@@ -51,6 +51,7 @@ const installationAddress = {
 }
 
 const mockOrder = getMockOrder({
+  deviceWearer: createDeviceWearer({ noFixedAbode: false }),
   addresses: [primaryAddress, secondaryAddress, tertiaryAddress, installationAddress],
 })
 
@@ -282,7 +283,6 @@ describe('AddressController', () => {
 
         mockAddressService.updateAddress.mockResolvedValue({
           addressType: 'PRIMARY',
-
           addressLine1: 'a',
           addressLine2: 'b',
           addressLine3: 'c',
@@ -303,7 +303,7 @@ describe('AddressController', () => {
       ['Primary', 'primary', `/order/${mockOrder.id}/contact-information/interested-parties`],
       ['Secondary', 'secondary', `/order/${mockOrder.id}/contact-information/interested-parties`],
     ])(
-      'should go to the notifying organisation page if the user indicates they do not have another address',
+      'should go to the interested parties page if the user indicates they do not have another address',
       async (_: string, param: string, expectedLocation: string) => {
         // Given
         const req = createMockRequest({
@@ -328,7 +328,6 @@ describe('AddressController', () => {
 
         mockAddressService.updateAddress.mockResolvedValue({
           addressType: 'PRIMARY',
-
           addressLine1: 'a',
           addressLine2: 'b',
           addressLine3: 'c',

--- a/server/controllers/monitoringConditions/CurfewReleaseDateController.test.ts
+++ b/server/controllers/monitoringConditions/CurfewReleaseDateController.test.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
-import { getMockOrder } from '../../../test/mocks/mockOrder'
+import { createMonitoringConditions, getMockOrder } from '../../../test/mocks/mockOrder'
 import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
 import AuditService from '../../services/auditService'
@@ -193,19 +193,7 @@ describe('CurfewReleaseDateController', () => {
     it('Should redirect to curfew condition page', async () => {
       req.order = getMockOrder({
         id: mockId,
-        monitoringConditions: {
-          alcohol: false,
-
-          exclusionZone: false,
-          mandatoryAttendance: false,
-          orderType: '',
-          trail: false,
-          curfew: true,
-          conditionType: '',
-          endDate: '',
-          orderTypeDescription: '',
-          startDate: '',
-        },
+        monitoringConditions: createMonitoringConditions({ curfew: true }),
       })
       req.body = {
         action: 'continue',
@@ -228,18 +216,7 @@ describe('CurfewReleaseDateController', () => {
     it('Should redirect back to summary page', async () => {
       req.order = getMockOrder({
         id: mockId,
-        monitoringConditions: {
-          alcohol: false,
-          exclusionZone: false,
-          mandatoryAttendance: false,
-          orderType: '',
-          trail: false,
-          curfew: true,
-          conditionType: '',
-          endDate: '',
-          orderTypeDescription: '',
-          startDate: '',
-        },
+        monitoringConditions: createMonitoringConditions({ curfew: true }),
       })
       req.body = {
         action: 'back',

--- a/server/controllers/monitoringConditions/curfewConditionsController.test.ts
+++ b/server/controllers/monitoringConditions/curfewConditionsController.test.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
-import { getMockOrder } from '../../../test/mocks/mockOrder'
+import { createMonitoringConditions, getMockOrder } from '../../../test/mocks/mockOrder'
 import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
 import AuditService from '../../services/auditService'
@@ -189,18 +189,7 @@ describe('CurfewConditionsController', () => {
     it('Should redirect to curfew condition page', async () => {
       req.order = getMockOrder({
         id: mockId,
-        monitoringConditions: {
-          alcohol: false,
-          exclusionZone: false,
-          mandatoryAttendance: false,
-          orderType: '',
-          trail: false,
-          curfew: true,
-          conditionType: '',
-          endDate: '',
-          orderTypeDescription: '',
-          startDate: '',
-        },
+        monitoringConditions: createMonitoringConditions({ curfew: true }),
       })
       req.body = {
         action: 'continue',
@@ -222,18 +211,7 @@ describe('CurfewConditionsController', () => {
     it('Should redirect back to summary page', async () => {
       req.order = getMockOrder({
         id: mockId,
-        monitoringConditions: {
-          alcohol: false,
-          exclusionZone: false,
-          mandatoryAttendance: false,
-          orderType: '',
-          trail: false,
-          curfew: true,
-          conditionType: '',
-          endDate: '',
-          orderTypeDescription: '',
-          startDate: '',
-        },
+        monitoringConditions: createMonitoringConditions({ curfew: true }),
       })
       req.body = {
         action: 'back',

--- a/server/controllers/monitoringConditions/enforcementZoneController.test.ts
+++ b/server/controllers/monitoringConditions/enforcementZoneController.test.ts
@@ -1,7 +1,7 @@
 import type { NextFunction, Request, Response } from 'express'
 import { Readable } from 'stream'
 import { v4 as uuidv4 } from 'uuid'
-import { getMockOrder } from '../../../test/mocks/mockOrder'
+import { createMonitoringConditions, getMockOrder } from '../../../test/mocks/mockOrder'
 import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
 import EnforcementZoneService from '../../services/enforcementZoneServices'
@@ -53,18 +53,7 @@ describe('EnforcementZoneController', () => {
       },
       order: getMockOrder({
         id: mockId,
-        monitoringConditions: {
-          orderType: '',
-          alcohol: false,
-          curfew: false,
-          mandatoryAttendance: true,
-          exclusionZone: false,
-          trail: false,
-          orderTypeDescription: '',
-          conditionType: '',
-          startDate: '',
-          endDate: '',
-        },
+        monitoringConditions: createMonitoringConditions({ mandatoryAttendance: true }),
       }),
       user: {
         username: 'fakeUserName',

--- a/server/controllers/monitoringConditions/monitoringConditionsController.ts
+++ b/server/controllers/monitoringConditions/monitoringConditionsController.ts
@@ -117,7 +117,7 @@ export default class MonitoringConditionsController {
     }
   }
 
-  createApiModelFromFormData(formData: MonitoringConditionsFormData): MonitoringConditions {
+  createApiModelFromFormData(formData: MonitoringConditionsFormData): Omit<MonitoringConditions, 'isValid'> {
     return {
       orderType: formData.orderType === '' ? null : formData.orderType,
       curfew: formData.monitoringRequired.includes('curfew'),

--- a/server/controllers/orderController.ts
+++ b/server/controllers/orderController.ts
@@ -19,6 +19,7 @@ export default class OrderController {
   summary: RequestHandler = async (req: Request, res: Response) => {
     const sections = this.taskListService.getTasksBySection(req.order!)
     const error = req.flash('submissionError')
+
     res.render('pages/order/summary', {
       order: req.order,
       sections,

--- a/server/models/MonitoringConditions.ts
+++ b/server/models/MonitoringConditions.ts
@@ -11,6 +11,7 @@ const MonitoringConditionsModel = z.object({
   alcohol: z.boolean().nullable(),
   conditionType: z.string().nullable(),
   orderTypeDescription: z.string().nullable(),
+  isValid: z.boolean().default(false),
 })
 
 export type MonitoringConditions = z.infer<typeof MonitoringConditionsModel>

--- a/server/services/monitoringConditionsService.ts
+++ b/server/services/monitoringConditionsService.ts
@@ -6,7 +6,7 @@ import { SanitisedError } from '../sanitisedError'
 
 type UpdateMonitoringConditionsInput = AuthenticatedRequestInput & {
   orderId: string
-  data: MonitoringConditions
+  data: Omit<MonitoringConditions, 'isValid'>
 }
 export default class MonitoringConditionsService {
   constructor(private readonly apiClient: RestClient) {}

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -1,0 +1,1179 @@
+import {
+  createAddress,
+  createContactDetails,
+  createCurfewConditions,
+  createCurfewReleaseDateConditions,
+  createCurfewTimeTable,
+  createDeviceWearer,
+  createEnforcementZoneCondition,
+  createInstallationAndRisk,
+  createInterestedParties,
+  createMonitoringConditions,
+  createMonitoringConditionsAlcohol,
+  createMonitoringConditionsAttendance,
+  createMonitoringConditionsTrail,
+  createResponsibleAdult,
+  getMockOrder,
+} from '../../test/mocks/mockOrder'
+import paths from '../constants/paths'
+import TaskListService from './taskListService'
+
+describe('TaskListService', () => {
+  describe('getNextPage', () => {
+    it('should return responsible adult if current page is device wearer and adultAtTheTimeOfInstallation is true', () => {
+      // Given
+      const currentPage = 'DEVICE_WEARER'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({ adultAtTimeOfInstallation: true }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.CONTACT_INFORMATION.CONTACT_DETAILS.replace(':orderId', order.id))
+    })
+
+    it('should return responsible adult if current page is device wearer and adultAtTheTimeOfInstallation is false', () => {
+      // Given
+      const currentPage = 'DEVICE_WEARER'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({ adultAtTimeOfInstallation: false }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id))
+    })
+
+    it('should return contact details if current page is responsible adult', () => {
+      // Given
+      const currentPage = 'RESPONSIBLE_ADULT'
+      const taskListService = new TaskListService()
+      const order = getMockOrder()
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.CONTACT_INFORMATION.CONTACT_DETAILS.replace(':orderId', order.id))
+    })
+
+    it('should return no fixed abode if current page is contact details', () => {
+      // Given
+      const currentPage = 'CONTACT_DETAILS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder()
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.CONTACT_INFORMATION.NO_FIXED_ABODE.replace(':orderId', order.id))
+    })
+
+    it('should return interested parties if current page is no fixed abode and noFixedAbode is true', () => {
+      // Given
+      const currentPage = 'NO_FIXED_ABODE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({ noFixedAbode: true }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.CONTACT_INFORMATION.INTERESTED_PARTIES.replace(':orderId', order.id))
+    })
+
+    it('should return primary address if current page is no fixed abode and noFixedAbode is false', () => {
+      // Given
+      const currentPage = 'NO_FIXED_ABODE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({ noFixedAbode: false }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(
+        paths.CONTACT_INFORMATION.ADDRESSES.replace(':addressType(primary|secondary|tertiary)', 'primary').replace(
+          ':orderId',
+          order.id,
+        ),
+      )
+    })
+
+    it('should return interested parties if current page is primary address and hasAnotherAddress is false', () => {
+      // Given
+      const currentPage = 'PRIMARY_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({ noFixedAbode: false }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order, {
+        hasAnotherAddress: false,
+        addressType: 'primary',
+      })
+
+      // Then
+      expect(nextPage).toBe(paths.CONTACT_INFORMATION.INTERESTED_PARTIES.replace(':orderId', order.id))
+    })
+
+    it('should return secondary address if current page is primary address and hasAnotherAddress is true', () => {
+      // Given
+      const currentPage = 'PRIMARY_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({ noFixedAbode: false }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order, {
+        hasAnotherAddress: true,
+        addressType: 'primary',
+      })
+
+      // Then
+      expect(nextPage).toBe(
+        paths.CONTACT_INFORMATION.ADDRESSES.replace(':addressType(primary|secondary|tertiary)', 'secondary').replace(
+          ':orderId',
+          order.id,
+        ),
+      )
+    })
+
+    it('should return interested parties if current page is seconddary address and hasAnotherAddress is false', () => {
+      // Given
+      const currentPage = 'SECONDARY_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({ noFixedAbode: false }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order, {
+        hasAnotherAddress: false,
+        addressType: 'seconddary',
+      })
+
+      // Then
+      expect(nextPage).toBe(paths.CONTACT_INFORMATION.INTERESTED_PARTIES.replace(':orderId', order.id))
+    })
+
+    it('should return tertiary address if current page is secondary address and hasAnotherAddress is true', () => {
+      // Given
+      const currentPage = 'SECONDARY_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({ noFixedAbode: false }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order, {
+        hasAnotherAddress: true,
+        addressType: 'secondary',
+      })
+
+      // Then
+      expect(nextPage).toBe(
+        paths.CONTACT_INFORMATION.ADDRESSES.replace(':addressType(primary|secondary|tertiary)', 'tertiary').replace(
+          ':orderId',
+          order.id,
+        ),
+      )
+    })
+
+    it('should return interested parties if current page is tertiary address', () => {
+      // Given
+      const currentPage = 'TERTIARY_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder()
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.CONTACT_INFORMATION.INTERESTED_PARTIES.replace(':orderId', order.id))
+    })
+
+    it('should return installation and risk if current page is interested parties', () => {
+      // Given
+      const currentPage = 'INTERESTED_PARTIES'
+      const taskListService = new TaskListService()
+      const order = getMockOrder()
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.INSTALLATION_AND_RISK.replace(':orderId', order.id))
+    })
+
+    it('should return monitoring conditions if current page is installation and risk', () => {
+      // Given
+      const currentPage = 'INSTALLATION_AND_RISK'
+      const taskListService = new TaskListService()
+      const order = getMockOrder()
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.BASE_URL.replace(':orderId', order.id))
+    })
+
+    it('should return installation address if current page is monitoring conditions', () => {
+      // Given
+      const currentPage = 'MONITORING_CONDITIONS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder()
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(
+        paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(':addressType(installation)', 'installation').replace(
+          ':orderId',
+          order.id,
+        ),
+      )
+    })
+
+    it('should return curfew release date if current page is installation address and curfew was selected', () => {
+      // Given
+      const currentPage = 'INSTALLATION_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          curfew: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE.replace(':orderId', order.id))
+    })
+
+    it('should return exclusion zone if current page is installation address and exclusionZone was selected', () => {
+      // Given
+      const currentPage = 'INSTALLATION_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          exclusionZone: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ZONE.replace(':zoneId', '0').replace(':orderId', order.id))
+    })
+
+    it('should return trail monitoring if current page is installation address and trail was selected', () => {
+      // Given
+      const currentPage = 'INSTALLATION_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          trail: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.TRAIL.replace(':orderId', order.id))
+    })
+
+    it('should return attendance monitoring if current page is installation address and mandatoryAttendance was selected', () => {
+      // Given
+      const currentPage = 'INSTALLATION_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          mandatoryAttendance: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ATTENDANCE.replace(':orderId', order.id))
+    })
+
+    it('should return alcohol monitoring if current page is installation address and alcohol was selected', () => {
+      // Given
+      const currentPage = 'INSTALLATION_ADDRESS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          alcohol: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ALCOHOL.replace(':orderId', order.id))
+    })
+
+    it('should return curfew conditions if current page is curfew release date', () => {
+      // Given
+      const currentPage = 'CURFEW_RELEASE_DATE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          curfew: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.CURFEW_CONDITIONS.replace(':orderId', order.id))
+    })
+
+    it('should return curfew timetable if current page is curfew conitions', () => {
+      // Given
+      const currentPage = 'CURFEW_CONDITIONS'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          curfew: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', order.id))
+    })
+
+    it('should return exclusion zone if current page is curfew timetable and exclusionZone is selected', () => {
+      // Given
+      const currentPage = 'CURFEW_TIMETABLE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          curfew: true,
+          exclusionZone: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ZONE.replace(':zoneId', '0').replace(':orderId', order.id))
+    })
+
+    it('should return trail monitoring if current page is curfew timetable and trail is selected', () => {
+      // Given
+      const currentPage = 'CURFEW_TIMETABLE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          curfew: true,
+          trail: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.TRAIL.replace(':orderId', order.id))
+    })
+
+    it('should return attendance monitoring if current page is curfew timetable and mandatoryAttendance is selected', () => {
+      // Given
+      const currentPage = 'CURFEW_TIMETABLE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          curfew: true,
+          mandatoryAttendance: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ATTENDANCE.replace(':orderId', order.id))
+    })
+
+    it('should return alcohol monitoring if current page is curfew timetable and alcohol is selected', () => {
+      // Given
+      const currentPage = 'CURFEW_TIMETABLE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          curfew: true,
+          alcohol: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ALCOHOL.replace(':orderId', order.id))
+    })
+
+    it('should return attachments if current page is curfew timetable and no other monitoring is selected', () => {
+      // Given
+      const currentPage = 'CURFEW_TIMETABLE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          curfew: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
+    })
+
+    it('should return trail monitoring if current page is exclusion zone and trail is selected', () => {
+      // Given
+      const currentPage = 'ZONE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          exclusionZone: true,
+          trail: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.TRAIL.replace(':orderId', order.id))
+    })
+
+    it('should return attendance monitoring if current page is exclusion zone and mandatoryAttendance is selected', () => {
+      // Given
+      const currentPage = 'ZONE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          exclusionZone: true,
+          mandatoryAttendance: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ATTENDANCE.replace(':orderId', order.id))
+    })
+
+    it('should return alcohol monitoring if current page is exclusion zone and alcohol is selected', () => {
+      // Given
+      const currentPage = 'ZONE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          exclusionZone: true,
+          alcohol: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ALCOHOL.replace(':orderId', order.id))
+    })
+
+    it('should return attachments if current page is exclusion zone and no other monitoring is selected', () => {
+      // Given
+      const currentPage = 'ZONE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          exclusionZone: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
+    })
+
+    it('should return attendance monitoring if current page is trail monitoring and mandatoryAttendance is selected', () => {
+      // Given
+      const currentPage = 'TRAIL'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          trail: true,
+          mandatoryAttendance: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ATTENDANCE.replace(':orderId', order.id))
+    })
+
+    it('should return alcohol monitoring if current page is trail monitoring and alcohol is selected', () => {
+      // Given
+      const currentPage = 'TRAIL'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          trail: true,
+          alcohol: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ALCOHOL.replace(':orderId', order.id))
+    })
+
+    it('should return attachments if current page is trail monitoring and no other monitoring is selected', () => {
+      // Given
+      const currentPage = 'TRAIL'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          trail: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
+    })
+
+    it('should return alcohol monitoring if current page is attendance monitoring and alcohol monitoring is selected', () => {
+      // Given
+      const currentPage = 'ATTENDANCE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          mandatoryAttendance: true,
+          alcohol: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.MONITORING_CONDITIONS.ALCOHOL.replace(':orderId', order.id))
+    })
+
+    it('should return attachments if current page is attendance monitoring and no other monitoring is selected', () => {
+      // Given
+      const currentPage = 'ATTENDANCE'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          mandatoryAttendance: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
+    })
+
+    it('should return attachments if current page is alcohol monitoring and no other monitoring is selected', () => {
+      // Given
+      const currentPage = 'ALCOHOL'
+      const taskListService = new TaskListService()
+      const order = getMockOrder({
+        monitoringConditions: createMonitoringConditions({
+          alcohol: true,
+        }),
+      })
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
+    })
+  })
+
+  describe('getTasksBySection', () => {
+    it('should return all tasks grouped by section and marked as incomplete', () => {
+      // Given
+      const order = getMockOrder()
+      const taskListService = new TaskListService()
+
+      // When
+      const sections = taskListService.getTasksBySection(order)
+
+      // Then
+      expect(sections).toEqual({
+        ABOUT_THE_DEVICE_WEARER: [
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'DEVICE_WEARER',
+            path: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'RESPONSIBLE_ADULT',
+            path: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+        ],
+        CONTACT_INFORMATION: [
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'CONTACT_DETAILS',
+            path: paths.CONTACT_INFORMATION.CONTACT_DETAILS.replace(':orderId', order.id),
+            state: 'OPTIONAL',
+            completed: false,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'NO_FIXED_ABODE',
+            path: paths.CONTACT_INFORMATION.NO_FIXED_ABODE.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'PRIMARY_ADDRESS',
+            path: paths.CONTACT_INFORMATION.ADDRESSES.replace(
+              ':addressType(primary|secondary|tertiary)',
+              'primary',
+            ).replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'SECONDARY_ADDRESS',
+            path: paths.CONTACT_INFORMATION.ADDRESSES.replace(
+              ':addressType(primary|secondary|tertiary)',
+              'secondary',
+            ).replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'TERTIARY_ADDRESS',
+            path: paths.CONTACT_INFORMATION.ADDRESSES.replace(
+              ':addressType(primary|secondary|tertiary)',
+              'tertiary',
+            ).replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'INTERESTED_PARTIES',
+            path: paths.CONTACT_INFORMATION.INTERESTED_PARTIES.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+        ],
+        INSTALLATION_AND_RISK: [
+          {
+            section: 'INSTALLATION_AND_RISK',
+            name: 'INSTALLATION_AND_RISK',
+            path: paths.INSTALLATION_AND_RISK.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+        ],
+        MONITORING_CONDITIONS: [
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'MONITORING_CONDITIONS',
+            path: paths.MONITORING_CONDITIONS.BASE_URL.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'INSTALLATION_ADDRESS',
+            path: paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(
+              ':addressType(installation)',
+              'installation',
+            ).replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'CURFEW_RELEASE_DATE',
+            path: paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'CURFEW_CONDITIONS',
+            path: paths.MONITORING_CONDITIONS.CURFEW_CONDITIONS.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'CURFEW_TIMETABLE',
+            path: paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'ZONE',
+            path: paths.MONITORING_CONDITIONS.ZONE.replace(':zoneId', '0').replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'TRAIL',
+            path: paths.MONITORING_CONDITIONS.TRAIL.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'ATTENDANCE',
+            path: paths.MONITORING_CONDITIONS.ATTENDANCE.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'ALCOHOL',
+            path: paths.MONITORING_CONDITIONS.ALCOHOL.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: false,
+          },
+        ],
+        ATTACHMENTS: [
+          {
+            section: 'ATTACHMENTS',
+            name: 'ATTACHMENT',
+            path: paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id),
+            state: 'OPTIONAL',
+            completed: false,
+          },
+        ],
+      })
+    })
+
+    it('should return all tasks grouped by section and marked as complete', () => {
+      // Given
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({
+          firstName: '',
+          noFixedAbode: true,
+        }),
+        deviceWearerResponsibleAdult: createResponsibleAdult(),
+        contactDetails: createContactDetails(),
+        installationAndRisk: createInstallationAndRisk(),
+        interestedParties: createInterestedParties(),
+        enforcementZoneConditions: [createEnforcementZoneCondition()],
+        addresses: [
+          createAddress({ addressType: 'PRIMARY' }),
+          createAddress({ addressType: 'SECONDARY' }),
+          createAddress({ addressType: 'TERTIARY' }),
+          createAddress({ addressType: 'INSTALLATION' }),
+        ],
+        monitoringConditions: createMonitoringConditions({ isValid: true }),
+        monitoringConditionsTrail: createMonitoringConditionsTrail(),
+        monitoringConditionsAlcohol: createMonitoringConditionsAlcohol(),
+        monitoringConditionsAttendance: [createMonitoringConditionsAttendance()],
+        curfewReleaseDateConditions: createCurfewReleaseDateConditions(),
+        curfewConditions: createCurfewConditions(),
+        curfewTimeTable: createCurfewTimeTable(),
+      })
+      const taskListService = new TaskListService()
+
+      // When
+      const sections = taskListService.getTasksBySection(order)
+
+      // Then
+      expect(sections).toEqual({
+        ABOUT_THE_DEVICE_WEARER: [
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'DEVICE_WEARER',
+            path: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: true,
+          },
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'RESPONSIBLE_ADULT',
+            path: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: true,
+          },
+        ],
+        CONTACT_INFORMATION: [
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'CONTACT_DETAILS',
+            path: paths.CONTACT_INFORMATION.CONTACT_DETAILS.replace(':orderId', order.id),
+            state: 'OPTIONAL',
+            completed: true,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'NO_FIXED_ABODE',
+            path: paths.CONTACT_INFORMATION.NO_FIXED_ABODE.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: true,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'PRIMARY_ADDRESS',
+            path: paths.CONTACT_INFORMATION.ADDRESSES.replace(
+              ':addressType(primary|secondary|tertiary)',
+              'primary',
+            ).replace(':orderId', order.id),
+            state: 'NOT_REQUIRED',
+            completed: true,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'SECONDARY_ADDRESS',
+            path: paths.CONTACT_INFORMATION.ADDRESSES.replace(
+              ':addressType(primary|secondary|tertiary)',
+              'secondary',
+            ).replace(':orderId', order.id),
+            state: 'NOT_REQUIRED',
+            completed: true,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'TERTIARY_ADDRESS',
+            path: paths.CONTACT_INFORMATION.ADDRESSES.replace(
+              ':addressType(primary|secondary|tertiary)',
+              'tertiary',
+            ).replace(':orderId', order.id),
+            state: 'NOT_REQUIRED',
+            completed: true,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'INTERESTED_PARTIES',
+            path: paths.CONTACT_INFORMATION.INTERESTED_PARTIES.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: true,
+          },
+        ],
+        INSTALLATION_AND_RISK: [
+          {
+            section: 'INSTALLATION_AND_RISK',
+            name: 'INSTALLATION_AND_RISK',
+            path: paths.INSTALLATION_AND_RISK.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: true,
+          },
+        ],
+        MONITORING_CONDITIONS: [
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'MONITORING_CONDITIONS',
+            path: paths.MONITORING_CONDITIONS.BASE_URL.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: true,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'INSTALLATION_ADDRESS',
+            path: paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(
+              ':addressType(installation)',
+              'installation',
+            ).replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: true,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'CURFEW_RELEASE_DATE',
+            path: paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: true,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'CURFEW_CONDITIONS',
+            path: paths.MONITORING_CONDITIONS.CURFEW_CONDITIONS.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: true,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'CURFEW_TIMETABLE',
+            path: paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: true,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'ZONE',
+            path: paths.MONITORING_CONDITIONS.ZONE.replace(':zoneId', '0').replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: true,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'TRAIL',
+            path: paths.MONITORING_CONDITIONS.TRAIL.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: true,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'ATTENDANCE',
+            path: paths.MONITORING_CONDITIONS.ATTENDANCE.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: true,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'ALCOHOL',
+            path: paths.MONITORING_CONDITIONS.ALCOHOL.replace(':orderId', order.id),
+            state: 'CANT_BE_STARTED',
+            completed: true,
+          },
+        ],
+        ATTACHMENTS: [
+          {
+            section: 'ATTACHMENTS',
+            name: 'ATTACHMENT',
+            path: paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id),
+            state: 'OPTIONAL',
+            completed: false,
+          },
+        ],
+      })
+    })
+
+    it('should return all tasks grouped by section and ready to start', () => {
+      // Given
+      const order = getMockOrder({
+        deviceWearer: createDeviceWearer({
+          firstName: '',
+          adultAtTimeOfInstallation: false,
+          noFixedAbode: false,
+        }),
+        monitoringConditions: createMonitoringConditions({
+          curfew: true,
+          alcohol: true,
+          exclusionZone: true,
+          trail: true,
+          mandatoryAttendance: true,
+        }),
+      })
+      const taskListService = new TaskListService()
+
+      // When
+      const sections = taskListService.getTasksBySection(order)
+
+      // Then
+      expect(sections).toEqual({
+        ABOUT_THE_DEVICE_WEARER: [
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'DEVICE_WEARER',
+            path: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: true,
+          },
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'RESPONSIBLE_ADULT',
+            path: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+        ],
+        CONTACT_INFORMATION: [
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'CONTACT_DETAILS',
+            path: paths.CONTACT_INFORMATION.CONTACT_DETAILS.replace(':orderId', order.id),
+            state: 'OPTIONAL',
+            completed: false,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'NO_FIXED_ABODE',
+            path: paths.CONTACT_INFORMATION.NO_FIXED_ABODE.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: true,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'PRIMARY_ADDRESS',
+            path: paths.CONTACT_INFORMATION.ADDRESSES.replace(
+              ':addressType(primary|secondary|tertiary)',
+              'primary',
+            ).replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'SECONDARY_ADDRESS',
+            path: paths.CONTACT_INFORMATION.ADDRESSES.replace(
+              ':addressType(primary|secondary|tertiary)',
+              'secondary',
+            ).replace(':orderId', order.id),
+            state: 'OPTIONAL',
+            completed: false,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'TERTIARY_ADDRESS',
+            path: paths.CONTACT_INFORMATION.ADDRESSES.replace(
+              ':addressType(primary|secondary|tertiary)',
+              'tertiary',
+            ).replace(':orderId', order.id),
+            state: 'OPTIONAL',
+            completed: false,
+          },
+          {
+            section: 'CONTACT_INFORMATION',
+            name: 'INTERESTED_PARTIES',
+            path: paths.CONTACT_INFORMATION.INTERESTED_PARTIES.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+        ],
+        INSTALLATION_AND_RISK: [
+          {
+            section: 'INSTALLATION_AND_RISK',
+            name: 'INSTALLATION_AND_RISK',
+            path: paths.INSTALLATION_AND_RISK.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+        ],
+        MONITORING_CONDITIONS: [
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'MONITORING_CONDITIONS',
+            path: paths.MONITORING_CONDITIONS.BASE_URL.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'INSTALLATION_ADDRESS',
+            path: paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(
+              ':addressType(installation)',
+              'installation',
+            ).replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'CURFEW_RELEASE_DATE',
+            path: paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'CURFEW_CONDITIONS',
+            path: paths.MONITORING_CONDITIONS.CURFEW_CONDITIONS.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'CURFEW_TIMETABLE',
+            path: paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'ZONE',
+            path: paths.MONITORING_CONDITIONS.ZONE.replace(':zoneId', '0').replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'TRAIL',
+            path: paths.MONITORING_CONDITIONS.TRAIL.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'ATTENDANCE',
+            path: paths.MONITORING_CONDITIONS.ATTENDANCE.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'MONITORING_CONDITIONS',
+            name: 'ALCOHOL',
+            path: paths.MONITORING_CONDITIONS.ALCOHOL.replace(':orderId', order.id),
+            state: 'REQUIRED',
+            completed: false,
+          },
+        ],
+        ATTACHMENTS: [
+          {
+            section: 'ATTACHMENTS',
+            name: 'ATTACHMENT',
+            path: paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id),
+            state: 'OPTIONAL',
+            completed: false,
+          },
+        ],
+      })
+    })
+  })
+})

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -219,7 +219,7 @@ export default class TaskListService {
         'REQUIRED',
         'NOT_REQUIRED',
       ),
-      completed: isNotNullOrUndefined(order.curfewTimeTable),
+      completed: isNotNullOrUndefined(order.curfewTimeTable) && order.curfewTimeTable.length > 0,
     })
 
     tasks.push({

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -1,5 +1,7 @@
 import { Order } from '../models/Order'
 import paths from '../constants/paths'
+import { AddressType } from '../models/Address'
+import { convertBooleanToEnum, isNotNullOrUndefined } from '../utils/utils'
 
 type Section =
   | 'ABOUT_THE_DEVICE_WEARER'
@@ -29,12 +31,14 @@ type Page =
   | 'ALCOHOL'
   | 'ATTACHMENT'
 
+type State = 'REQUIRED' | 'NOT_REQUIRED' | 'OPTIONAL' | 'CANT_BE_STARTED'
+
 type Task = {
   section: Section
   name: Page
   path: string
-  required: boolean
-  status: 'INCOMPLETE' | 'COMPLETE'
+  state: State
+  completed: boolean
 }
 
 type TasksBySections = {
@@ -43,181 +47,260 @@ type TasksBySections = {
 
 type FormData = Record<string, string | boolean>
 
+const canBeCompleted = (task: Task, formData: FormData): boolean => {
+  if (['SECONDARY_ADDRESS', 'TERTIARY_ADDRESS'].includes(task.name)) {
+    if (task.name === 'SECONDARY_ADDRESS') {
+      if (!(formData.hasAnotherAddress === true && formData.addressType === 'primary')) {
+        return false
+      }
+    }
+    if (task.name === 'TERTIARY_ADDRESS') {
+      if (!(formData.hasAnotherAddress === true && formData.addressType === 'secondary')) {
+        return false
+      }
+    }
+  }
+
+  return ['OPTIONAL', 'REQUIRED'].includes(task.state)
+}
+const isCurrentPage = (task: Task, currentPage: Page): boolean => task.name === currentPage
+
+const isCompletedAddress = (order: Order, addressType: AddressType): boolean => {
+  return order.addresses.find(address => address.addressType === addressType) !== undefined
+}
+
 export default class TaskListService {
   constructor() {}
 
-  getTasks(order: Order, formData: FormData = {}): Array<Task> {
+  getTasks(order: Order): Array<Task> {
     const tasks: Array<Task> = []
 
     tasks.push({
       section: 'ABOUT_THE_DEVICE_WEARER',
       name: 'DEVICE_WEARER',
       path: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER,
-      required: true,
-      status: 'INCOMPLETE',
+      state: 'REQUIRED',
+      completed: isNotNullOrUndefined(order.deviceWearer.firstName),
     })
 
     tasks.push({
       section: 'ABOUT_THE_DEVICE_WEARER',
       name: 'RESPONSIBLE_ADULT',
       path: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT,
-      required: !order.deviceWearer.adultAtTimeOfInstallation,
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.deviceWearer.adultAtTimeOfInstallation,
+        'CANT_BE_STARTED',
+        'NOT_REQUIRED',
+        'REQUIRED',
+      ),
+      completed: isNotNullOrUndefined(order.deviceWearerResponsibleAdult),
     })
 
     tasks.push({
       section: 'CONTACT_INFORMATION',
       name: 'CONTACT_DETAILS',
       path: paths.CONTACT_INFORMATION.CONTACT_DETAILS,
-      required: true,
-      status: 'INCOMPLETE',
+      state: 'OPTIONAL',
+      completed: isNotNullOrUndefined(order.contactDetails),
     })
 
     tasks.push({
       section: 'CONTACT_INFORMATION',
       name: 'NO_FIXED_ABODE',
       path: paths.CONTACT_INFORMATION.NO_FIXED_ABODE,
-      required: true,
-      status: 'INCOMPLETE',
+      state: 'REQUIRED',
+      completed: isNotNullOrUndefined(order.deviceWearer.noFixedAbode),
     })
 
     tasks.push({
       section: 'CONTACT_INFORMATION',
       name: 'PRIMARY_ADDRESS',
       path: paths.CONTACT_INFORMATION.ADDRESSES.replace(':addressType(primary|secondary|tertiary)', 'primary'),
-      required: !order.deviceWearer.noFixedAbode,
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.deviceWearer.noFixedAbode,
+        'CANT_BE_STARTED',
+        'NOT_REQUIRED',
+        'REQUIRED',
+      ),
+      completed: isCompletedAddress(order, 'PRIMARY'),
     })
 
     tasks.push({
       section: 'CONTACT_INFORMATION',
       name: 'SECONDARY_ADDRESS',
       path: paths.CONTACT_INFORMATION.ADDRESSES.replace(':addressType(primary|secondary|tertiary)', 'secondary'),
-      required: formData.hasAnotherAddress === true && formData.addressType === 'primary',
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.deviceWearer.noFixedAbode,
+        'CANT_BE_STARTED',
+        'NOT_REQUIRED',
+        'OPTIONAL',
+      ),
+      completed: isCompletedAddress(order, 'SECONDARY'),
     })
 
     tasks.push({
       section: 'CONTACT_INFORMATION',
       name: 'TERTIARY_ADDRESS',
       path: paths.CONTACT_INFORMATION.ADDRESSES.replace(':addressType(primary|secondary|tertiary)', 'tertiary'),
-      required: formData.hasAnotherAddress === true && formData.addressType === 'secondary',
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.deviceWearer.noFixedAbode,
+        'CANT_BE_STARTED',
+        'NOT_REQUIRED',
+        'OPTIONAL',
+      ),
+      completed: isCompletedAddress(order, 'TERTIARY'),
     })
 
     tasks.push({
       section: 'CONTACT_INFORMATION',
       name: 'INTERESTED_PARTIES',
       path: paths.CONTACT_INFORMATION.INTERESTED_PARTIES,
-      required: true,
-      status: 'INCOMPLETE',
+      state: 'REQUIRED',
+      completed: isNotNullOrUndefined(order.interestedParties),
     })
 
     tasks.push({
       section: 'INSTALLATION_AND_RISK',
       name: 'INSTALLATION_AND_RISK',
       path: paths.INSTALLATION_AND_RISK,
-      required: true,
-      status: 'INCOMPLETE',
+      state: 'REQUIRED',
+      completed: isNotNullOrUndefined(order.installationAndRisk),
     })
 
     tasks.push({
       section: 'MONITORING_CONDITIONS',
       name: 'MONITORING_CONDITIONS',
       path: paths.MONITORING_CONDITIONS.BASE_URL,
-      required: true,
-      status: 'INCOMPLETE',
+      state: 'REQUIRED',
+      completed: order.monitoringConditions.isValid,
     })
 
     tasks.push({
       section: 'MONITORING_CONDITIONS',
       name: 'INSTALLATION_ADDRESS',
       path: paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(':addressType(installation)', 'installation'),
-      required: true,
-      status: 'INCOMPLETE',
+      state: 'REQUIRED',
+      completed: isCompletedAddress(order, 'INSTALLATION'),
     })
 
     tasks.push({
       section: 'MONITORING_CONDITIONS',
       name: 'CURFEW_RELEASE_DATE',
       path: paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE,
-      required: !!order.monitoringConditions.curfew,
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.monitoringConditions.curfew,
+        'CANT_BE_STARTED',
+        'REQUIRED',
+        'NOT_REQUIRED',
+      ),
+      completed: isNotNullOrUndefined(order.curfewReleaseDateConditions),
     })
 
     tasks.push({
       section: 'MONITORING_CONDITIONS',
       name: 'CURFEW_CONDITIONS',
       path: paths.MONITORING_CONDITIONS.CURFEW_CONDITIONS,
-      required: !!order.monitoringConditions.curfew,
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.monitoringConditions.curfew,
+        'CANT_BE_STARTED',
+        'REQUIRED',
+        'NOT_REQUIRED',
+      ),
+      completed: isNotNullOrUndefined(order.curfewConditions),
     })
 
     tasks.push({
       section: 'MONITORING_CONDITIONS',
       name: 'CURFEW_TIMETABLE',
       path: paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE,
-      required: !!order.monitoringConditions.curfew,
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.monitoringConditions.curfew,
+        'CANT_BE_STARTED',
+        'REQUIRED',
+        'NOT_REQUIRED',
+      ),
+      completed: isNotNullOrUndefined(order.curfewTimeTable),
     })
 
     tasks.push({
       section: 'MONITORING_CONDITIONS',
       name: 'ZONE',
-      path: paths.MONITORING_CONDITIONS.ZONE,
-      required: !!order.monitoringConditions.exclusionZone,
-      status: 'INCOMPLETE',
+      path: paths.MONITORING_CONDITIONS.ZONE.replace(':zoneId', '0'),
+      state: convertBooleanToEnum<State>(
+        order.monitoringConditions.exclusionZone,
+        'CANT_BE_STARTED',
+        'REQUIRED',
+        'NOT_REQUIRED',
+      ),
+      completed: order.enforcementZoneConditions.length > 0,
     })
 
     tasks.push({
       section: 'MONITORING_CONDITIONS',
       name: 'TRAIL',
       path: paths.MONITORING_CONDITIONS.TRAIL,
-      required: !!order.monitoringConditions.trail,
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.monitoringConditions.trail,
+        'CANT_BE_STARTED',
+        'REQUIRED',
+        'NOT_REQUIRED',
+      ),
+      completed: isNotNullOrUndefined(order.monitoringConditionsTrail),
     })
 
     tasks.push({
       section: 'MONITORING_CONDITIONS',
       name: 'ATTENDANCE',
       path: paths.MONITORING_CONDITIONS.ATTENDANCE,
-      required: !!order.monitoringConditions.mandatoryAttendance,
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.monitoringConditions.mandatoryAttendance,
+        'CANT_BE_STARTED',
+        'REQUIRED',
+        'NOT_REQUIRED',
+      ),
+      completed:
+        isNotNullOrUndefined(order.monitoringConditionsAttendance) && order.monitoringConditionsAttendance.length > 0,
     })
 
     tasks.push({
       section: 'MONITORING_CONDITIONS',
       name: 'ALCOHOL',
       path: paths.MONITORING_CONDITIONS.ALCOHOL,
-      required: !!order.monitoringConditions.alcohol,
-      status: 'INCOMPLETE',
+      state: convertBooleanToEnum<State>(
+        order.monitoringConditions.alcohol,
+        'CANT_BE_STARTED',
+        'REQUIRED',
+        'NOT_REQUIRED',
+      ),
+      completed: isNotNullOrUndefined(order.monitoringConditionsAlcohol),
     })
 
     tasks.push({
       section: 'ATTACHMENTS',
       name: 'ATTACHMENT',
       path: paths.ATTACHMENT.ATTACHMENTS,
-      required: true,
-      status: 'INCOMPLETE',
+      state: 'OPTIONAL',
+      completed: false,
     })
 
     return tasks
   }
 
   getNextPage(currentPage: Page, order: Order, formData: FormData = {}) {
-    const tasks = this.getTasks(order, formData)
-    const requiredTasks = tasks.filter(({ name, required }) => required || name === currentPage)
-    const currentTaskIndex = requiredTasks.findIndex(({ name }) => name === currentPage)
+    const tasks = this.getTasks(order)
+    const availableTasks = tasks.filter(task => canBeCompleted(task, formData) || isCurrentPage(task, currentPage))
+    const currentTaskIndex = availableTasks.findIndex(({ name }) => name === currentPage)
 
-    if (currentTaskIndex === -1 || currentTaskIndex + 1 >= requiredTasks.length) {
+    if (currentTaskIndex === -1 || currentTaskIndex + 1 >= availableTasks.length) {
       return paths.ORDER.SUMMARY.replace(':orderId', order.id)
     }
 
-    return requiredTasks[currentTaskIndex + 1].path.replace(':orderId', order.id)
+    return availableTasks[currentTaskIndex + 1].path.replace(':orderId', order.id)
   }
 
   getTasksBySection(order: Order) {
     const tasks = this.getTasks(order)
+
     return tasks.reduce((acc, task) => {
       if (!acc[task.section]) {
         acc[task.section] = []

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -3,12 +3,15 @@ import {
   calculateAge,
   camelCaseToSentenceCase,
   checkType,
+  convertBooleanToEnum,
   convertToTitleCase,
   deserialiseDate,
   deserialiseTime,
   getError,
   initialiseName,
   isEmpty,
+  isNotNullOrUndefined,
+  isNullOrUndefined,
   serialiseDate,
   serialiseTime,
 } from './utils'
@@ -111,6 +114,40 @@ describe('getError', () => {
     },
   ])('getError($errors, $field)', ({ errors, field, expected }) => {
     expect(getError(errors, field)).toEqual(expected)
+  })
+})
+
+describe('convertBooleanToEnum', () => {
+  it.each([
+    [null, 'null', 'true', 'false', 'null'],
+    [true, 'null', 'true', 'false', 'true'],
+    [false, 'null', 'true', 'false', 'false'],
+  ])('convertBooleanToEnum(%s, %s, %s, %s', (value, nullValue, truthyValue, falsyValue, expectedValue) => {
+    expect(convertBooleanToEnum(value, nullValue, truthyValue, falsyValue)).toEqual(expectedValue)
+  })
+})
+
+describe('isNullOrUndefined', () => {
+  it.each([
+    ['object', {}, false],
+    ['number', 0, false],
+    ['string', '', false],
+    ['undefined', undefined, true],
+    ['null', null, true],
+  ])('%s isNullOrUndefined(%s)', (_: string, value: unknown, expected: boolean) => {
+    expect(isNullOrUndefined(value)).toBe(expected)
+  })
+})
+
+describe('isNotNullOrUndefined', () => {
+  it.each([
+    ['object', {}, true],
+    ['number', 0, true],
+    ['string', '', true],
+    ['undefined', undefined, false],
+    ['null', null, false],
+  ])('%s isNotNullOrUndefined(%s)', (_: string, value: unknown, expected: boolean) => {
+    expect(isNotNullOrUndefined(value)).toBe(expected)
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -136,3 +136,26 @@ export const isEmpty = (input: unknown): boolean => {
   }
   return false
 }
+
+export const convertBooleanToEnum = <T extends string>(
+  value: boolean | null,
+  nullValue: T,
+  truthyValue: T,
+  falsyValue: T,
+) => {
+  if (value === null) {
+    return nullValue
+  }
+
+  if (value) {
+    return truthyValue
+  }
+
+  return falsyValue
+}
+
+export const isNullOrUndefined = <T>(value: T | null | undefined): value is null | undefined => {
+  return value === null || value === undefined
+}
+
+export const isNotNullOrUndefined = <T>(value: T | null | undefined): value is T => !isNullOrUndefined(value)

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -41,30 +41,6 @@
     }) }}
   {% endif %}
 
-{% set taskListItems = [] %}
-{% for section, tasks in sections %}
-  {% set task = tasks[0] %}
-  {% set name = section | replace("_", " ") | capitalize %}
-  {% set href = task.path %}
-  {% set complete = task.status != 'INCOMPLETE' %}
-
-  {% if task.required %}
-    {% set taskListItems = (taskListItems.push({
-        idPrefix: "order-section",
-        title: { text: name },
-        href: href,
-        status: {
-          tag: {
-            text: "Completed" if complete === true else "Incomplete",
-            classes: "govuk-tag--green" if complete === true else "govuk-tag--grey"
-          }
-        }
-      }), taskListItems) %}
-  {% endif %}
-{% endfor %}
-{{ govukTaskList({ idPrefix: "sections", items: taskListItems }) }}
-
-{#
   {% for section, tasks in sections %}
     <h3 class="govuk-heading-m">{{ section | replace("_", " ") | capitalize }}</h3>
 
@@ -72,25 +48,64 @@
     {% for task in tasks %}
       {% set name = task.name | replace("_", " ") | capitalize %}
       {% set href = task.path %}
-      {% set complete = task.status != 'INCOMPLETE' %}
+      {% set status = 'COMPLETE' if task.completed else 'INCOMPLETE' %}
+      {% set tagColour = 'govuk-tag--green' if task.completed else 'govuk-tag--grey' %}
 
-      {% if task.required %}
+      {% if task.state == 'CANT_BE_STARTED' %}
+        {% set taskListItems = (taskListItems.push({
+          idPrefix: "order-section",
+          title: { text: name },
+          status: {
+            text: 'Cannot start yet',
+            classes: "govuk-task-list__status--cannot-start-yet"
+            
+          }
+        }), taskListItems) %}
+      {% elif task.state == 'NOT_REQUIRED' %}
+        {% set taskListItems = (taskListItems.push({
+          idPrefix: "order-section",
+          title: { text: name },
+          status: {
+            text: 'Not required',
+            classes: "govuk-task-list__status--cannot-start-yet"
+            
+          }
+        }), taskListItems) %}
+      {% elif task.state == 'OPTIONAL' %}
+        {% set tagHtml %}
+            <strong class="govuk-tag govuk-tag--light-blue">
+              Optional
+            </strong>
+            <strong class="govuk-tag {{ tagColour }}">
+              {{ status | capitalize }} 
+            </strong>
+        {% endset %}
+
+        {% set taskListItems = (taskListItems.push({
+            idPrefix: "order-section",
+            title: { text: name },
+            href: href,
+            status: {
+              html: tagHtml
+            }
+          }), taskListItems) %}
+      {% else %}
         {% set taskListItems = (taskListItems.push({
           idPrefix: "order-section",
           title: { text: name },
           href: href,
           status: {
             tag: {
-              text: "Completed" if complete === true else "Incomplete",
-              classes: "govuk-tag--green" if complete === true else "govuk-tag--grey"
+              text: status | capitalize,
+              classes: tagColour
             }
           }
         }), taskListItems) %}
+
       {% endif %}
     {% endfor %}
     {{ govukTaskList({ idPrefix: "sections", items: taskListItems }) }}
   {% endfor %}
-#}
 
   {% if order.status == "IN_PROGRESS" %}
     <form action="/order/{{ order.id }}/submit" method="post">
@@ -100,18 +115,18 @@
             text: "Submit order",
             disabled: not order.isValid
         }) }}
-    </div>
-  </form>
-{% else %}
-  <img src="{{ formDownloadIcon }}" alt="Icon of a form">
-  {{ govukButton({
-          text: "Get tag request form summary for download",
-          href: "/order/" + orderId + "/receipt",
-          classes: "govuk-button--secondary"
-      }) }}
+      </div>
+    </form>
+  {% else %}
+    <img src="{{ formDownloadIcon }}" alt="Icon of a form">
+    {{ govukButton({
+      text: "Get tag request form summary for download",
+      href: "/order/" + orderId + "/receipt",
+      classes: "govuk-button--secondary"
+    }) }}
 
-  <div class="govuk-button-group">
-    <a id="backToSearch" class="govuk-link" href="/">Return to order search view</a>
-  </div>
-{% endif %}
+    <div class="govuk-button-group">
+      <a id="backToSearch" class="govuk-link" href="/">Return to order search view</a>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/test/mocks/mockOrder.ts
+++ b/test/mocks/mockOrder.ts
@@ -1,25 +1,186 @@
 import { randomUUID } from 'crypto'
 import { Order, OrderStatusEnum } from '../../server/models/Order'
+import { DeviceWearer } from '../../server/models/DeviceWearer'
+import { MonitoringConditions } from '../../server/models/MonitoringConditions'
+import { Address } from '../../server/models/Address'
+import { ContactDetails } from '../../server/models/ContactDetails'
+import { DeviceWearerResponsibleAdult } from '../../server/models/DeviceWearerResponsibleAdult'
+import { InstallationAndRisk } from '../../server/models/InstallationAndRisk'
+import { InterestedParties } from '../../server/models/InterestedParties'
+import { EnforcementZone } from '../../server/models/EnforcementZone'
+import { TrailMonitoring } from '../../server/models/TrailMonitoring'
+import { AlcoholMonitoring } from '../../server/models/AlcoholMonitoring'
+import { AttendanceMonitoring } from '../../server/models/AttendanceMonitoring'
+import { CurfewReleaseDate } from '../../server/models/CurfewReleaseDate'
+import { CurfewConditions } from '../../server/models/CurfewConditions'
+import { CurfewTimetable } from '../../server/models/CurfewTimetable'
+
+export const createDeviceWearer = (overrideProperties?: Partial<DeviceWearer>): DeviceWearer => ({
+  nomisId: null,
+  pncId: null,
+  deliusId: null,
+  prisonNumber: null,
+  homeOfficeReferenceNumber: null,
+  firstName: null,
+  lastName: null,
+  alias: null,
+  dateOfBirth: null,
+  adultAtTimeOfInstallation: null,
+  sex: null,
+  gender: null,
+  disabilities: [],
+  noFixedAbode: null,
+  ...overrideProperties,
+})
+
+export const createResponsibleAdult = (
+  overrideProperties?: Partial<DeviceWearerResponsibleAdult>,
+): DeviceWearerResponsibleAdult => ({
+  contactNumber: null,
+  fullName: null,
+  otherRelationshipDetails: null,
+  relationship: null,
+  ...overrideProperties,
+})
+
+export const createContactDetails = (overrideProperties?: Partial<ContactDetails>): ContactDetails => ({
+  contactNumber: '',
+  ...overrideProperties,
+})
+
+export const createInstallationAndRisk = (overrideProperties?: Partial<InstallationAndRisk>): InstallationAndRisk => ({
+  mappaCaseType: null,
+  mappaLevel: null,
+  riskCategory: null,
+  riskDetails: null,
+  offence: null,
+  ...overrideProperties,
+})
+
+export const createInterestedParties = (overrideProperties?: Partial<InterestedParties>): InterestedParties => ({
+  notifyingOrganisationEmail: '',
+  responsibleOfficerName: '',
+  responsibleOfficerPhoneNumber: '',
+  responsibleOrganisation: 'FIELD_MONITORING_SERVICE',
+  responsibleOrganisationAddressLine1: '',
+  responsibleOrganisationAddressLine2: '',
+  responsibleOrganisationAddressLine3: '',
+  responsibleOrganisationAddressLine4: '',
+  responsibleOrganisationAddressPostcode: '',
+  responsibleOrganisationEmail: '',
+  responsibleOrganisationPhoneNumber: '',
+  responsibleOrganisationRegion: '',
+  ...overrideProperties,
+})
+
+export const createAddress = (overrideProperties?: Partial<Address>): Address => ({
+  addressType: 'PRIMARY',
+  addressLine1: '',
+  addressLine2: '',
+  addressLine3: '',
+  addressLine4: '',
+  postcode: '',
+  ...overrideProperties,
+})
+
+export const createEnforcementZoneCondition = (overrideProperties?: Partial<EnforcementZone>): EnforcementZone => ({
+  description: null,
+  duration: null,
+  endDate: null,
+  fileId: null,
+  fileName: null,
+  startDate: null,
+  zoneId: null,
+  zoneType: null,
+  ...overrideProperties,
+})
+
+export const createMonitoringConditions = (
+  overrideProperties?: Partial<MonitoringConditions>,
+): MonitoringConditions => ({
+  orderType: null,
+  curfew: null,
+  exclusionZone: null,
+  trail: null,
+  mandatoryAttendance: null,
+  alcohol: null,
+  orderTypeDescription: null,
+  conditionType: null,
+  startDate: null,
+  endDate: null,
+  isValid: false,
+  ...overrideProperties,
+})
+
+export const createMonitoringConditionsTrail = (overriddeProperties?: Partial<TrailMonitoring>): TrailMonitoring => ({
+  startDate: null,
+  endDate: null,
+  ...overriddeProperties,
+})
+
+export const createMonitoringConditionsAlcohol = (
+  overrideProperties?: Partial<AlcoholMonitoring>,
+): AlcoholMonitoring => ({
+  endDate: null,
+  installationLocation: null,
+  monitoringType: null,
+  prisonName: null,
+  probationOfficeName: null,
+  startDate: null,
+  ...overrideProperties,
+})
+
+export const createMonitoringConditionsAttendance = (
+  overrideProperties?: Partial<AttendanceMonitoring>,
+): AttendanceMonitoring => ({
+  addressLine1: null,
+  addressLine2: null,
+  addressLine3: null,
+  addressLine4: null,
+  appointmentDay: null,
+  endDate: null,
+  endTime: null,
+  postcode: null,
+  purpose: null,
+  startDate: null,
+  startTime: null,
+  ...overrideProperties,
+})
+
+export const createCurfewReleaseDateConditions = (
+  overrideProperties?: Partial<CurfewReleaseDate>,
+): CurfewReleaseDate => ({
+  curfewAddress: null,
+  endTime: null,
+  orderId: null,
+  releaseDate: null,
+  startTime: null,
+  ...overrideProperties,
+})
+
+export const createCurfewConditions = (overrideProperties?: Partial<CurfewConditions>): CurfewConditions => ({
+  curfewAddress: null,
+  endDate: null,
+  orderId: null,
+  startDate: null,
+  ...overrideProperties,
+})
+
+export const createCurfewTimeTable = (overrideProperties?: Partial<CurfewTimetable>): CurfewTimetable => [
+  {
+    curfewAddress: '',
+    dayOfWeek: '',
+    endTime: '',
+    orderId: '',
+    startTime: '',
+    ...overrideProperties,
+  },
+]
 
 export const getMockOrder = (overrideProperties?: Partial<Order>): Order => ({
   id: randomUUID(),
   status: OrderStatusEnum.Enum.IN_PROGRESS,
-  deviceWearer: {
-    nomisId: null,
-    pncId: null,
-    deliusId: null,
-    prisonNumber: null,
-    homeOfficeReferenceNumber: null,
-    firstName: null,
-    lastName: null,
-    alias: null,
-    dateOfBirth: null,
-    adultAtTimeOfInstallation: null,
-    sex: null,
-    gender: null,
-    disabilities: [],
-    noFixedAbode: null,
-  },
+  deviceWearer: createDeviceWearer(),
   deviceWearerResponsibleAdult: null,
   contactDetails: null,
   installationAndRisk: null,
@@ -27,18 +188,7 @@ export const getMockOrder = (overrideProperties?: Partial<Order>): Order => ({
   enforcementZoneConditions: [],
   addresses: [],
   additionalDocuments: [],
-  monitoringConditions: {
-    orderType: null,
-    curfew: null,
-    exclusionZone: null,
-    trail: null,
-    mandatoryAttendance: null,
-    alcohol: null,
-    orderTypeDescription: null,
-    conditionType: null,
-    startDate: null,
-    endDate: null,
-  },
+  monitoringConditions: createMonitoringConditions(),
   monitoringConditionsTrail: null,
   monitoringConditionsAlcohol: null,
   isValid: false,


### PR DESCRIPTION
## Changes
- Refactors the summary view to display whether tasks are completed
- Refactors the summary view to display whether a task can be started, is or is not required or whether its optional
- Adds new states to tasks `CANT_BE_STARTED` and `OPTIONAL`
- Adds unit tests for the the `taskListService` as it does a bunch of heavy lifting that wasn't adequately tested by the controllers / integration tests
- Add isValid field to `MonitoringConditions` model
- Adds helpers for constructing test orders
- Refactor tests in the `MonitoringConditions` section to use test helps (instead of adding `isValid: false` everywhere

## Todo
- Integration tests