### PR TITLE
Device wearer check your answers

### DIFF
--- a/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.cy.ts
@@ -1,0 +1,148 @@
+import { v4 as uuidv4 } from 'uuid'
+import { NotFoundErrorPage } from '../../../pages/error'
+import Page from '../../../pages/page'
+import CheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
+
+const mockOrderId = uuidv4()
+const pagePath = '/about-the-device-wearer/check-your-answers'
+
+context('Device wearer - check your answers', () => {
+  context('Draft order', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
+
+      cy.signIn()
+    })
+
+    it('Should display the user name visible in header', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
+      page.header.userName().should('contain.text', 'J. Smith')
+    })
+
+    it('Should display the phase banner in header', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
+      page.header.phaseBanner().should('contain.text', 'dev')
+    })
+
+    it('Should render the save and continue, and return buttons', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
+
+      page.continueButton().should('exist')
+      page.returnButton().should('exist')
+    })
+
+    it('Should be accessible', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
+      page.checkIsAccessible()
+    })
+  })
+
+  context('Device Wearer is 18 or over', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+        order: {
+          deviceWearer: {
+            nomisId: null,
+            pncId: null,
+            deliusId: null,
+            prisonNumber: null,
+            homeOfficeReferenceNumber: null,
+            firstName: 'test',
+            lastName: 'tester',
+            alias: null,
+            dateOfBirth: null,
+            adultAtTimeOfInstallation: true,
+            sex: null,
+            gender: 'self-identify',
+            otherGender: 'Furby',
+            disabilities: 'Other',
+            otherDisability: 'Broken arm',
+            noFixedAbode: null,
+            interpreterRequired: null,
+          },
+          DeviceWearerResponsibleAdult: null,
+        },
+      })
+
+      cy.signIn()
+    })
+
+    it('should not show responsible adult section', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
+
+      page.responsibleAdultSection().should('not.exist')
+    })
+  })
+
+  context('Device Wearer is under 18', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+        order: {
+          deviceWearer: {
+            nomisId: null,
+            pncId: null,
+            deliusId: null,
+            prisonNumber: null,
+            homeOfficeReferenceNumber: null,
+            firstName: 'test',
+            lastName: 'tester',
+            alias: null,
+            dateOfBirth: null,
+            adultAtTimeOfInstallation: false,
+            sex: null,
+            gender: 'self-identify',
+            otherGender: 'Furby',
+            disabilities: 'Other',
+            otherDisability: 'Broken arm',
+            noFixedAbode: null,
+            interpreterRequired: null,
+          },
+          deviceWearerResponsibleAdult: {
+            relationship: 'Other',
+            otherRelationshipDetails: 'Partner',
+            fullName: 'Audrey Taylor',
+            contactNumber: '07101 123 456',
+          },
+        },
+      })
+
+      cy.signIn()
+    })
+
+    it('should not show responsible adult section', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
+
+      page.responsibleAdultSection().should('exist')
+    })
+  })
+
+  context('Unhealthy backend', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', { httpStatus: 404 })
+    })
+
+    it('Should indicate to the user that there was an error', () => {
+      cy.signIn().visit(`/order/${mockOrderId}${pagePath}`, { failOnStatusCode: false })
+
+      Page.verifyOnPage(NotFoundErrorPage)
+    })
+  })
+})

--- a/integration_tests/e2e/order/about-the-device-wearer/device-wearer.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/device-wearer.cy.ts
@@ -3,7 +3,7 @@ import { NotFoundErrorPage } from '../../../pages/error'
 import Page from '../../../pages/page'
 import AboutDeviceWearerPage from '../../../pages/order/about-the-device-wearer/device-wearer'
 import ResponsibleAdultPage from '../../../pages/order/about-the-device-wearer/responsible-adult-details'
-import ContactDetailsPage from '../../../pages/order/contact-information/contact-details'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 const mockOrderId = uuidv4()
 const apiPath = '/device-wearer'
@@ -107,7 +107,7 @@ context('About the device wearer', () => {
     context('for someone over 18 years old', () => {
       const birthYear = 1970
 
-      it('should continue to collect the contact details', () => {
+      it('should continue to check your answers page', () => {
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 200,
           id: mockOrderId,
@@ -182,7 +182,7 @@ context('About the device wearer', () => {
           },
         }).should('be.true')
 
-        Page.verifyOnPage(ContactDetailsPage)
+        Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       })
     })
 

--- a/integration_tests/e2e/order/about-the-device-wearer/device-wearer.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/device-wearer.cy.ts
@@ -70,6 +70,7 @@ context('About the device wearer', () => {
             disabilities: 'Other',
             otherDisability: 'Broken arm',
             noFixedAbode: null,
+            interpreterRequired: null,
           },
         },
       })

--- a/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { NotFoundErrorPage } from '../../../pages/error'
 import Page from '../../../pages/page'
 import ResponsibleAdultPage from '../../../pages/order/about-the-device-wearer/responsible-adult-details'
-import ContactDetailsPage from '../../../pages/order/contact-information/contact-details'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 const mockOrderId = uuidv4()
 
@@ -55,7 +55,7 @@ context('About the device wearer - Responsible Adult', () => {
       cy.signIn()
     })
 
-    it('should continue to collect the responsible officer details', () => {
+    it('should continue to check your answers page', () => {
       const page = Page.visit(ResponsibleAdultPage, { orderId: mockOrderId })
 
       const validFormData = {
@@ -78,7 +78,7 @@ context('About the device wearer - Responsible Adult', () => {
         },
       }).should('be.true')
 
-      Page.verifyOnPage(ContactDetailsPage)
+      Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
     })
   })
 

--- a/integration_tests/e2e/order/contact-information/no-fixed-abode.submission.cy.ts
+++ b/integration_tests/e2e/order/contact-information/no-fixed-abode.submission.cy.ts
@@ -35,6 +35,7 @@ context('Contact information', () => {
             dateOfBirth: null,
             disabilities: null,
             noFixedAbode: false,
+            interpreterRequired: null,
           },
         })
 
@@ -111,6 +112,7 @@ context('Contact information', () => {
             dateOfBirth: null,
             disabilities: null,
             noFixedAbode: true,
+            interpreterRequired: null,
           },
         })
 

