### PR TITLE
Update deprecated allow list group

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-create-an-order/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-create-an-order/values.yaml
@@ -57,7 +57,7 @@ generic-service:
 
   allowlist:
     groups:
-      - internal
+      - digital_staff_and_mojo
 
 generic-prometheus-alerts:
   targetApplication: hmpps-electronic-monitoring-create-an-order


### PR DESCRIPTION
This PR replaces the deprecated 'internal' [allow list group](https://github.com/ministryofjustice/hmpps-ip-allowlists) for our preprod and prod environments with the newer 'digital_staff_and_mojo' group.