### PR TITLE
Make log level configurable

### DIFF
--- a/logger.ts
+++ b/logger.ts
@@ -7,7 +7,7 @@ const formatOut = bunyanFormat({ outputMode: 'short', color: !config.production 
 const logger = bunyan.createLogger({
   name: 'Hmpps·Electronic·Monitoring·Create·An·Order',
   stream: formatOut,
-  level: 'debug',
+  level: config.logLevel as bunyan.LogLevel,
 })
 
 export default logger

--- a/server/config.ts
+++ b/server/config.ts
@@ -104,4 +104,5 @@ export default {
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
+  logLevel: get('LOG_LEVEL', 'debug'),
 }


### PR DESCRIPTION
Does the log output whilst running tests annoy you and make it hard to find the test that fails? Well no more!

Hide annoying log messages like so:
```shell
LOG_LEVEL=fatal npm run test
```

> May also be useful in deployed environments ¯\\_(ツ)_/¯