--- a/integration_tests/e2e/order/summary.cy.ts
+++ b/integration_tests/e2e/order/summary.cy.ts
@@ -118,6 +118,7 @@ context('Order Summary', () => {
             gender: null,
             disabilities: '',
             noFixedAbode: false,
+            interpreterRequired: null,
           },
           deviceWearerResponsibleAdult: null,
           contactDetails: null,
@@ -237,6 +238,7 @@ context('Order Summary', () => {
             gender: null,
             disabilities: '',
             noFixedAbode: false,
+            interpreterRequired: null,
           },
           deviceWearerResponsibleAdult: {
             contactNumber: null,

--- a/integration_tests/mockApis/cemo.ts
+++ b/integration_tests/mockApis/cemo.ts
@@ -40,6 +40,7 @@ export const mockApiOrder = (status: string = 'IN_PROGRESS') => ({
     gender: null,
     disabilities: null,
     noFixedAbode: null,
+    interpreterRequired: null,
   },
   deviceWearerResponsibleAdult: null,
   enforcementZoneConditions: [],
@@ -93,6 +94,7 @@ const defaultListOrdersOptions: ListOrdersStubOptions = {
         gender: null,
         disabilities: null,
         noFixedAbode: null,
+        intepreterRequired: null,
       },
     },
   ],
@@ -317,6 +319,7 @@ const defaultPutDeviceWearerOptions = {
     gender: null,
     disabilities: null,
     noFixedAbode: null,
+    interpreterRequired: null,
   },
 }
 

--- a/integration_tests/mockApis/cemo.ts
+++ b/integration_tests/mockApis/cemo.ts
@@ -94,7 +94,7 @@ const defaultListOrdersOptions: ListOrdersStubOptions = {
         gender: null,
         disabilities: null,
         noFixedAbode: null,
-        intepreterRequired: null,
+        interpreterRequired: null,
       },
     },
   ],

--- a/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerForm.ts
+++ b/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerForm.ts
@@ -107,7 +107,7 @@ export default class AboutDeviceWearerFormComponent extends FormComponent {
       'Hearing',
       'Mobility',
       'Dexterity',
-      'Learning, understanding or concentrating',
+      'Learning or understanding or concentrating',
       'Memory',
       'Mental health',
       'Stamina or breathing or fatigue',

--- a/integration_tests/pages/order/about-the-device-wearer/check-your-answers.ts
+++ b/integration_tests/pages/order/about-the-device-wearer/check-your-answers.ts
@@ -1,0 +1,17 @@
+import AppPage from '../../appPage'
+import paths from '../../../../server/constants/paths'
+import { PageElement } from '../../page'
+
+export default class DeviceWearerCheckYourAnswersPage extends AppPage {
+  constructor() {
+    super('Check your answers', paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS)
+  }
+
+  phaseBanner = (): PageElement => cy.get('[data-qa=header-phase-banner]')
+
+  continueButton = (): PageElement => cy.contains('Save and continue')
+
+  returnButton = (): PageElement => cy.contains('Return back to form section menu')
+
+  responsibleAdultSection = (): PageElement => cy.contains('Responsible adult')
+}

--- a/integration_tests/pages/order/about-the-device-wearer/check-your-answers.ts
+++ b/integration_tests/pages/order/about-the-device-wearer/check-your-answers.ts
@@ -9,7 +9,7 @@ export default class DeviceWearerCheckYourAnswersPage extends AppPage {
 
   phaseBanner = (): PageElement => cy.get('[data-qa=header-phase-banner]')
 
-  continueButton = (): PageElement => cy.contains('Save and continue')
+  continueButton = (): PageElement => cy.contains('Continue')
 
   returnButton = (): PageElement => cy.contains('Return back to form section menu')
 

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO003 - AAMR Post Release.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO003 - AAMR Post Release.cy.ts
@@ -16,6 +16,7 @@ import InstallationAddressPage from '../../../pages/order/monitoring-conditions/
 import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -89,6 +90,9 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
@@ -16,6 +16,7 @@ import InstallationAddressPage from '../../../pages/order/monitoring-conditions/
 import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -91,6 +92,9 @@ context('Scenarios', () => {
         const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
         aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
         aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+        const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+        deviceWearerCheckYourAnswersPage.continueButton().click()
 
         const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
         contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO013 - AML Post Release.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO013 - AML Post Release.cy.ts
@@ -16,6 +16,7 @@ import InstallationAddressPage from '../../../pages/order/monitoring-conditions/
 import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -89,6 +90,9 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO001 - RF - 7 nights - single attachment.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO001 - RF - 7 nights - single attachment.cy.ts
@@ -18,6 +18,7 @@ import CurfewReleaseDatePage from '../../../pages/order/monitoring-conditions/cu
 import SubmitSuccessPage from '../../../pages/order/submit-success'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -111,6 +112,9 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO002 - RF - 7 nights - single attachment.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO002 - RF - 7 nights - single attachment.cy.ts
@@ -18,6 +18,7 @@ import CurfewReleaseDatePage from '../../../pages/order/monitoring-conditions/cu
 import SubmitSuccessPage from '../../../pages/order/submit-success'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -111,6 +112,9 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO005 - RF - weekend only - mandatory information missing.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO005 - RF - weekend only - mandatory information missing.cy.ts
@@ -18,6 +18,7 @@ import CurfewReleaseDatePage from '../../../pages/order/monitoring-conditions/cu
 import SubmitSuccessPage from '../../../pages/order/submit-success'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -127,6 +128,9 @@ context('Scenarios', () => {
         const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
         aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
         aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+        const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+        deviceWearerCheckYourAnswersPage.continueButton().click()
 
         const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
         contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO009 -  Immigration with GPS tag.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO009 -  Immigration with GPS tag.cy.ts
@@ -16,6 +16,7 @@ import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import TrailMonitoringPage from '../../../pages/order/monitoring-conditions/trail-monitoring'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -87,6 +88,9 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO010 -  Immigration with Location with Non Fitted Device.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO010 -  Immigration with Location with Non Fitted Device.cy.ts
@@ -16,6 +16,7 @@ import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import TrailMonitoringPage from '../../../pages/order/monitoring-conditions/trail-monitoring'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -87,6 +88,9 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO008 - suspended community sentence - weekend only 7pm-7am.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO008 - suspended community sentence - weekend only 7pm-7am.cy.ts
@@ -24,6 +24,7 @@ import CurfewConditionsPage from '../../../pages/order/monitoring-conditions/cur
 import CurfewTimetablePage from '../../../pages/order/monitoring-conditions/curfew-timetable'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -136,6 +137,9 @@ context('Scenarios', () => {
       const responsibleAdultDetailsPage = Page.verifyOnPage(ResponsibleAdultDetailsPage)
       responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
       responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO015 - DAPOL pre-trial - weekday only 7pm-7am.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO015 - DAPOL pre-trial - weekday only 7pm-7am.cy.ts
@@ -25,6 +25,7 @@ import CurfewTimetablePage from '../../../pages/order/monitoring-conditions/curf
 import SecondaryAddressPage from '../../../pages/order/contact-information/secondary-address'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -143,6 +144,9 @@ context('Scenarios', () => {
         const responsibleAdultDetailsPage = Page.verifyOnPage(ResponsibleAdultDetailsPage)
         responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
         responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+        const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+        deviceWearerCheckYourAnswersPage.continueButton().click()
 
         const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
         contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - GPS fitted Post Release - multiple exclusion zones.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - GPS fitted Post Release - multiple exclusion zones.cy.ts
@@ -22,6 +22,7 @@ import SubmitSuccessPage from '../../../pages/order/submit-success'
 import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -122,6 +123,9 @@ context('Scenarios', () => {
         const responsibleAdultDetailsPage = Page.verifyOnPage(ResponsibleAdultDetailsPage)
         responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
         responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+        const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+        deviceWearerCheckYourAnswersPage.continueButton().click()
 
         const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
         contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Trail monitoring/CEMO006 - Youth Rehabilitation Order with Intensive Supervision and Surveillance with GPS tag.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Trail monitoring/CEMO006 - Youth Rehabilitation Order with Intensive Supervision and Surveillance with GPS tag.cy.ts
@@ -22,6 +22,7 @@ import TrailMonitoringPage from '../../../pages/order/monitoring-conditions/trai
 import ResponsibleAdultPage from '../../../pages/order/about-the-device-wearer/responsible-adult-details'
 import AttachmentPage from '../../../pages/order/attachment'
 import { formatAsFmsDateTime } from '../../utils'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -100,6 +101,9 @@ context('Scenarios', () => {
         const responsibleAdultDetailsPage = Page.verifyOnPage(ResponsibleAdultPage)
         responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
         responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+        const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+        deviceWearerCheckYourAnswersPage.continueButton().click()
 
         const contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
         contactDetailsPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/kitchen-sink.cy.ts
+++ b/integration_tests/scenarios/kitchen-sink.cy.ts
@@ -23,6 +23,7 @@ import CurfewConditionsPage from '../pages/order/monitoring-conditions/curfew-co
 import EnforcementZonePage from '../pages/order/monitoring-conditions/enforcement-zone'
 import TrailMonitoringPage from '../pages/order/monitoring-conditions/trail-monitoring'
 import AttachmentPage from '../pages/order/attachment'
+import DeviceWearerCheckYourAnswersPage from '../pages/order/about-the-device-wearer/check-your-answers'
 
 context('The kitchen sink', () => {
   const takeScreenshots = true
@@ -172,6 +173,9 @@ context('The kitchen sink', () => {
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       if (takeScreenshots) cy.screenshot('03. aboutDeviceWearerPage', { overwrite: true })
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       let contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith({ contactNumber: '0123456789' })

--- a/integration_tests/scenarios/mandatory-field-only.cy.ts
+++ b/integration_tests/scenarios/mandatory-field-only.cy.ts
@@ -28,6 +28,7 @@ import EnforcementZonePage from '../pages/order/monitoring-conditions/enforcemen
 import TrailMonitoringPage from '../pages/order/monitoring-conditions/trail-monitoring'
 import ResponsibleAdultPage from '../pages/order/about-the-device-wearer/responsible-adult-details'
 import AttachmentPage from '../pages/order/attachment'
+import DeviceWearerCheckYourAnswersPage from '../pages/order/about-the-device-wearer/check-your-answers'
 
 context('Mandatory fields only', () => {
   const takeScreenshots = true
@@ -142,6 +143,9 @@ context('Mandatory fields only', () => {
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       if (takeScreenshots) cy.screenshot('03. aboutDeviceWearerPage - minimum', { overwrite: true })
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       let contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith({ contactNumber: '0123456789' })
@@ -370,6 +374,9 @@ context('Mandatory fields only', () => {
       responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
       if (takeScreenshots) cy.screenshot('04. responsibleAdultDetailsPage - minimum', { overwrite: true })
       responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+      const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      deviceWearerCheckYourAnswersPage.continueButton().click()
 
       let contactDetailsPage = Page.verifyOnPage(ContactDetailsPage)
       contactDetailsPage.form.fillInWith({ contactNumber: '0123456789' })

--- a/server/controllers/contact-information/noFixedAbodeController.test.ts
+++ b/server/controllers/contact-information/noFixedAbodeController.test.ts
@@ -30,6 +30,7 @@ const createMockOrder = (noFixedAbode: boolean | null) =>
       gender: null,
       disabilities: [],
       noFixedAbode,
+      interpreterRequired: null,
     },
   })
 
@@ -182,6 +183,7 @@ describe('NoFixedAbodeController', () => {
         gender: null,
         disabilities: [],
         noFixedAbode: false,
+        interpreterRequired: null,
       })
 
       // When
@@ -224,6 +226,7 @@ describe('NoFixedAbodeController', () => {
         gender: null,
         disabilities: [],
         noFixedAbode: true,
+        interpreterRequired: null,
       })
 
       // When
@@ -265,6 +268,7 @@ describe('NoFixedAbodeController', () => {
         gender: null,
         disabilities: [],
         noFixedAbode: false,
+        interpreterRequired: null,
       })
 
       // When

--- a/server/controllers/deviceWearerCheckAnswersController.test.ts
+++ b/server/controllers/deviceWearerCheckAnswersController.test.ts
@@ -68,6 +68,14 @@ const createMockOrder = (status: OrderStatus): Order => {
       gender: 'male',
       disabilities: ['Vision', 'Mobilitiy'],
       noFixedAbode: null,
+      interpreterRequired: false,
+      language: null,
+    },
+    deviceWearerResponsibleAdult: {
+      relationship: 'Parent',
+      otherRelationshipDetails: null,
+      fullName: 'Firstname Lastname',
+      contactNumber: '07999999999',
     },
   }
 }
@@ -88,7 +96,7 @@ describe('DeviceWearerCheckAnswersController', () => {
     deviceWearerCheckAnswersController = new DeviceWearerCheckAnswersController(mockAuditService)
   })
 
-  it('should render the page using the saved device wearer data', async () => {
+  it('should render the page using the saved device wearer and responsible adult data', async () => {
     // Given
     const mockOrder = createMockOrder(OrderStatusEnum.Enum.IN_PROGRESS)
     const req = createMockRequest(mockOrder)
@@ -103,22 +111,31 @@ describe('DeviceWearerCheckAnswersController', () => {
       'pages/order/about-the-device-wearer/check-your-answers',
       expect.objectContaining({
         aboutTheDeviceWearerUri: '/order/123456789/about-the-device-wearer',
+        adultAtTimeOfInstallation: 'No',
+        alias: 'test',
+        dateOfBirth_day: '1',
+        dateOfBirth_month: '1',
+        dateOfBirth_year: '1980',
+        deliusId: '',
+        deviceWearerResponsibleAdultUri: '/order/123456789/about-the-device-wearer/responsible-adult',
+        disabilities: ['Vision', 'Mobilitiy'],
+        displayResponsibleAdult: true,
+        firstName: 'tester',
+        gender: 'male',
+        homeOfficeReferenceNumber: '',
+        interpreterRequired: 'No',
+        language: '',
+        lastName: 'testington',
+        noFixedAbode: '',
+        nomisId: '',
         orderSummaryUri: '/order/123456789/summary',
-        nomisId: { value: '' },
-        pncId: { value: '' },
-        deliusId: { value: '' },
-        prisonNumber: { value: '' },
-        firstName: { value: 'tester' },
-        lastName: { value: 'testington' },
-        alias: { value: 'test' },
-        dateOfBirth_day: { value: '1' },
-        dateOfBirth_month: { value: '1' },
-        dateOfBirth_year: { value: '1980' },
-        dateOfBirth: { value: '' },
-        adultAtTimeOfInstallation: { value: 'false' },
-        sex: { value: 'male' },
-        gender: { value: 'male' },
-        disabilities: { values: ['Vision', 'Mobilitiy'] },
+        pncId: '',
+        prisonNumber: '',
+        responsibleAdultContactNumber: '07999999999',
+        responsibleAdultFullName: 'Firstname Lastname',
+        responsibleAdultOtherRelationshipDetails: '',
+        responsibleAdultRelationship: 'Parent',
+        sex: 'male',
       }),
     )
   })

--- a/server/controllers/deviceWearerCheckAnswersController.test.ts
+++ b/server/controllers/deviceWearerCheckAnswersController.test.ts
@@ -126,7 +126,6 @@ describe('DeviceWearerCheckAnswersController', () => {
         interpreterRequired: 'No',
         language: '',
         lastName: 'testington',
-        noFixedAbode: '',
         nomisId: '',
         orderSummaryUri: '/order/123456789/summary',
         pncId: '',

--- a/server/controllers/deviceWearerController.test.ts
+++ b/server/controllers/deviceWearerController.test.ts
@@ -227,7 +227,7 @@ describe('DeviceWearerController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer`)
     })
 
-    it('should save and redirect to the contact details page if the device wearer is an adult', async () => {
+    it('should save and redirect to the device wearer check your answers page if the device wearer is an adult', async () => {
       // Given
       const order = getMockOrder()
       const req = createMockRequest({
@@ -280,7 +280,7 @@ describe('DeviceWearerController', () => {
 
       // Then
       expect(req.flash).not.toHaveBeenCalled()
-      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/contact-information/contact-details`)
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/check-your-answers`)
     })
 
     it('should save and redirect to the responsible adult page if the device wearer is not an adult', async () => {

--- a/server/controllers/deviceWearerResponsibleAdultController.test.ts
+++ b/server/controllers/deviceWearerResponsibleAdultController.test.ts
@@ -157,7 +157,7 @@ describe('DeviceWearerResponsibleAdultController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/responsible-adult`)
     })
 
-    it('should save and redirect to the contact details page', async () => {
+    it('should save and redirect to the device wearer check your answers page', async () => {
       // Given
       const order = createMockOrder('Parent Name')
       const req = createMockRequest({
@@ -185,7 +185,7 @@ describe('DeviceWearerResponsibleAdultController', () => {
 
       // Then
       expect(req.flash).not.toHaveBeenCalled()
-      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/contact-information/contact-details`)
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/check-your-answers`)
     })
   })
 

--- a/server/controllers/deviceWearersCheckAnswersController.ts
+++ b/server/controllers/deviceWearersCheckAnswersController.ts
@@ -1,71 +1,15 @@
 import { Request, RequestHandler, Response } from 'express'
-import paths from '../constants/paths'
-import { DeviceWearer } from '../models/DeviceWearer'
-import { MultipleChoiceField, TextField } from '../models/view-models/utils'
 import { AuditService } from '../services'
-import { deserialiseDate } from '../utils/utils'
-
-type DeviceWearerCheckAnswersViewModel = {
-  aboutTheDeviceWearerUri: string
-  orderSummaryUri: string
-  nomisId: TextField
-  pncId: TextField
-  deliusId: TextField
-  prisonNumber: TextField
-  firstName: TextField
-  lastName: TextField
-  alias: TextField
-  dateOfBirth_day: TextField
-  dateOfBirth_month: TextField
-  dateOfBirth_year: TextField
-  dateOfBirth: TextField
-  adultAtTimeOfInstallation: TextField
-  sex: TextField
-  gender: TextField
-  disabilities: MultipleChoiceField
-}
+import deviceWearerCheckAnswersViewModel from '../models/view-models/deviceWearerCheckAnswers'
 
 export default class DeviceWearerCheckAnswersController {
   constructor(private readonly auditService: AuditService) {}
 
-  private createViewModelFromDeviceWearer(
-    deviceWearer: DeviceWearer,
-    orderId: string,
-  ): DeviceWearerCheckAnswersViewModel {
-    const [year, month, day] = deserialiseDate(deviceWearer.dateOfBirth || '')
-
-    return {
-      aboutTheDeviceWearerUri: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', orderId),
-      orderSummaryUri: paths.ORDER.SUMMARY.replace(':orderId', orderId),
-      nomisId: { value: deviceWearer.nomisId || '' },
-      pncId: { value: deviceWearer.pncId || '' },
-      deliusId: { value: deviceWearer.deliusId || '' },
-      prisonNumber: { value: deviceWearer.prisonNumber || '' },
-      firstName: { value: deviceWearer.firstName || '' },
-      lastName: { value: deviceWearer.lastName || '' },
-      alias: { value: deviceWearer.alias || '' },
-      dateOfBirth_day: { value: day },
-      dateOfBirth_month: { value: month },
-      dateOfBirth_year: { value: year },
-      dateOfBirth: {
-        value: '',
-      },
-      adultAtTimeOfInstallation: { value: String(deviceWearer.adultAtTimeOfInstallation) },
-      sex: { value: deviceWearer.sex || '' },
-      gender: { value: deviceWearer.gender || '' },
-      disabilities: { values: deviceWearer.disabilities ?? [] },
-    }
-  }
-
-  private constructViewModel(deviceWearer: DeviceWearer, formAction: string): DeviceWearerCheckAnswersViewModel {
-    return this.createViewModelFromDeviceWearer(deviceWearer, formAction)
-  }
-
   view: RequestHandler = async (req: Request, res: Response) => {
     const { orderId } = req.params
-    const { deviceWearer } = req.order!
+    const { deviceWearer, deviceWearerResponsibleAdult } = req.order!
 
-    const viewModel = this.constructViewModel(deviceWearer, orderId)
+    const viewModel = deviceWearerCheckAnswersViewModel.construct(deviceWearer, deviceWearerResponsibleAdult, orderId)
 
     res.render(`pages/order/about-the-device-wearer/check-your-answers`, viewModel)
   }

--- a/server/controllers/orderSearchController.test.ts
+++ b/server/controllers/orderSearchController.test.ts
@@ -31,6 +31,8 @@ const mockSubmittedOrder = getMockOrder({
     gender: null,
     disabilities: [],
     noFixedAbode: null,
+    language: null,
+    interpreterRequired: null,
   },
   enforcementZoneConditions: [],
   additionalDocuments: [],

--- a/server/models/DeviceWearer.ts
+++ b/server/models/DeviceWearer.ts
@@ -21,7 +21,7 @@ const DeviceWearerModel = z.object({
   otherDisability: z.string().nullable().optional(),
   noFixedAbode: z.boolean().nullable(),
   language: z.string().nullable().optional(),
-  interpreterRequired: z.boolean().nullable().optional(),
+  interpreterRequired: z.boolean().nullable(),
 })
 
 export type DeviceWearer = z.infer<typeof DeviceWearerModel>

--- a/server/models/view-models/deviceWearerCheckAnswers.ts
+++ b/server/models/view-models/deviceWearerCheckAnswers.ts
@@ -1,0 +1,83 @@
+import paths from '../../constants/paths'
+import { convertBooleanToEnum, deserialiseDate } from '../../utils/utils'
+import { DeviceWearer } from '../DeviceWearer'
+import { DeviceWearerResponsibleAdult } from '../DeviceWearerResponsibleAdult'
+
+type DeviceWearerCheckAnswersViewModel = {
+  aboutTheDeviceWearerUri: string
+  deviceWearerResponsibleAdultUri: string
+  orderSummaryUri: string
+  displayResponsibleAdult: boolean
+  firstName: string
+  lastName: string
+  alias: string
+  dateOfBirth_day: string
+  dateOfBirth_month: string
+  dateOfBirth_year: string
+  adultAtTimeOfInstallation: string
+  sex: string
+  gender: string
+  disabilities: string[]
+  noFixedAbode: string
+  language: string
+  interpreterRequired: string
+  nomisId: string
+  pncId: string
+  deliusId: string
+  prisonNumber: string
+  homeOfficeReferenceNumber: string
+  responsibleAdultRelationship: string
+  responsibleAdultOtherRelationshipDetails: string
+  responsibleAdultFullName: string
+  responsibleAdultContactNumber: string
+}
+
+const createViewModelFromDeviceWearer = (
+  deviceWearer: DeviceWearer,
+  deviceWearerResponsibleAdult: DeviceWearerResponsibleAdult | null,
+  orderId: string,
+): DeviceWearerCheckAnswersViewModel => {
+  const [year, month, day] = deserialiseDate(deviceWearer.dateOfBirth || '')
+  const displayResponsibleAdult = !deviceWearer.adultAtTimeOfInstallation
+
+  return {
+    aboutTheDeviceWearerUri: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', orderId),
+    deviceWearerResponsibleAdultUri: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', orderId),
+    orderSummaryUri: paths.ORDER.SUMMARY.replace(':orderId', orderId),
+    displayResponsibleAdult,
+    firstName: deviceWearer.firstName || '',
+    lastName: deviceWearer.lastName || '',
+    alias: deviceWearer.alias || '',
+    dateOfBirth_day: day,
+    dateOfBirth_month: month,
+    dateOfBirth_year: year,
+    adultAtTimeOfInstallation: convertBooleanToEnum<string>(deviceWearer.adultAtTimeOfInstallation, '', 'Yes', 'No'),
+    sex: deviceWearer.sex || '',
+    gender: deviceWearer.gender || '',
+    disabilities: deviceWearer.disabilities || [],
+    noFixedAbode: convertBooleanToEnum<string>(deviceWearer.noFixedAbode, '', 'Yes', 'No'),
+    language: deviceWearer.language || '',
+    interpreterRequired: convertBooleanToEnum<string>(deviceWearer.interpreterRequired, '', 'Yes', 'No'),
+    nomisId: deviceWearer.nomisId || '',
+    pncId: deviceWearer.pncId || '',
+    deliusId: deviceWearer.deliusId || '',
+    prisonNumber: deviceWearer.prisonNumber || '',
+    homeOfficeReferenceNumber: deviceWearer.homeOfficeReferenceNumber || '',
+    responsibleAdultRelationship: deviceWearerResponsibleAdult?.relationship || '',
+    responsibleAdultOtherRelationshipDetails: deviceWearerResponsibleAdult?.otherRelationshipDetails || '',
+    responsibleAdultFullName: deviceWearerResponsibleAdult?.fullName || '',
+    responsibleAdultContactNumber: deviceWearerResponsibleAdult?.contactNumber || '',
+  }
+}
+
+const construct = (
+  deviceWearer: DeviceWearer,
+  deviceWearerResponsibleAdult: DeviceWearerResponsibleAdult | null,
+  formAction: string,
+): DeviceWearerCheckAnswersViewModel => {
+  return createViewModelFromDeviceWearer(deviceWearer, deviceWearerResponsibleAdult, formAction)
+}
+
+export default {
+  construct,
+}

--- a/server/models/view-models/deviceWearerCheckAnswers.ts
+++ b/server/models/view-models/deviceWearerCheckAnswers.ts
@@ -18,7 +18,6 @@ type DeviceWearerCheckAnswersViewModel = {
   sex: string
   gender: string
   disabilities: string[]
-  noFixedAbode: string
   language: string
   interpreterRequired: string
   nomisId: string
@@ -55,7 +54,6 @@ const createViewModelFromDeviceWearer = (
     sex: deviceWearer.sex || '',
     gender: deviceWearer.gender || '',
     disabilities: deviceWearer.disabilities || [],
-    noFixedAbode: convertBooleanToEnum<string>(deviceWearer.noFixedAbode, '', 'Yes', 'No'),
     language: deviceWearer.language || '',
     interpreterRequired: convertBooleanToEnum<string>(deviceWearer.interpreterRequired, '', 'Yes', 'No'),
     nomisId: deviceWearer.nomisId || '',

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -20,7 +20,7 @@ import TaskListService from './taskListService'
 
 describe('TaskListService', () => {
   describe('getNextPage', () => {
-    it('should return responsible adult if current page is device wearer and adultAtTheTimeOfInstallation is true', () => {
+    it('should return check your answers if current page is device wearer and adultAtTheTimeOfInstallation is true', () => {
       // Given
       const currentPage = 'DEVICE_WEARER'
       const taskListService = new TaskListService()
@@ -32,7 +32,7 @@ describe('TaskListService', () => {
       const nextPage = taskListService.getNextPage(currentPage, order)
 
       // Then
-      expect(nextPage).toBe(paths.CONTACT_INFORMATION.CONTACT_DETAILS.replace(':orderId', order.id))
+      expect(nextPage).toBe(paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id))
     })
 
     it('should return responsible adult if current page is device wearer and adultAtTheTimeOfInstallation is false', () => {
@@ -50,7 +50,7 @@ describe('TaskListService', () => {
       expect(nextPage).toBe(paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id))
     })
 
-    it('should return contact details if current page is responsible adult', () => {
+    it('should return check your answers if current page is responsible adult', () => {
       // Given
       const currentPage = 'RESPONSIBLE_ADULT'
       const taskListService = new TaskListService()
@@ -60,7 +60,7 @@ describe('TaskListService', () => {
       const nextPage = taskListService.getNextPage(currentPage, order)
 
       // Then
-      expect(nextPage).toBe(paths.CONTACT_INFORMATION.CONTACT_DETAILS.replace(':orderId', order.id))
+      expect(nextPage).toBe(paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id))
     })
 
     it('should return no fixed abode if current page is contact details', () => {
@@ -661,6 +661,13 @@ describe('TaskListService', () => {
             state: 'CANT_BE_STARTED',
             completed: false,
           },
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'CHECK_ANSWERS_DEVICE_WEARER',
+            path: paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
+            state: 'CHECK_YOUR_ANSWERS',
+            completed: true,
+          },
         ],
         CONTACT_INFORMATION: [
           {
@@ -852,6 +859,13 @@ describe('TaskListService', () => {
             state: 'CANT_BE_STARTED',
             completed: true,
           },
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'CHECK_ANSWERS_DEVICE_WEARER',
+            path: paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
+            state: 'CHECK_YOUR_ANSWERS',
+            completed: true,
+          },
         ],
         CONTACT_INFORMATION: [
           {
@@ -1032,6 +1046,13 @@ describe('TaskListService', () => {
             path: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
             state: 'REQUIRED',
             completed: false,
+          },
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'CHECK_ANSWERS_DEVICE_WEARER',
+            path: paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
+            state: 'CHECK_YOUR_ANSWERS',
+            completed: true,
           },
         ],
         CONTACT_INFORMATION: [

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -13,6 +13,7 @@ type Section =
 type Page =
   | 'DEVICE_WEARER'
   | 'RESPONSIBLE_ADULT'
+  | 'CHECK_ANSWERS_DEVICE_WEARER'
   | 'CONTACT_DETAILS'
   | 'NO_FIXED_ABODE'
   | 'PRIMARY_ADDRESS'
@@ -31,7 +32,7 @@ type Page =
   | 'ALCOHOL'
   | 'ATTACHMENT'
 
-type State = 'REQUIRED' | 'NOT_REQUIRED' | 'OPTIONAL' | 'CANT_BE_STARTED'
+type State = 'REQUIRED' | 'NOT_REQUIRED' | 'OPTIONAL' | 'CANT_BE_STARTED' | 'CHECK_YOUR_ANSWERS'
 
 type Task = {
   section: Section
@@ -61,7 +62,7 @@ const canBeCompleted = (task: Task, formData: FormData): boolean => {
     }
   }
 
-  return ['OPTIONAL', 'REQUIRED'].includes(task.state)
+  return ['OPTIONAL', 'REQUIRED', 'CHECK_YOUR_ANSWERS'].includes(task.state)
 }
 const isCurrentPage = (task: Task, currentPage: Page): boolean => task.name === currentPage
 
@@ -94,6 +95,14 @@ export default class TaskListService {
         'REQUIRED',
       ),
       completed: isNotNullOrUndefined(order.deviceWearerResponsibleAdult),
+    })
+
+    tasks.push({
+      section: 'ABOUT_THE_DEVICE_WEARER',
+      name: 'CHECK_ANSWERS_DEVICE_WEARER',
+      path: paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS,
+      state: 'CHECK_YOUR_ANSWERS',
+      completed: true,
     })
 
     tasks.push({

--- a/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
+++ b/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
@@ -235,23 +235,6 @@
                 }
                 ]
             }
-        },
-        {
-            key: {
-                text: "Does the person have no fixed abode?"
-            },
-            value: {
-                text: noFixedAbode
-            },
-            actions: {
-                items: [
-                {
-                    href: aboutTheDeviceWearerUri,
-                    text: "Change",
-                    visuallyHiddenText: "interpreter required"
-                }
-                ]
-            }
         }
     ]
   }) }}
@@ -429,18 +412,15 @@
     {% endif %}
 
     <div class="govuk-button-group">
-        {% if isOrderEditable %}
-            {{ govukButton({
-        text: "Continue",
-        href: orderSummaryUri
-      }) }}
-            {{ govukButton({
+        {{ govukButton({
+          text: "Continue",
+          href: "/order/" + orderId + "/contact-information/contact-details",
+          classes: "govuk-button--warning"
+        }) }}
+        {{ govukButton({
         text: "Return back to form section menu",
         href: orderSummaryUri
       }) }}
-        {% else %}
-            <a id="backToSummary" class="govuk-link" href="{{ orderSummaryUri }}">Return back to form section menu</a>
-        {% endif %}
     </div>
 
 {% endblock %}

--- a/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
+++ b/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
@@ -39,11 +39,11 @@
 
     {{ mojPageHeaderActions({
     heading: {
-        text: "About the device wearer"
+        text: "Check your answers"
     }
 }) }}
 
-    <h2 class="govuk-heading-l">Check your answers</h2>
+    <h2 class="govuk-heading-l">About the device wearer</h2>
 
     <h3 class="govuk-heading-m">Device wearer</h2>
 
@@ -350,7 +350,8 @@
   }) }}
 
     {% if displayResponsibleAdult %}
-        <br><h3 class="govuk-heading-m">Responsible adult</h3>
+        <br>
+        <h3 class="govuk-heading-m">Responsible adult</h3>
 
         {{ govukSummaryList({
     rows: [
@@ -430,7 +431,7 @@
     <div class="govuk-button-group">
         {% if isOrderEditable %}
             {{ govukButton({
-        text: "Save and continue",
+        text: "Continue",
         href: orderSummaryUri
       }) }}
             {{ govukButton({

--- a/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
+++ b/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
@@ -10,116 +10,58 @@
 
 {% block content %}
 
-  {{ govukBackLink({
+    {{ govukBackLink({
     text: "Back",
     href: orderSummaryUri
   }) }}
 
-  {% if not isOrderEditable %}
-      {% set html %}
+    {% if not isOrderEditable %}
+        {% set html %}
         <p class="govuk-notification-banner__heading">
           You are viewing a submitted order.
         </p>
-      {% endset %}
+        {% endset %}
 
-      {{ govukNotificationBanner({
+        {{ govukNotificationBanner({
         html: html
       }) }}
-  {% endif %}
+    {% endif %}
 
-{{ mojPageHeaderActions({
+    {% if disabilities %}
+        {% set disabilitiesHtml %}
+        <ul>
+            {% for disability in disabilities %}
+                <li>{{ disability }}</li>
+            {% endfor %}
+        </ul>
+        {% endset %}
+    {% endif %}
+
+    {{ mojPageHeaderActions({
     heading: {
         text: "About the device wearer"
     }
 }) }}
 
-  <h2 class="govuk-heading-l">Check your answers</h2>
+    <h2 class="govuk-heading-l">Check your answers</h2>
 
-  <h3 class="govuk-heading-m">About the device wearer</h3>
+    <h3 class="govuk-heading-m">Device wearer</h2>
 
-  {{ govukSummaryList({
+    {{ govukSummaryList({
     rows: [
-      {
-          key: {
-              text: "NOMIS ID"
-          },
-          value: {
-              text: firstName.value
-          },
-          actions: {
-              items: [
-              {
-                  href: aboutTheDeviceWearerUri,
-                  text: "Change",
-                  visuallyHiddenText: "name"
-              }
-              ]
-          }
-        },
         {
             key: {
-                text: "PNC ID"
+                text: "First names"
             },
             value: {
-                text: pncId.value
+                text: firstName
             },
             actions: {
                 items: [
                 {
                     href: aboutTheDeviceWearerUri,
                     text: "Change",
-                    visuallyHiddenText: "name"
-                }
-                ]
-            }
-        },
-        {
-            key: {
-                text: "DELIUS ID"
-            },
-            value: {
-                text: deliusId.value
-            },
-            actions: {
-                items: [
-                {
-                    href: aboutTheDeviceWearerUri,
-                    text: "Change",
-                    visuallyHiddenText: "name"
-                }
-                ]
-            }
-        },
-        {
-            key: {
-                text: "Prison number"
-            },
-            value: {
-                text: prisonNumber.value
-            },
-            actions: {
-                items: [
-                {
-                    href: aboutTheDeviceWearerUri,
-                    text: "Change",
-                    visuallyHiddenText: "name"
-                }
-                ]
-            }
-        },
-        {
-            key: {
-                text: "First name"
-            },
-            value: {
-                text: firstName.value
-            },
-            actions: {
-                items: [
-                {
-                    href: aboutTheDeviceWearerUri,
-                    text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "first names"
                 }
                 ]
             }
@@ -129,31 +71,31 @@
                 text: "Last name"
             },
             value: {
-                text: lastName.value
+                text: lastName
             },
             actions: {
                 items: [
                 {
                     href: aboutTheDeviceWearerUri,
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "last name"
                 }
                 ]
             }
         },
         {
             key: {
-                text: "Alias (optional)"
+                text: "Preferred name or alias (optional)"
             },
             value: {
-                text: alias.value
+                text: alias
             },
             actions: {
                 items: [
                 {
                     href: aboutTheDeviceWearerUri,
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "preferred name or alias"
                 }
                 ]
             }
@@ -163,14 +105,14 @@
                 text: "Date of birth"
             },
             value: {
-                html: dateOfBirth_day.value+"/"+dateOfBirth_month.value+"/"+dateOfBirth_year.value
+                html: dateOfBirth_day+"/"+dateOfBirth_month+"/"+dateOfBirth_year
             },
             actions: {
                 items: [
                 {
                     href: aboutTheDeviceWearerUri,
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "date of birth"
                 }
                 ]
             }
@@ -180,14 +122,14 @@
                 text: "Will the device wearer be 18 years old when the device is installed?"
             },
             value: {
-                text: adultAtTimeOfInstallation.value
+                text: adultAtTimeOfInstallation
             },
             actions: {
                 items: [
                 {
                     href: aboutTheDeviceWearerUri,
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "adult at time of installation"
                 }
                 ]
             }
@@ -197,14 +139,14 @@
                 text: "Sex"
             },
             value: {
-                text: sex.value
+                text: sex
             },
             actions: {
                 items: [
                 {
                     href: aboutTheDeviceWearerUri,
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "sex"
                 }
                 ]
             }
@@ -214,31 +156,99 @@
                 text: "Gender"
             },
             value: {
-                text: gender.value
+                text: gender
             },
             actions: {
                 items: [
                 {
                     href: aboutTheDeviceWearerUri,
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "gender"
                 }
                 ]
             }
         },
         {
             key: {
-                text: "Disabilities"
+                text: "Disabilities (optional)"
             },
             value: {
-                text: disabilities.values
+                html: disabilitiesHtml
             },
             actions: {
                 items: [
                 {
                     href: aboutTheDeviceWearerUri,
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "disabilities"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Disability, if other (optional)"
+            },
+            value: {
+                text: otherDisability
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "disability if other"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Main language"
+            },
+            value: {
+                text: language
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "interpreter required"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Is an interpreter required?"
+            },
+            value: {
+                text: interpreterRequired
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "interpreter required"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Does the person have no fixed abode?"
+            },
+            value: {
+                text: noFixedAbode
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "interpreter required"
                 }
                 ]
             }
@@ -246,19 +256,190 @@
     ]
   }) }}
 
-  <div class="govuk-button-group">
-    {% if isOrderEditable %}
-      {{ govukButton({
+    <br>
+    <h3 class="govuk-heading-m">Person identifiers</h3>
+
+    {{ govukSummaryList({
+    rows: [
+      {
+          key: {
+              text: "NOMIS ID (optional)"
+          },
+          value: {
+              text: nomisId
+          },
+          actions: {
+              items: [
+              {
+                  href: aboutTheDeviceWearerUri,
+                  text: "Change",
+                  visuallyHiddenText: "NOMIS ID"
+              }
+              ]
+          }
+        },
+        {
+            key: {
+                text: "PNC ID (optional)"
+            },
+            value: {
+                text: pncId
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "PNC ID"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "DELIUS ID (optional)"
+            },
+            value: {
+                text: deliusId
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "DELIUS ID"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Prison number (optional)"
+            },
+            value: {
+                text: prisonNumber
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "Prison number"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Home Office reference number (optional)"
+            },
+            value: {
+                text: homeOfficeReferenceNumber
+            },
+            actions: {
+                items: [
+                {
+                    href: aboutTheDeviceWearerUri,
+                    text: "Change",
+                    visuallyHiddenText: "Home Office reference number"
+                }
+                ]
+            }
+        }
+    ]
+  }) }}
+
+    {% if displayResponsibleAdult %}
+        <br><h3 class="govuk-heading-m">Responsible adult</h3>
+
+        {{ govukSummaryList({
+    rows: [
+      {
+          key: {
+              text: "Relationship"
+          },
+          value: {
+              text: responsibleAdultRelationship
+          },
+          actions: {
+              items: [
+              {
+                  href: deviceWearerResponsibleAdultUri,
+                  text: "Change",
+                  visuallyHiddenText: "Relationship"
+              }
+              ]
+          }
+        },
+        {
+            key: {
+                text: "Relationship details, if other (optional)"
+            },
+            value: {
+                text: responsibleAdultOtherRelationshipDetails
+            },
+            actions: {
+                items: [
+                {
+                    href: deviceWearerResponsibleAdultUri,
+                    text: "Change",
+                    visuallyHiddenText: "Relationship details, if other"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Full name"
+            },
+            value: {
+                text: responsibleAdultFullName
+            },
+            actions: {
+                items: [
+                {
+                    href: deviceWearerResponsibleAdultUri,
+                    text: "Change",
+                    visuallyHiddenText: "Full name"
+                }
+                ]
+            }
+        },
+        {
+            key: {
+                text: "Contact number"
+            },
+            value: {
+                text: responsibleAdultContactNumber
+            },
+            actions: {
+                items: [
+                {
+                    href: deviceWearerResponsibleAdultUri,
+                    text: "Change",
+                    visuallyHiddenText: "Contact number"
+                }
+                ]
+            }
+        }
+    ]
+  }) }}
+
+    {% endif %}
+
+    <div class="govuk-button-group">
+        {% if isOrderEditable %}
+            {{ govukButton({
         text: "Save and continue",
         href: orderSummaryUri
       }) }}
-      {{ govukButton({
+            {{ govukButton({
         text: "Return back to form section menu",
         href: orderSummaryUri
       }) }}
-    {% else %}
-      <a id="backToSummary" class="govuk-link" href="{{ orderSummaryUri }}">Return back to form section menu</a>
-    {% endif %}
-  </div>
+        {% else %}
+            <a id="backToSummary" class="govuk-link" href="{{ orderSummaryUri }}">Return back to form section menu</a>
+        {% endif %}
+    </div>
 
 {% endblock %}

--- a/server/views/pages/order/about-the-device-wearer/device-wearer.njk
+++ b/server/views/pages/order/about-the-device-wearer/device-wearer.njk
@@ -205,22 +205,22 @@
     },
     items: [
       {
-        value: "male",
+        value: "Male",
         text: "Male",
         disabled: not isOrderEditable
       },
       {
-        value: "female",
+        value: "Female",
         text: "Female",
         disabled: not isOrderEditable
       },
       {
-        value: "prefer not to say",
+        value: "Prefer not to say",
         text: "Prefer not to say",
         disabled: not isOrderEditable
       },
       {
-        value: "unknown",
+        value: "Unknown",
         text: "Don't know",
         disabled: not isOrderEditable
       }
@@ -260,27 +260,27 @@
     },
     items: [
       {
-        value: "male",
+        value: "Male",
         text: "Male",
         disabled: not isOrderEditable
       },
       {
-        value: "female",
+        value: "Female",
         text: "Female",
         disabled: not isOrderEditable
       },
       {
-        value: "non-binary",
+        value: "Non-binary",
         text: "Non binary",
         disabled: not isOrderEditable
       },
       {
-        value: "unknown",
+        value: "Unknown",
         text: "Don't know",
         disabled: not isOrderEditable
       },
       {
-        value: "self-identify",
+        value: "Self-identify",
         text: "Self identify",
         conditional: {
           html: otherGenderHtml
@@ -340,8 +340,8 @@
         text: "Dexterity"
       },
       {
-        value: "Learning, understanding or concentrating",
-        text: "Learning, understanding or concentrating"
+        value: "Learning or understanding or concentrating",
+        text: "Learning or understanding or concentrating"
       },
       {
         value: "Memory",

--- a/server/views/pages/order/about-the-device-wearer/device-wearer.njk
+++ b/server/views/pages/order/about-the-device-wearer/device-wearer.njk
@@ -205,22 +205,22 @@
     },
     items: [
       {
-        value: "Male",
+        value: "male",
         text: "Male",
         disabled: not isOrderEditable
       },
       {
-        value: "Female",
+        value: "female",
         text: "Female",
         disabled: not isOrderEditable
       },
       {
-        value: "Prefer not to say",
+        value: "prefer not to say",
         text: "Prefer not to say",
         disabled: not isOrderEditable
       },
       {
-        value: "Unknown",
+        value: "unknown",
         text: "Don't know",
         disabled: not isOrderEditable
       }
@@ -260,27 +260,27 @@
     },
     items: [
       {
-        value: "Male",
+        value: "male",
         text: "Male",
         disabled: not isOrderEditable
       },
       {
-        value: "Female",
+        value: "female",
         text: "Female",
         disabled: not isOrderEditable
       },
       {
-        value: "Non-binary",
+        value: "non-binary",
         text: "Non binary",
         disabled: not isOrderEditable
       },
       {
-        value: "Unknown",
+        value: "unknown",
         text: "Don't know",
         disabled: not isOrderEditable
       },
       {
-        value: "Self-identify",
+        value: "self-identify",
         text: "Self identify",
         conditional: {
           html: otherGenderHtml

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -48,7 +48,8 @@
     {% for task in tasks %}
       {% set name = task.name | replace("_", " ") | capitalize %}
       {% set href = task.path %}
-      {% set status = 'COMPLETE' if task.completed else 'INCOMPLETE' %}
+      {% set status = 'COMPLETE' if task.completed else 
+        'INCOMPLETE' %}
       {% set tagColour = 'govuk-tag--green' if task.completed else 'govuk-tag--grey' %}
 
       {% if task.state == 'CANT_BE_STARTED' %}
@@ -73,14 +74,13 @@
         }), taskListItems) %}
       {% elif task.state == 'OPTIONAL' %}
         {% set tagHtml %}
-            <strong class="govuk-tag govuk-tag--light-blue">
+        <strong class="govuk-tag govuk-tag--light-blue">
               Optional
             </strong>
-            <strong class="govuk-tag {{ tagColour }}">
-              {{ status | capitalize }} 
-            </strong>
+        <strong class="govuk-tag {{ tagColour }}">
+          {{ status | capitalize }}
+        </strong>
         {% endset %}
-
         {% set taskListItems = (taskListItems.push({
             idPrefix: "order-section",
             title: { text: name },
@@ -89,6 +89,8 @@
               html: tagHtml
             }
           }), taskListItems) %}
+      {% elif task.state == 'CHECK_YOUR_ANSWERS' %}
+        {# do not display #}
       {% else %}
         {% set taskListItems = (taskListItems.push({
           idPrefix: "order-section",

--- a/test/mocks/mockOrder.ts
+++ b/test/mocks/mockOrder.ts
@@ -30,6 +30,7 @@ export const createDeviceWearer = (overrideProperties?: Partial<DeviceWearer>): 
   gender: null,
   disabilities: [],
   noFixedAbode: null,
+  interpreterRequired: null,
   ...overrideProperties,
 })
 


### PR DESCRIPTION
This PR adds a check your answers page for the device wearer section (which includes info about both the device wearer and, if they're under 18 years old, their responsible adult).

## Additional notes
- 'Optional' has been taken off the interpreterRequired field to enable re-use of the boolean to enum function (otherwise interpreterRequired can be one of 4 values (null, undefined, true or false)
- 'Or' has been added to one of the disabilities, replacing a comma, because the list is at one point split on commas which erroneously splits the single disability category, causing display problems on the Check Your Answers page

## Next steps
- If it decided that the 'other gender' and 'other disability' fields should be kept, they will need to be added to this page.
- It may be best to give some additional thought to how to fit 'Check Your Answers' pages into the Task Service logic, which currently expects pages that represent tasks (i.e., completable forms).
