### PR TITLE
Separate identity numbers into their own page

### DIFF
--- a/integration_tests/e2e/order/about-the-device-wearer/device-wearer.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/device-wearer.cy.ts
@@ -3,7 +3,7 @@ import { NotFoundErrorPage } from '../../../pages/error'
 import Page from '../../../pages/page'
 import AboutDeviceWearerPage from '../../../pages/order/about-the-device-wearer/device-wearer'
 import ResponsibleAdultPage from '../../../pages/order/about-the-device-wearer/responsible-adult-details'
-import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 const mockOrderId = uuidv4()
 const apiPath = '/device-wearer'
@@ -107,7 +107,7 @@ context('About the device wearer', () => {
     context('for someone over 18 years old', () => {
       const birthYear = 1970
 
-      it('should continue to check your answers page', () => {
+      it('should continue to the identity numbers page', () => {
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 200,
           id: mockOrderId,
@@ -137,11 +137,6 @@ context('About the device wearer', () => {
         const page = Page.visit(AboutDeviceWearerPage, { orderId: mockOrderId })
 
         const validFormData = {
-          nomisId: '1234567',
-          pncId: '1234567',
-          deliusId: '1234567',
-          prisonNumber: '1234567',
-          homeOfficeReferenceNumber: '1234567',
           firstNames: 'Barton',
           lastName: 'Fink',
           alias: 'Barty',
@@ -162,27 +157,22 @@ context('About the device wearer', () => {
         cy.task('stubCemoVerifyRequestReceived', {
           uri: `/orders/${mockOrderId}/device-wearer`,
           body: {
-            nomisId: '1234567',
-            pncId: '1234567',
-            deliusId: '1234567',
-            prisonNumber: '1234567',
-            homeOfficeReferenceNumber: '1234567',
             firstName: 'Barton',
             lastName: 'Fink',
             alias: 'Barty',
-            adultAtTimeOfInstallation: 'true',
+            adultAtTimeOfInstallation: true,
             sex: 'male',
             gender: 'male',
             otherGender: '',
             dateOfBirth: `${birthYear}-01-01T00:00:00.000Z`,
             disabilities: '',
             otherDisability: '',
-            interpreterRequired: 'true',
+            interpreterRequired: true,
             language: 'British Sign',
           },
         }).should('be.true')
 
-        Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+        Page.verifyOnPage(IdentityNumbersPage)
       })
     })
 
@@ -218,11 +208,6 @@ context('About the device wearer', () => {
         const page = Page.visit(AboutDeviceWearerPage, { orderId: mockOrderId })
 
         const validFormData = {
-          nomisId: '1234567',
-          pncId: '1234567',
-          deliusId: '1234567',
-          prisonNumber: '1234567',
-          homeOfficeReferenceNumber: '1234567',
           firstNames: 'Barton',
           lastName: 'Fink',
           alias: 'Barty',
@@ -242,22 +227,17 @@ context('About the device wearer', () => {
         cy.task('stubCemoVerifyRequestReceived', {
           uri: `/orders/${mockOrderId}/device-wearer`,
           body: {
-            nomisId: '1234567',
-            pncId: '1234567',
-            deliusId: '1234567',
-            prisonNumber: '1234567',
-            homeOfficeReferenceNumber: '1234567',
             firstName: 'Barton',
             lastName: 'Fink',
             alias: 'Barty',
-            adultAtTimeOfInstallation: 'false',
+            adultAtTimeOfInstallation: false,
             sex: 'male',
             gender: 'male',
             otherGender: '',
             dateOfBirth: `${birthYear}-01-01T00:00:00.000Z`,
             disabilities: '',
             otherDisability: '',
-            interpreterRequired: 'false',
+            interpreterRequired: false,
             language: '',
           },
         }).should('be.true')

--- a/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.page.draft.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.page.draft.cy.ts
@@ -1,0 +1,44 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
+
+const mockOrderId = uuidv4()
+
+context('About the device wearer', () => {
+  context('Identity numbers', () => {
+    context('Viewing a draft order', () => {
+      beforeEach(() => {
+        cy.task('reset')
+        cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
+
+        cy.signIn()
+      })
+
+      it('Should display the user name visible in header', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+        page.header.userName().should('contain.text', 'J. Smith')
+      })
+
+      it('Should display the phase banner in header', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+        page.header.phaseBanner().should('contain.text', 'dev')
+      })
+
+      it('Should allow the user to update the identity numbers', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+
+        page.form.saveAndContinueButton.should('exist')
+        page.form.saveAndReturnButton.should('exist')
+        page.form.shouldNotBeDisabled()
+        page.backToSummaryButton.should('exist')
+      })
+
+      it('Should be accessible', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+        page.checkIsAccessible()
+      })
+    })
+  })
+})

--- a/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.page.missing.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.page.missing.cy.ts
@@ -1,0 +1,25 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import { NotFoundErrorPage } from '../../../pages/error'
+
+const mockOrderId = uuidv4()
+const pagePath = '/about-the-device-wearer/identity-numbers'
+
+context('About the device wearer', () => {
+  context('Identity numbers', () => {
+    context('Viewing a non-existent order', () => {
+      beforeEach(() => {
+        cy.task('reset')
+        cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+        cy.task('stubCemoGetOrder', { httpStatus: 404 })
+      })
+
+      it('Should indicate to the user that there was an error', () => {
+        cy.signIn().visit(`/order/${mockOrderId}${pagePath}`, { failOnStatusCode: false })
+
+        Page.verifyOnPage(NotFoundErrorPage)
+      })
+    })
+  })
+})

--- a/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.page.submitted.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.page.submitted.cy.ts
@@ -1,0 +1,44 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
+
+const mockOrderId = uuidv4()
+
+context('About the device wearer', () => {
+  context('Identity numbers', () => {
+    context('Viewing a submitted order', () => {
+      beforeEach(() => {
+        cy.task('reset')
+        cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'SUBMITTED' })
+
+        cy.signIn()
+      })
+
+      it('Should display the user name visible in header', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+        page.header.userName().should('contain.text', 'J. Smith')
+      })
+
+      it('Should display the phase banner in header', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+        page.header.phaseBanner().should('contain.text', 'dev')
+      })
+
+      it('Should display the submitted order notification', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+        page.submittedBanner.should('contain', 'You are viewing a submitted order.')
+      })
+
+      it('Should not allow the user to update the no fixed abode details', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+
+        page.form.saveAndContinueButton.should('not.exist')
+        page.form.saveAndReturnButton.should('not.exist')
+        page.backToSummaryButton.should('exist').should('have.attr', 'href', `/order/${mockOrderId}/summary`)
+        page.form.shouldBeDisabled()
+      })
+    })
+  })
+})

--- a/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.submission.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.submission.cy.ts
@@ -1,0 +1,105 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import OrderSummaryPage from '../../../pages/order/summary'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
+import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
+
+const mockOrderId = uuidv4()
+const apiPath = '/device-wearer/identity-numbers'
+
+context('About the device wearer', () => {
+  context('Identity numbers', () => {
+    context('Submitting valid identity numbers', () => {
+      beforeEach(() => {
+        cy.task('reset')
+        cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
+        cy.task('stubCemoSubmitOrder', {
+          httpStatus: 200,
+          id: mockOrderId,
+          subPath: apiPath,
+          response: {
+            nomisId: null,
+            pncId: null,
+            deliusId: null,
+            prisonNumber: null,
+            homeOfficeReferenceNumber: null,
+            firstName: null,
+            lastName: null,
+            alias: null,
+            adultAtTimeOfInstallation: null,
+            sex: null,
+            gender: null,
+            dateOfBirth: null,
+            disabilities: null,
+            noFixedAbode: false,
+            interpreterRequired: null,
+          },
+        })
+
+        cy.signIn()
+      })
+
+      it('should submit a correctly formatted identity numbers submission', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+
+        const validFormData = {
+          nomisId: 'nomis',
+          pncId: 'pnc',
+          deliusId: 'delius',
+          prisonNumber: 'prison',
+          homeOfficeReferenceNumber: 'homeoffice',
+        }
+
+        page.form.fillInWith(validFormData)
+        page.form.saveAndContinueButton.click()
+
+        cy.task('stubCemoVerifyRequestReceived', {
+          uri: `/orders/${mockOrderId}${apiPath}`,
+          body: {
+            nomisId: 'nomis',
+            pncId: 'pnc',
+            deliusId: 'delius',
+            prisonNumber: 'prison',
+            homeOfficeReferenceNumber: 'homeoffice',
+          },
+        }).should('be.true')
+      })
+
+      it('should continue to the check your answers page', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+
+        const validFormData = {
+          nomisId: 'nomis',
+          pncId: 'pnc',
+          deliusId: 'delius',
+          prisonNumber: 'prison',
+          homeOfficeReferenceNumber: 'homeoffice',
+        }
+
+        page.form.fillInWith(validFormData)
+        page.form.saveAndContinueButton.click()
+
+        Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      })
+
+      it('should return to the summary page', () => {
+        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
+
+        const validFormData = {
+          nomisId: 'nomis',
+          pncId: 'pnc',
+          deliusId: 'delius',
+          prisonNumber: 'prison',
+          homeOfficeReferenceNumber: 'homeoffice',
+        }
+
+        page.form.fillInWith(validFormData)
+        page.form.saveAndReturnButton.click()
+
+        Page.verifyOnPage(OrderSummaryPage)
+      })
+    })
+  })
+})

--- a/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { NotFoundErrorPage } from '../../../pages/error'
 import Page from '../../../pages/page'
 import ResponsibleAdultPage from '../../../pages/order/about-the-device-wearer/responsible-adult-details'
-import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 const mockOrderId = uuidv4()
 
@@ -78,7 +78,7 @@ context('About the device wearer - Responsible Adult', () => {
         },
       }).should('be.true')
 
-      Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
+      Page.verifyOnPage(IdentityNumbersPage)
     })
   })
 

--- a/integration_tests/e2e/order/contact-information/no-fixed-abode.submission.cy.ts
+++ b/integration_tests/e2e/order/contact-information/no-fixed-abode.submission.cy.ts
@@ -55,7 +55,7 @@ context('Contact information', () => {
         cy.task('stubCemoVerifyRequestReceived', {
           uri: `/orders/${mockOrderId}${apiPath}`,
           body: {
-            noFixedAbode: 'true',
+            noFixedAbode: true,
           },
         }).should('be.true')
       })

--- a/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerForm.ts
+++ b/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerForm.ts
@@ -5,11 +5,6 @@ import FormRadiosComponent from '../../formRadiosComponent'
 import FormSelectComponent from '../../formSelectComponent'
 
 export type AboutDeviceWearerFormData = {
-  nomisId?: string
-  pncId?: string
-  deliusId?: string
-  prisonNumber?: string
-  homeOfficeReferenceNumber?: string
   firstNames?: string
   lastName?: string
   alias?: string
@@ -24,30 +19,6 @@ export type AboutDeviceWearerFormData = {
 export default class AboutDeviceWearerFormComponent extends FormComponent {
   // FIELDS
 
-  get nomisIdField(): FormInputComponent {
-    const label = 'National Offender Management Information System (NOMIS) ID (optional)'
-    return new FormInputComponent(this.form, label)
-  }
-
-  get pncIdField(): FormInputComponent {
-    const label = 'Police National Computer (PNC) ID (optional)'
-    return new FormInputComponent(this.form, label)
-  }
-
-  get deliusIdField(): FormInputComponent {
-    const label = 'Delius ID (optional)'
-    return new FormInputComponent(this.form, label)
-  }
-
-  get prisonNumberField(): FormInputComponent {
-    const label = 'Prison Number (Optional)'
-    return new FormInputComponent(this.form, label)
-  }
-
-  get homeOfficeReferenceNumberField(): FormInputComponent {
-    const label = 'Home Office Reference Number (Optional)'
-    return new FormInputComponent(this.form, label)
-  }
   // NAMES
 
   get firstNamesField(): FormInputComponent {
@@ -248,25 +219,10 @@ export default class AboutDeviceWearerFormComponent extends FormComponent {
   // FORM HELPERS
 
   fillInWith = (profile: AboutDeviceWearerFormData): undefined => {
-    if (profile.nomisId) {
-      this.nomisIdField.set(profile.nomisId)
-    }
-    if (profile.pncId) {
-      this.pncIdField.set(profile.pncId)
-    }
-    if (profile.deliusId) {
-      this.deliusIdField.set(profile.deliusId)
-    }
-    if (profile.prisonNumber) {
-      this.prisonNumberField.set(profile.prisonNumber)
-    }
-    if (profile.homeOfficeReferenceNumber) {
-      this.homeOfficeReferenceNumberField.set(profile.homeOfficeReferenceNumber)
-    }
-
     if (profile.firstNames) {
       this.firstNamesField.set(profile.firstNames)
     }
+
     if (profile.lastName) {
       this.lastNameField.set(profile.lastName)
     }

--- a/integration_tests/pages/components/forms/about-the-device-wearer/identityNumbersForm.ts
+++ b/integration_tests/pages/components/forms/about-the-device-wearer/identityNumbersForm.ts
@@ -1,0 +1,87 @@
+import FormComponent from '../../formComponent'
+import FormInputComponent from '../../formInputComponent'
+
+export type IdentityNumbersFormData = {
+  nomisId?: string
+  pncId?: string
+  deliusId?: string
+  prisonNumber?: string
+  homeOfficeReferenceNumber?: string
+}
+
+export default class IdentityNumbersFormComponent extends FormComponent {
+  // FIELDS
+
+  get nomisIdField(): FormInputComponent {
+    const label = 'National Offender Management Information System (NOMIS) ID (optional)'
+    return new FormInputComponent(this.form, label)
+  }
+
+  get pncIdField(): FormInputComponent {
+    const label = 'Police National Computer (PNC) ID (optional)'
+    return new FormInputComponent(this.form, label)
+  }
+
+  get deliusIdField(): FormInputComponent {
+    const label = 'Delius ID (optional)'
+    return new FormInputComponent(this.form, label)
+  }
+
+  get prisonNumberField(): FormInputComponent {
+    const label = 'Prison Number (Optional)'
+    return new FormInputComponent(this.form, label)
+  }
+
+  get homeOfficeReferenceNumberField(): FormInputComponent {
+    const label = 'Home Office Reference Number (Optional)'
+    return new FormInputComponent(this.form, label)
+  }
+
+  // FORM HELPERS
+
+  fillInWith = (profile: IdentityNumbersFormData): undefined => {
+    if (profile.nomisId) {
+      this.nomisIdField.set(profile.nomisId)
+    }
+
+    if (profile.pncId) {
+      this.pncIdField.set(profile.pncId)
+    }
+
+    if (profile.deliusId) {
+      this.deliusIdField.set(profile.deliusId)
+    }
+
+    if (profile.prisonNumber) {
+      this.prisonNumberField.set(profile.prisonNumber)
+    }
+
+    if (profile.homeOfficeReferenceNumber) {
+      this.homeOfficeReferenceNumberField.set(profile.homeOfficeReferenceNumber)
+    }
+  }
+
+  shouldBeValid(): void {
+    this.nomisIdField.shouldNotHaveValidationMessage()
+    this.pncIdField.shouldNotHaveValidationMessage()
+    this.deliusIdField.shouldNotHaveValidationMessage()
+    this.prisonNumberField.shouldNotHaveValidationMessage()
+    this.homeOfficeReferenceNumberField.shouldNotHaveValidationMessage()
+  }
+
+  shouldBeDisabled(): void {
+    this.nomisIdField.shouldBeDisabled()
+    this.pncIdField.shouldBeDisabled()
+    this.deliusIdField.shouldBeDisabled()
+    this.prisonNumberField.shouldBeDisabled()
+    this.homeOfficeReferenceNumberField.shouldBeDisabled()
+  }
+
+  shouldNotBeDisabled(): void {
+    this.nomisIdField.shouldNotBeDisabled()
+    this.pncIdField.shouldNotBeDisabled()
+    this.deliusIdField.shouldNotBeDisabled()
+    this.prisonNumberField.shouldNotBeDisabled()
+    this.homeOfficeReferenceNumberField.shouldNotBeDisabled()
+  }
+}

--- a/integration_tests/pages/order/about-the-device-wearer/identity-numbers.ts
+++ b/integration_tests/pages/order/about-the-device-wearer/identity-numbers.ts
@@ -1,0 +1,13 @@
+import AppFormPage from '../../appFormPage'
+
+import paths from '../../../../server/constants/paths'
+
+import IdentityNumbersFormComponent from '../../components/forms/about-the-device-wearer/identityNumbersForm'
+
+export default class IdentityNumbersPage extends AppFormPage {
+  form = new IdentityNumbersFormComponent()
+
+  constructor() {
+    super('Identity numbers', paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS, '')
+  }
+}

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO003 - AAMR Post Release.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO003 - AAMR Post Release.cy.ts
@@ -19,6 +19,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -92,6 +93,10 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(deviceWearerDetails)
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
@@ -19,6 +19,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -94,6 +95,10 @@ context('Scenarios', () => {
         const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
         aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
         aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+        const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+        identityNumbersPage.form.fillInWith(deviceWearerDetails)
+        identityNumbersPage.form.saveAndContinueButton.click()
 
         const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
         deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO013 - AML Post Release.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO013 - AML Post Release.cy.ts
@@ -19,6 +19,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -92,6 +93,10 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(deviceWearerDetails)
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO001 - RF - 7 nights - single attachment.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO001 - RF - 7 nights - single attachment.cy.ts
@@ -21,6 +21,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -114,6 +115,10 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(deviceWearerDetails)
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO002 - RF - 7 nights - single attachment.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO002 - RF - 7 nights - single attachment.cy.ts
@@ -21,6 +21,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -114,6 +115,10 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(deviceWearerDetails)
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO005 - RF - weekend only - mandatory information missing.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO005 - RF - weekend only - mandatory information missing.cy.ts
@@ -21,6 +21,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -130,6 +131,10 @@ context('Scenarios', () => {
         const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
         aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
         aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+        const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+        identityNumbersPage.form.fillInWith(deviceWearerDetails)
+        identityNumbersPage.form.saveAndContinueButton.click()
 
         const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
         deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO009 -  Immigration with GPS tag.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO009 -  Immigration with GPS tag.cy.ts
@@ -19,6 +19,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -90,6 +91,10 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(deviceWearerDetails)
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO010 -  Immigration with Location with Non Fitted Device.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO010 -  Immigration with Location with Non Fitted Device.cy.ts
@@ -19,6 +19,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -90,6 +91,10 @@ context('Scenarios', () => {
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(deviceWearerDetails)
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO008 - suspended community sentence - weekend only 7pm-7am.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO008 - suspended community sentence - weekend only 7pm-7am.cy.ts
@@ -27,6 +27,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -139,6 +140,10 @@ context('Scenarios', () => {
       const responsibleAdultDetailsPage = Page.verifyOnPage(ResponsibleAdultDetailsPage)
       responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
       responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(deviceWearerDetails)
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO015 - DAPOL pre-trial - weekday only 7pm-7am.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO015 - DAPOL pre-trial - weekday only 7pm-7am.cy.ts
@@ -28,6 +28,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -146,6 +147,10 @@ context('Scenarios', () => {
         const responsibleAdultDetailsPage = Page.verifyOnPage(ResponsibleAdultDetailsPage)
         responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
         responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+        const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+        identityNumbersPage.form.fillInWith(deviceWearerDetails)
+        identityNumbersPage.form.saveAndContinueButton.click()
 
         const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
         deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - GPS fitted Post Release - multiple exclusion zones.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - GPS fitted Post Release - multiple exclusion zones.cy.ts
@@ -25,6 +25,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -125,6 +126,10 @@ context('Scenarios', () => {
         const responsibleAdultDetailsPage = Page.verifyOnPage(ResponsibleAdultDetailsPage)
         responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
         responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+        const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+        identityNumbersPage.form.fillInWith(deviceWearerDetails)
+        identityNumbersPage.form.saveAndContinueButton.click()
 
         const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
         deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Trail monitoring/CEMO006 - Youth Rehabilitation Order with Intensive Supervision and Surveillance with GPS tag.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Trail monitoring/CEMO006 - Youth Rehabilitation Order with Intensive Supervision and Surveillance with GPS tag.cy.ts
@@ -25,6 +25,7 @@ import { formatAsFmsDateTime } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -103,6 +104,10 @@ context('Scenarios', () => {
         const responsibleAdultDetailsPage = Page.verifyOnPage(ResponsibleAdultPage)
         responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
         responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+        const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+        identityNumbersPage.form.fillInWith(deviceWearerDetails)
+        identityNumbersPage.form.saveAndContinueButton.click()
 
         const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
         deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/kitchen-sink.cy.ts
+++ b/integration_tests/scenarios/kitchen-sink.cy.ts
@@ -26,6 +26,7 @@ import AttachmentPage from '../pages/order/attachment'
 import DeviceWearerCheckYourAnswersPage from '../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../pages/order/about-the-device-wearer/identity-numbers'
 
 context('The kitchen sink', () => {
   const takeScreenshots = true
@@ -175,6 +176,11 @@ context('The kitchen sink', () => {
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       if (takeScreenshots) cy.screenshot('03. aboutDeviceWearerPage', { overwrite: true })
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(deviceWearerDetails)
+      if (takeScreenshots) cy.screenshot('04. identityNumbersPage', { overwrite: true })
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/integration_tests/scenarios/mandatory-field-only.cy.ts
+++ b/integration_tests/scenarios/mandatory-field-only.cy.ts
@@ -31,6 +31,7 @@ import AttachmentPage from '../pages/order/attachment'
 import DeviceWearerCheckYourAnswersPage from '../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../pages/order/contact-information/check-your-answers'
+import IdentityNumbersPage from '../pages/order/about-the-device-wearer/identity-numbers'
 
 context('Mandatory fields only', () => {
   const takeScreenshots = true
@@ -69,6 +70,13 @@ context('Mandatory fields only', () => {
       interpreterRequired: false,
       contactNumber: undefined,
       hasFixedAddress: 'Yes',
+    }
+    const identityNumbers = {
+      nomisId: fullDeviceWearerDetails.nomisId,
+      deliusId: fullDeviceWearerDetails.deliusId,
+      pncId: fullDeviceWearerDetails.pncId,
+      prisonNumber: fullDeviceWearerDetails.prisonNumber,
+      homeOfficeReferenceNumber: fullDeviceWearerDetails.homeOfficeReferenceNumber,
     }
     const fakeAddress = createFakeAddress()
     const primaryAddressDetails = {
@@ -145,6 +153,11 @@ context('Mandatory fields only', () => {
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)
       if (takeScreenshots) cy.screenshot('03. aboutDeviceWearerPage - minimum', { overwrite: true })
       aboutDeviceWearerPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(identityNumbers)
+      if (takeScreenshots) cy.screenshot('04. identityNumbersPage', { overwrite: true })
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()
@@ -293,6 +306,13 @@ context('Mandatory fields only', () => {
       contactNumber: undefined,
       hasFixedAddress: 'Yes',
     }
+    const identityNumbers = {
+      nomisId: fullDeviceWearerDetails.nomisId,
+      deliusId: fullDeviceWearerDetails.deliusId,
+      pncId: fullDeviceWearerDetails.pncId,
+      prisonNumber: fullDeviceWearerDetails.prisonNumber,
+      homeOfficeReferenceNumber: fullDeviceWearerDetails.homeOfficeReferenceNumber,
+    }
     const fakeAdult = createFakeResponsibleAdult()
     const responsibleAdultDetails = {
       relationship: fakeAdult.relationship,
@@ -382,6 +402,11 @@ context('Mandatory fields only', () => {
       responsibleAdultDetailsPage.form.fillInWith(responsibleAdultDetails)
       if (takeScreenshots) cy.screenshot('04. responsibleAdultDetailsPage - minimum', { overwrite: true })
       responsibleAdultDetailsPage.form.saveAndContinueButton.click()
+
+      const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
+      identityNumbersPage.form.fillInWith(identityNumbers)
+      if (takeScreenshots) cy.screenshot('04. identityNumbersPage', { overwrite: true })
+      identityNumbersPage.form.saveAndContinueButton.click()
 
       const deviceWearerCheckYourAnswersPage = Page.verifyOnPage(DeviceWearerCheckYourAnswersPage)
       deviceWearerCheckYourAnswersPage.continueButton().click()

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -15,6 +15,7 @@ const paths = {
     CHECK_YOUR_ANSWERS: '/order/:orderId/about-the-device-wearer/check-your-answers',
     DEVICE_WEARER: '/order/:orderId/about-the-device-wearer',
     RESPONSIBLE_ADULT: '/order/:orderId/about-the-device-wearer/responsible-adult',
+    IDENTITY_NUMBERS: '/order/:orderId/about-the-device-wearer/identity-numbers',
   },
 
   CONTACT_INFORMATION: {

--- a/server/controllers/about-the-device-wearer/deviceWearerController.test.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerController.test.ts
@@ -62,7 +62,7 @@ describe('DeviceWearerController', () => {
     jest.setSystemTime(new Date('2020-01-01'))
   })
 
-  describe('view', () => {
+  describe('viewDeviceWearer', () => {
     it('should render the form using the saved device wearer data', async () => {
       // Given
       const req = createMockRequest({ order: mockOrder, flash: jest.fn().mockReturnValue([]) })
@@ -70,29 +70,33 @@ describe('DeviceWearerController', () => {
       const next = jest.fn()
 
       // When
-      await deviceWearerController.view(req, res, next)
+      await deviceWearerController.viewDeviceWearer(req, res, next)
 
       // Then
       expect(res.render).toHaveBeenCalledWith(
         'pages/order/about-the-device-wearer/device-wearer',
         expect.objectContaining({
-          nomisId: { value: '' },
-          pncId: { value: '' },
-          deliusId: { value: '' },
-          prisonNumber: { value: '' },
-          firstName: { value: 'tester' },
-          lastName: { value: 'testington' },
-          alias: { value: 'test' },
-          dateOfBirth_day: { value: '1' },
-          dateOfBirth_month: { value: '1' },
-          dateOfBirth_year: { value: '1980' },
-          dateOfBirth: { value: '' },
-          adultAtTimeOfInstallation: { value: 'false' },
-          sex: { value: 'male' },
-          gender: { value: 'male' },
-          disabilities: { values: ['VISION', 'MOBILITY'] },
-          interpreterRequired: { value: 'true' },
-          language: { value: 'British Sign' },
+          nomisId: null,
+          pncId: null,
+          deliusId: null,
+          prisonNumber: null,
+          homeOfficeReferenceNumber: null,
+          firstName: 'tester',
+          lastName: 'testington',
+          alias: 'test',
+          dateOfBirth: {
+            day: '1',
+            month: '1',
+            year: '1980',
+          },
+          adultAtTimeOfInstallation: 'false',
+          sex: 'male',
+          gender: 'male',
+          disabilities: ['VISION', 'MOBILITY'],
+          interpreterRequired: 'true',
+          language: 'British Sign',
+          noFixedAbode: null,
+          errors: {},
         }),
       )
     })
@@ -106,16 +110,14 @@ describe('DeviceWearerController', () => {
           .mockReturnValueOnce([{ error: 'Date of birth must be in the past', field: 'dateOfBirth' }])
           .mockReturnValueOnce([
             {
-              nomisId: 'nomis',
-              pncId: 'pnc',
-              deliusId: 'delius',
-              prisonNumber: 'prison',
               firstName: 'new',
               lastName: 'name',
               alias: 'new',
-              'dateOfBirth-day': '02',
-              'dateOfBirth-month': '03',
-              'dateOfBirth-year': '1990',
+              dateOfBirth: {
+                day: '02',
+                month: '03',
+                year: '1990',
+              },
               adultAtTimeOfInstallation: 'true',
               sex: 'female',
               gender: 'female',
@@ -129,35 +131,37 @@ describe('DeviceWearerController', () => {
       const next = jest.fn()
 
       // When
-      await deviceWearerController.view(req, res, next)
+      await deviceWearerController.viewDeviceWearer(req, res, next)
 
       // Then
       expect(res.render).toHaveBeenCalledWith(
         'pages/order/about-the-device-wearer/device-wearer',
         expect.objectContaining({
-          nomisId: { value: 'nomis' },
-          pncId: { value: 'pnc' },
-          deliusId: { value: 'delius' },
-          prisonNumber: { value: 'prison' },
-          firstName: { value: 'new' },
-          lastName: { value: 'name' },
-          alias: { value: 'new' },
-          dateOfBirth_day: { value: '02' },
-          dateOfBirth_month: { value: '03' },
-          dateOfBirth_year: { value: '1990' },
-          dateOfBirth: { value: '', error: { text: 'Date of birth must be in the past' } },
-          adultAtTimeOfInstallation: { value: 'true' },
-          sex: { value: 'female' },
-          gender: { value: 'female' },
-          disabilities: { values: ['VISION', 'MOBILITY'] },
-          interpreterRequired: { value: 'true' },
-          language: { value: 'British Sign' },
+          firstName: 'new',
+          lastName: 'name',
+          alias: 'new',
+          dateOfBirth: {
+            day: '02',
+            month: '03',
+            year: '1990',
+          },
+          adultAtTimeOfInstallation: 'true',
+          sex: 'female',
+          gender: 'female',
+          disabilities: ['VISION', 'MOBILITY'],
+          interpreterRequired: 'true',
+          language: 'British Sign',
+          errors: {
+            dateOfBirth: {
+              text: 'Date of birth must be in the past',
+            },
+          },
         }),
       )
     })
   })
 
-  describe('update', () => {
+  describe('updateDeviceWearer', () => {
     it('should persist data and redirect to the form when the user submits invalid values', async () => {
       // Given
       const order = getMockOrder()
@@ -165,17 +169,14 @@ describe('DeviceWearerController', () => {
         order,
         body: {
           action: 'continue',
-          nomisId: 'nomis',
-          pncId: 'pnc',
-          deliusId: 'delius',
-          prisonNumber: 'prison',
-          homeOfficeReferenceNumber: 'homeoffice',
           firstName: 'new',
           lastName: 'name',
           alias: 'new',
-          'dateOfBirth-day': '02',
-          'dateOfBirth-month': '03',
-          'dateOfBirth-year': '1990',
+          dateOfBirth: {
+            day: '02',
+            month: '03',
+            year: '1990',
+          },
           adultAtTimeOfInstallation: 'true',
           sex: 'female',
           gender: 'female',
@@ -195,22 +196,19 @@ describe('DeviceWearerController', () => {
       ])
 
       // When
-      await deviceWearerController.update(req, res, next)
+      await deviceWearerController.updateDeviceWearer(req, res, next)
 
       // Then
       expect(req.flash).toHaveBeenCalledTimes(2)
       expect(req.flash).toHaveBeenNthCalledWith(1, 'formData', {
-        nomisId: 'nomis',
-        pncId: 'pnc',
-        deliusId: 'delius',
-        prisonNumber: 'prison',
-        homeOfficeReferenceNumber: 'homeoffice',
         firstName: 'new',
         lastName: 'name',
         alias: 'new',
-        'dateOfBirth-day': '02',
-        'dateOfBirth-month': '03',
-        'dateOfBirth-year': '1990',
+        dateOfBirth: {
+          day: '02',
+          month: '03',
+          year: '1990',
+        },
         adultAtTimeOfInstallation: 'true',
         sex: 'female',
         gender: 'female',
@@ -227,7 +225,7 @@ describe('DeviceWearerController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer`)
     })
 
-    it('should save and redirect to the device wearer check your answers page if the device wearer is an adult', async () => {
+    it('should save and redirect to the identity numbers page if the device wearer is an adult', async () => {
       // Given
       const order = getMockOrder()
       const req = createMockRequest({
@@ -242,9 +240,11 @@ describe('DeviceWearerController', () => {
           firstName: 'new',
           lastName: 'name',
           alias: 'new',
-          'dateOfBirth-day': '02',
-          'dateOfBirth-month': '03',
-          'dateOfBirth-year': '1990',
+          dateOfBirth: {
+            day: '02',
+            month: '03',
+            year: '1990',
+          },
           adultAtTimeOfInstallation: 'true',
           sex: 'female',
           gender: 'female',
@@ -276,11 +276,11 @@ describe('DeviceWearerController', () => {
       })
 
       // When
-      await deviceWearerController.update(req, res, next)
+      await deviceWearerController.updateDeviceWearer(req, res, next)
 
       // Then
       expect(req.flash).not.toHaveBeenCalled()
-      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/check-your-answers`)
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/identity-numbers`)
     })
 
     it('should save and redirect to the responsible adult page if the device wearer is not an adult', async () => {
@@ -298,9 +298,11 @@ describe('DeviceWearerController', () => {
           firstName: 'new',
           lastName: 'name',
           alias: 'new',
-          'dateOfBirth-day': '02',
-          'dateOfBirth-month': '03',
-          'dateOfBirth-year': '1990',
+          dateOfBirth: {
+            day: '02',
+            month: '03',
+            year: '1990',
+          },
           adultAtTimeOfInstallation: 'true',
           sex: 'female',
           gender: 'female',
@@ -332,7 +334,7 @@ describe('DeviceWearerController', () => {
       })
 
       // When
-      await deviceWearerController.update(req, res, next)
+      await deviceWearerController.updateDeviceWearer(req, res, next)
 
       // Then
       expect(req.flash).not.toHaveBeenCalled()
@@ -354,9 +356,11 @@ describe('DeviceWearerController', () => {
           firstName: 'new',
           lastName: 'name',
           alias: 'new',
-          'dateOfBirth-day': '02',
-          'dateOfBirth-month': '03',
-          'dateOfBirth-year': '1990',
+          dateOfBirth: {
+            day: '02',
+            month: '03',
+            year: '1990',
+          },
           adultAtTimeOfInstallation: 'true',
           sex: 'female',
           gender: 'female',
@@ -391,7 +395,168 @@ describe('DeviceWearerController', () => {
       })
 
       // When
-      await deviceWearerController.update(req, res, next)
+      await deviceWearerController.updateDeviceWearer(req, res, next)
+
+      // Then
+      expect(req.flash).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/summary`)
+    })
+  })
+
+  describe('viewIdentityNumbers', () => {
+    it('should render the form using the saved device wearer data', async () => {
+      // Given
+      const req = createMockRequest({ order: mockOrder, flash: jest.fn().mockReturnValue([]) })
+      const res = createMockResponse()
+      const next = jest.fn()
+
+      // When
+      await deviceWearerController.viewIdentityNumbers(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/order/about-the-device-wearer/identity-numbers',
+        expect.objectContaining({
+          nomisId: null,
+          pncId: null,
+          deliusId: null,
+          prisonNumber: null,
+          homeOfficeReferenceNumber: null,
+          firstName: 'tester',
+          lastName: 'testington',
+          alias: 'test',
+          dateOfBirth: {
+            day: '1',
+            month: '1',
+            year: '1980',
+          },
+          adultAtTimeOfInstallation: 'false',
+          sex: 'male',
+          gender: 'male',
+          disabilities: ['VISION', 'MOBILITY'],
+          interpreterRequired: 'true',
+          language: 'British Sign',
+          noFixedAbode: null,
+          errors: {},
+        }),
+      )
+    })
+  })
+
+  describe('updateIdentityNumbers', () => {
+    it('should save and redirect to the device wearer check your answers page', async () => {
+      // Given
+      const order = getMockOrder()
+      const req = createMockRequest({
+        order,
+        body: {
+          action: 'continue',
+          nomisId: 'nomis',
+          pncId: 'pnc',
+          deliusId: 'delius',
+          prisonNumber: 'prison',
+          homeOfficeReferenceNumber: 'homeoffice',
+          firstName: 'new',
+          lastName: 'name',
+          alias: 'new',
+          dateOfBirth: {
+            day: '02',
+            month: '03',
+            year: '1990',
+          },
+          adultAtTimeOfInstallation: 'true',
+          sex: 'female',
+          gender: 'female',
+          disabilities: ['VISION', 'MOBILITY'],
+          interpreterRequired: 'true',
+          language: 'British Sign',
+        },
+        flash: jest.fn(),
+      })
+      const res = createMockResponse()
+      const next = jest.fn()
+      mockDeviceWearerService.updateIdentityNumbers.mockResolvedValue({
+        nomisId: 'nomis',
+        pncId: 'pnc',
+        deliusId: 'delius',
+        prisonNumber: 'prison',
+        homeOfficeReferenceNumber: 'homeoffice',
+        firstName: 'tester',
+        lastName: 'testington',
+        alias: 'test',
+        dateOfBirth: '1980-01-01T00:00:00.000Z',
+        adultAtTimeOfInstallation: true,
+        sex: 'male',
+        gender: 'male',
+        disabilities: ['VISION', 'MOBILITY'],
+        noFixedAbode: null,
+        interpreterRequired: true,
+        language: 'British Sign',
+      })
+
+      // When
+      await deviceWearerController.updateIdentityNumbers(req, res, next)
+
+      // Then
+      expect(req.flash).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/check-your-answers`)
+    })
+
+    it('should save and redirect to the order summary page if the user chooses', async () => {
+      // Given
+      const order = getMockOrder()
+      const req = createMockRequest({
+        order,
+        body: {
+          action: 'back',
+          nomisId: 'nomis',
+          pncId: 'pnc',
+          deliusId: 'delius',
+          homeOfficeReferenceNumber: 'homeoffice',
+          prisonNumber: 'prison',
+          firstName: 'new',
+          lastName: 'name',
+          alias: 'new',
+          dateOfBirth: {
+            day: '02',
+            month: '03',
+            year: '1990',
+          },
+          adultAtTimeOfInstallation: 'true',
+          sex: 'female',
+          gender: 'female',
+          disabilities: ['VISION', 'MOBILITY'],
+          interpreterRequired: 'true',
+          language: 'British Sign',
+        },
+        params: {
+          orderId: order.id,
+        },
+        flash: jest.fn(),
+      })
+      const res = createMockResponse()
+      const next = jest.fn()
+      mockDeviceWearerService.updateIdentityNumbers.mockResolvedValue({
+        nomisId: 'nomis',
+        pncId: 'pnc',
+        deliusId: 'delius',
+        homeOfficeReferenceNumber: 'homeoffice',
+        prisonNumber: 'prison',
+        firstName: 'tester',
+        lastName: 'testington',
+        alias: 'test',
+        dateOfBirth: '1980-01-01T00:00:00.000Z',
+        adultAtTimeOfInstallation: true,
+        sex: 'male',
+        gender: 'male',
+        disabilities: ['VISION', 'MOBILITY'],
+        noFixedAbode: null,
+        interpreterRequired: true,
+        language: 'British Sign',
+      })
+
+      // When
+      await deviceWearerController.updateIdentityNumbers(req, res, next)
 
       // Then
       expect(req.flash).not.toHaveBeenCalled()

--- a/server/controllers/about-the-device-wearer/deviceWearerController.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerController.ts
@@ -1,65 +1,11 @@
 import { Request, RequestHandler, Response } from 'express'
-import z from 'zod'
 import paths from '../../constants/paths'
-import { DeviceWearer } from '../../models/DeviceWearer'
-import { isValidationResult, ValidationResult } from '../../models/Validation'
-import { MultipleChoiceField, TextField } from '../../models/view-models/utils'
-import { AuditService, DeviceWearerService } from '../../services'
-import { deserialiseDate, getError } from '../../utils/utils'
+import { isValidationResult } from '../../models/Validation'
+import { DeviceWearerFormDataParser, IdentityNumbersFormDataModel } from '../../models/form-data/deviceWearer'
+import createViewModel from '../../models/view-models/deviceWearer'
+import AuditService from '../../services/auditService'
+import DeviceWearerService from '../../services/deviceWearerService'
 import TaskListService from '../../services/taskListService'
-
-// Basic validation of user submitted form data
-const DeviceWearerFormDataModel = z.object({
-  action: z.string(),
-  nomisId: z.string(),
-  pncId: z.string(),
-  deliusId: z.string(),
-  prisonNumber: z.string(),
-  homeOfficeReferenceNumber: z.string(),
-  firstName: z.string(),
-  lastName: z.string(),
-  alias: z.string(),
-  'dateOfBirth-day': z.string(),
-  'dateOfBirth-month': z.string(),
-  'dateOfBirth-year': z.string(),
-  language: z.string(),
-  interpreterRequired: z.string().default(''),
-  adultAtTimeOfInstallation: z.string().default(''),
-  sex: z.string().default(''),
-  gender: z.string().default(''),
-  otherGender: z.string().optional(),
-  disabilities: z
-    .union([z.string(), z.array(z.string()).default([])])
-    .transform(val => (Array.isArray(val) ? val : [val])),
-  otherDisability: z.string().optional(),
-})
-
-type DeviceWearerFormData = z.infer<typeof DeviceWearerFormDataModel>
-
-type DeviceWearerViewModel = {
-  formActionUri: string
-  orderSummaryUri: string
-  nomisId: TextField
-  pncId: TextField
-  deliusId: TextField
-  prisonNumber: TextField
-  homeOfficeReferenceNumber: TextField
-  firstName: TextField
-  lastName: TextField
-  alias: TextField
-  dateOfBirth_day: TextField
-  dateOfBirth_month: TextField
-  dateOfBirth_year: TextField
-  dateOfBirth: TextField
-  adultAtTimeOfInstallation: TextField
-  sex: TextField
-  gender: TextField
-  otherGender: TextField
-  disabilities: MultipleChoiceField
-  otherDisability: TextField
-  language: TextField
-  interpreterRequired: TextField
-}
 
 export default class DeviceWearerController {
   constructor(
@@ -68,124 +14,89 @@ export default class DeviceWearerController {
     private readonly taskListService: TaskListService,
   ) {}
 
-  private createViewModelFromFormData(
-    formData: DeviceWearerFormData,
-    validationErrors: ValidationResult,
-    orderId: string,
-  ): DeviceWearerViewModel {
-    return {
-      formActionUri: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', orderId),
-      orderSummaryUri: paths.ORDER.SUMMARY.replace(':orderId', orderId),
-      nomisId: { value: formData.nomisId, error: getError(validationErrors, 'nomisId') },
-      pncId: { value: formData.pncId, error: getError(validationErrors, 'pncId') },
-      deliusId: { value: formData.deliusId, error: getError(validationErrors, 'deliusId') },
-      prisonNumber: { value: formData.prisonNumber, error: getError(validationErrors, 'prisonNumber') },
-      homeOfficeReferenceNumber: {
-        value: formData.homeOfficeReferenceNumber,
-        error: getError(validationErrors, 'homeOfficeReferenceNumber'),
-      },
-      firstName: { value: formData.firstName, error: getError(validationErrors, 'firstName') },
-      lastName: { value: formData.lastName, error: getError(validationErrors, 'lastName') },
-      alias: { value: formData.alias, error: getError(validationErrors, 'alias') },
-      dateOfBirth_day: { value: formData['dateOfBirth-day'] },
-      dateOfBirth_month: { value: formData['dateOfBirth-month'] },
-      dateOfBirth_year: { value: formData['dateOfBirth-year'] },
-      dateOfBirth: { value: '', error: getError(validationErrors, 'dateOfBirth') },
-      adultAtTimeOfInstallation: {
-        value: formData.adultAtTimeOfInstallation || '',
-        error: getError(validationErrors, 'adultAtTimeOfInstallation'),
-      },
-      sex: { value: formData.sex || '', error: getError(validationErrors, 'sex') },
-      gender: { value: formData.gender || '', error: getError(validationErrors, 'gender') },
-      otherGender: { value: formData.otherGender || '', error: getError(validationErrors, 'otherGender') },
-      disabilities: { values: formData.disabilities || '', error: getError(validationErrors, 'disabilities') },
-      otherDisability: { value: formData.otherDisability || '', error: getError(validationErrors, 'otherDisability') },
-      language: { value: formData.language || '', error: getError(validationErrors, 'language') },
-      interpreterRequired: {
-        value: formData.interpreterRequired || '',
-        error: getError(validationErrors, 'interpreterRequired'),
-      },
-    }
-  }
-
-  private createViewModelFromDeviceWearer(deviceWearer: DeviceWearer, orderId: string): DeviceWearerViewModel {
-    const [year, month, day] = deserialiseDate(deviceWearer.dateOfBirth || '')
-
-    return {
-      formActionUri: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', orderId),
-      orderSummaryUri: paths.ORDER.SUMMARY.replace(':orderId', orderId),
-      nomisId: { value: deviceWearer.nomisId || '' },
-      pncId: { value: deviceWearer.pncId || '' },
-      deliusId: { value: deviceWearer.deliusId || '' },
-      prisonNumber: { value: deviceWearer.prisonNumber || '' },
-      homeOfficeReferenceNumber: { value: deviceWearer.homeOfficeReferenceNumber || '' },
-      firstName: { value: deviceWearer.firstName || '' },
-      lastName: { value: deviceWearer.lastName || '' },
-      alias: { value: deviceWearer.alias || '' },
-      dateOfBirth_day: { value: day },
-      dateOfBirth_month: { value: month },
-      dateOfBirth_year: { value: year },
-      dateOfBirth: {
-        value: '',
-      },
-      adultAtTimeOfInstallation: { value: String(deviceWearer.adultAtTimeOfInstallation) },
-      sex: { value: deviceWearer.sex || '' },
-      gender: { value: deviceWearer.gender || '' },
-      otherGender: { value: deviceWearer.otherGender || '' },
-      disabilities: { values: deviceWearer.disabilities ?? [] },
-      otherDisability: { value: deviceWearer.otherDisability || '' },
-      language: { value: deviceWearer.language || '' },
-      interpreterRequired: { value: String(deviceWearer.interpreterRequired) || '' },
-    }
-  }
-
-  private constructViewModel(
-    deviceWearer: DeviceWearer,
-    validationErrors: ValidationResult,
-    formData: [DeviceWearerFormData],
-    orderId: string,
-  ): DeviceWearerViewModel {
-    if (validationErrors.length > 0 && formData.length > 0) {
-      return this.createViewModelFromFormData(formData[0], validationErrors, orderId)
-    }
-
-    return this.createViewModelFromDeviceWearer(deviceWearer, orderId)
-  }
-
-  view: RequestHandler = async (req: Request, res: Response) => {
-    const { orderId } = req.params
-    const { deviceWearer } = req.order!
+  viewDeviceWearer: RequestHandler = async (req: Request, res: Response) => {
+    const order = req.order!
     const errors = req.flash('validationErrors')
     const formData = req.flash('formData')
-    const viewModel = this.constructViewModel(deviceWearer, errors as never, formData as never, orderId)
 
-    res.render(`pages/order/about-the-device-wearer/device-wearer`, viewModel)
+    res.render(
+      'pages/order/about-the-device-wearer/device-wearer',
+      createViewModel(
+        order.deviceWearer,
+        formData.length > 0 ? (formData[0] as never) : ({} as never),
+        errors as never,
+      ),
+    )
   }
 
-  update: RequestHandler = async (req: Request, res: Response) => {
+  updateDeviceWearer: RequestHandler = async (req: Request, res: Response) => {
     const { orderId } = req.params
-    const { action, ...formData } = DeviceWearerFormDataModel.parse(req.body)
+    const { action, ...formData } = DeviceWearerFormDataParser.parse(req.body)
 
-    const updateDeviceWearerResult = await this.deviceWearerService.updateDeviceWearer({
+    const result = await this.deviceWearerService.updateDeviceWearer({
       accessToken: res.locals.user.token,
       orderId,
       data: formData,
     })
 
-    if (isValidationResult(updateDeviceWearerResult)) {
+    if (isValidationResult(result)) {
       req.flash('formData', formData)
-      req.flash('validationErrors', updateDeviceWearerResult)
+      req.flash('validationErrors', result)
 
       res.redirect(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', orderId))
     } else if (action === 'continue') {
       res.redirect(
         this.taskListService.getNextPage('DEVICE_WEARER', {
           ...req.order!,
-          deviceWearer: updateDeviceWearerResult,
+          deviceWearer: result,
         }),
       )
     } else {
       res.redirect(paths.ORDER.SUMMARY.replace(':orderId', orderId))
+    }
+  }
+
+  viewIdentityNumbers: RequestHandler = async (req, res) => {
+    const { deviceWearer } = req.order!
+    const errors = req.flash('validationErrors')
+    const formData = req.flash('formData')
+
+    res.render(
+      'pages/order/about-the-device-wearer/identity-numbers',
+      createViewModel(
+        {
+          ...deviceWearer,
+          ...(formData.length > 0 ? (formData[0] as never) : {}),
+        },
+        {} as never,
+        errors as never,
+      ),
+    )
+  }
+
+  updateIdentityNumbers: RequestHandler = async (req, res) => {
+    const order = req.order!
+    const { action, ...formData } = IdentityNumbersFormDataModel.parse(req.body)
+
+    const result = await this.deviceWearerService.updateIdentityNumbers({
+      accessToken: res.locals.user.token,
+      orderId: order.id,
+      data: formData,
+    })
+
+    if (isValidationResult(result)) {
+      req.flash('formData', formData)
+      req.flash('validationErrors', result)
+      res.redirect(paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id))
+    } else if (action === 'continue') {
+      res.redirect(
+        this.taskListService.getNextPage('IDENTITY_NUMBERS', {
+          ...order,
+          deviceWearer: result,
+        }),
+      )
+    } else {
+      res.redirect(paths.ORDER.SUMMARY.replace(':orderId', order.id))
     }
   }
 }

--- a/server/controllers/about-the-device-wearer/deviceWearerResponsibleAdultController.test.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerResponsibleAdultController.test.ts
@@ -185,7 +185,7 @@ describe('DeviceWearerResponsibleAdultController', () => {
 
       // Then
       expect(req.flash).not.toHaveBeenCalled()
-      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/check-your-answers`)
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/identity-numbers`)
     })
   })
 

--- a/server/controllers/contact-information/noFixedAbodeController.ts
+++ b/server/controllers/contact-information/noFixedAbodeController.ts
@@ -6,10 +6,11 @@ import DeviceWearerService from '../../services/deviceWearerService'
 import { getErrorsViewModel } from '../../utils/utils'
 import { isValidationResult } from '../../models/Validation'
 import TaskListService from '../../services/taskListService'
+import { BooleanInputModel } from '../../models/form-data/formData'
 
 const FormDataModel = z.object({
   action: z.string().default('continue'),
-  noFixedAbode: z.string().default(''),
+  noFixedAbode: BooleanInputModel,
 })
 
 export default class NoFixedAbodeController {

--- a/server/models/DeviceWearer.ts
+++ b/server/models/DeviceWearer.ts
@@ -36,8 +36,9 @@ const DeviceWearerModel = z.object({
       if (disabilities === null || disabilities === '') {
         return []
       }
-      return disabilities.split(',').map(disability => DisabilityEnum.parse(disability))
-    }),
+      return disabilities.split(',')
+    })
+    .pipe(z.array(DisabilityEnum)),
   otherDisability: z.string().nullable().optional(),
   noFixedAbode: z.boolean().nullable(),
   language: z.string().nullable().optional(),
@@ -45,5 +46,6 @@ const DeviceWearerModel = z.object({
 })
 
 export type DeviceWearer = z.infer<typeof DeviceWearerModel>
+export type Disability = z.infer<typeof DisabilityEnum>
 
 export default DeviceWearerModel

--- a/server/models/form-data/deviceWearer.ts
+++ b/server/models/form-data/deviceWearer.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod'
+import { BooleanInputModel, DateInputModel, FormDataModel, MultipleChoiceInputModel } from './formData'
+import { DisabilityEnum } from '../DeviceWearer'
+
+// Parse html form data to ensure basic type safety at runtime
+const DeviceWearerFormDataParser = FormDataModel.extend({
+  firstName: z.string(),
+  lastName: z.string(),
+  alias: z.string(),
+  dateOfBirth: z.object({
+    day: z.string(),
+    month: z.string(),
+    year: z.string(),
+  }),
+  language: z.string(),
+  interpreterRequired: z.string().default(''),
+  adultAtTimeOfInstallation: z.string().default(''),
+  sex: z.string().default(''),
+  gender: z.string().default(''),
+  otherGender: z.string().optional(),
+  disabilities: MultipleChoiceInputModel.pipe(z.array(DisabilityEnum)),
+  otherDisability: z.string().optional(),
+})
+
+type DeviceWearerFormData = Omit<z.infer<typeof DeviceWearerFormDataParser>, 'action'>
+
+// Validate form data on the client to ensure creation of successful api requests
+const DeviceWearerFormDataValidator = z.object({
+  firstName: z.string().min(1, 'First name is required'),
+  lastName: z.string().min(1, 'Last name is required'),
+  alias: z.string(),
+  dateOfBirth: DateInputModel.pipe(z.string({ message: 'Date of birth is required' }).datetime()),
+  language: z.string(),
+  interpreterRequired: BooleanInputModel.pipe(
+    z.boolean({
+      message: 'You must indicate whether the device wearer will require an interpreter on the day of installation',
+    }),
+  ),
+  adultAtTimeOfInstallation: BooleanInputModel.pipe(
+    z.boolean({ message: 'You must indicate whether the device wearer will be an adult at installation' }),
+  ),
+  sex: z.string().min(1, 'Sex is required'),
+  gender: z.string().min(1, 'Gender is required'),
+  otherGender: z.string().optional(),
+  disabilities: MultipleChoiceInputModel.pipe(z.array(DisabilityEnum)).transform(val => val.join(',')),
+  otherDisability: z.string().optional(),
+})
+
+// The output of validation should be an object that can be sent to the API
+type DeviceWearerApiRequestBody = z.infer<typeof DeviceWearerFormDataValidator>
+
+const IdentityNumbersFormDataModel = FormDataModel.extend({
+  nomisId: z.string(),
+  pncId: z.string(),
+  deliusId: z.string(),
+  prisonNumber: z.string(),
+  homeOfficeReferenceNumber: z.string(),
+})
+
+export {
+  DeviceWearerFormData,
+  DeviceWearerFormDataParser,
+  DeviceWearerApiRequestBody,
+  DeviceWearerFormDataValidator,
+  IdentityNumbersFormDataModel,
+}

--- a/server/models/view-models/deviceWearer.ts
+++ b/server/models/view-models/deviceWearer.ts
@@ -1,0 +1,45 @@
+import { convertBooleanToEnum, getErrorsViewModel } from '../../utils/utils'
+import { DeviceWearer } from '../DeviceWearer'
+import { DeviceWearerFormData } from '../form-data/deviceWearer'
+import { ValidationResult } from '../Validation'
+
+const deserialiseDate = (dateString: string | null) => {
+  if (dateString === null || dateString === '') {
+    return {
+      day: '',
+      month: '',
+      year: '',
+    }
+  }
+
+  const date = new Date(dateString)
+
+  return {
+    day: date.getDate().toString(),
+    month: (date.getMonth() + 1).toString(),
+    year: date.getFullYear().toString(),
+  }
+}
+
+const createViewModelFromDeviceWearer = (deviceWearer: DeviceWearer) => ({
+  ...deviceWearer,
+  adultAtTimeOfInstallation: convertBooleanToEnum(deviceWearer.adultAtTimeOfInstallation, '', 'true', 'false'),
+  dateOfBirth: deserialiseDate(deviceWearer.dateOfBirth),
+  interpreterRequired: convertBooleanToEnum(deviceWearer.interpreterRequired, '', 'true', 'false'),
+  errors: {},
+})
+
+const createViewModelFromFormData = (formData: DeviceWearerFormData, errors: ValidationResult) => ({
+  ...formData,
+  errors: getErrorsViewModel(errors),
+})
+
+const createViewModel = (deviceWearer: DeviceWearer, formData: DeviceWearerFormData, errors: ValidationResult) => {
+  if (errors.length > 0) {
+    return createViewModelFromFormData(formData, errors)
+  }
+
+  return createViewModelFromDeviceWearer(deviceWearer)
+}
+
+export default createViewModel

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -133,8 +133,12 @@ export default function routes({
    */
 
   // Device Wearer
-  get(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER, deviceWearerController.view)
-  post(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER, deviceWearerController.update)
+  get(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER, deviceWearerController.viewDeviceWearer)
+  post(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER, deviceWearerController.updateDeviceWearer)
+
+  // Identity numbers
+  get(paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS, deviceWearerController.viewIdentityNumbers)
+  post(paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS, deviceWearerController.updateIdentityNumbers)
 
   // Responsible Adult
   get(paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT, responsibleAdultController.view)

--- a/server/services/deviceWearerService.test.ts
+++ b/server/services/deviceWearerService.test.ts
@@ -1,4 +1,5 @@
 import RestClient from '../data/restClient'
+import { Disability } from '../models/DeviceWearer'
 import DeviceWearerService from './deviceWearerService'
 
 jest.mock('../data/restClient')
@@ -42,24 +43,21 @@ describe('Device wearer service', () => {
         accessToken: 'mockToken',
         orderId: 'mockUid',
         data: {
-          nomisId: '',
-          pncId: '',
-          deliusId: '',
-          prisonNumber: '',
-          homeOfficeReferenceNumber: '',
           firstName: 'First names',
           lastName: 'Surname',
           alias: '',
-          'dateOfBirth-day': '1',
-          'dateOfBirth-month': '4',
-          'dateOfBirth-year': '1996',
+          dateOfBirth: {
+            day: '1',
+            month: '4',
+            year: '1996',
+          },
           language: '',
           interpreterRequired: 'false',
           adultAtTimeOfInstallation: 'true',
           sex: 'male',
           gender: 'male',
           otherGender: '',
-          disabilities: ['MOBILITY', 'LEARNING_UNDERSTANDING_CONCENTRATING'],
+          disabilities: ['MOBILITY', 'LEARNING_UNDERSTANDING_CONCENTRATING'] as Array<Disability>,
           otherDisability: '',
         },
       }
@@ -68,18 +66,13 @@ describe('Device wearer service', () => {
 
       expect(mockRestClient.put).toHaveBeenCalledWith({
         data: {
-          nomisId: '',
-          pncId: '',
-          deliusId: '',
-          prisonNumber: '',
-          homeOfficeReferenceNumber: '',
           firstName: 'First names',
           lastName: 'Surname',
           alias: '',
           dateOfBirth: '1996-04-01T00:00:00.000Z',
-          interpreterRequired: 'false',
+          interpreterRequired: false,
           language: '',
-          adultAtTimeOfInstallation: 'true',
+          adultAtTimeOfInstallation: true,
           sex: 'male',
           gender: 'male',
           otherGender: '',

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -20,7 +20,7 @@ import TaskListService from './taskListService'
 
 describe('TaskListService', () => {
   describe('getNextPage', () => {
-    it('should return check your answers if current page is device wearer and adultAtTheTimeOfInstallation is true', () => {
+    it('should return idenity numbers if current page is device wearer and adultAtTheTimeOfInstallation is true', () => {
       // Given
       const currentPage = 'DEVICE_WEARER'
       const taskListService = new TaskListService()
@@ -32,7 +32,7 @@ describe('TaskListService', () => {
       const nextPage = taskListService.getNextPage(currentPage, order)
 
       // Then
-      expect(nextPage).toBe(paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id))
+      expect(nextPage).toBe(paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id))
     })
 
     it('should return responsible adult if current page is device wearer and adultAtTheTimeOfInstallation is false', () => {
@@ -50,9 +50,22 @@ describe('TaskListService', () => {
       expect(nextPage).toBe(paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id))
     })
 
-    it('should return check your answers if current page is responsible adult', () => {
+    it('should return idenity numbers if current page is responsible adult', () => {
       // Given
       const currentPage = 'RESPONSIBLE_ADULT'
+      const taskListService = new TaskListService()
+      const order = getMockOrder()
+
+      // When
+      const nextPage = taskListService.getNextPage(currentPage, order)
+
+      // Then
+      expect(nextPage).toBe(paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id))
+    })
+
+    it('should return check your answers if current page is idenity numbers', () => {
+      // Given
+      const currentPage = 'IDENTITY_NUMBERS'
       const taskListService = new TaskListService()
       const order = getMockOrder()
 
@@ -702,6 +715,13 @@ describe('TaskListService', () => {
           },
           {
             section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'IDENTITY_NUMBERS',
+            path: paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id),
+            state: 'OPTIONAL',
+            completed: false,
+          },
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
             name: 'CHECK_ANSWERS_DEVICE_WEARER',
             path: paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
             state: 'CHECK_YOUR_ANSWERS',
@@ -868,6 +888,7 @@ describe('TaskListService', () => {
       // Given
       const order = getMockOrder({
         deviceWearer: createDeviceWearer({
+          nomisId: '',
           firstName: '',
           noFixedAbode: true,
         }),
@@ -910,6 +931,13 @@ describe('TaskListService', () => {
             name: 'RESPONSIBLE_ADULT',
             path: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
             state: 'CANT_BE_STARTED',
+            completed: true,
+          },
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'IDENTITY_NUMBERS',
+            path: paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id),
+            state: 'OPTIONAL',
             completed: true,
           },
           {
@@ -1112,6 +1140,13 @@ describe('TaskListService', () => {
             name: 'RESPONSIBLE_ADULT',
             path: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
             state: 'REQUIRED',
+            completed: false,
+          },
+          {
+            section: 'ABOUT_THE_DEVICE_WEARER',
+            name: 'IDENTITY_NUMBERS',
+            path: paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id),
+            state: 'OPTIONAL',
             completed: false,
           },
           {

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -13,6 +13,7 @@ type Section =
 type Page =
   | 'DEVICE_WEARER'
   | 'RESPONSIBLE_ADULT'
+  | 'IDENTITY_NUMBERS'
   | 'CHECK_ANSWERS_DEVICE_WEARER'
   | 'CONTACT_DETAILS'
   | 'NO_FIXED_ABODE'
@@ -97,6 +98,14 @@ export default class TaskListService {
         'REQUIRED',
       ),
       completed: isNotNullOrUndefined(order.deviceWearerResponsibleAdult),
+    })
+
+    tasks.push({
+      section: 'ABOUT_THE_DEVICE_WEARER',
+      name: 'IDENTITY_NUMBERS',
+      path: paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS,
+      state: 'OPTIONAL',
+      completed: isNotNullOrUndefined(order.deviceWearer.nomisId),
     })
 
     tasks.push({

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -1,0 +1,13 @@
+import { ZodError } from 'zod'
+import { ValidationResult } from '../models/Validation'
+
+// eslint-disable-next-line  import/prefer-default-export
+export const convertZodErrorToValidationError = (error: ZodError): ValidationResult => {
+  return error.issues.reduce((acc, issue) => {
+    acc.push({
+      error: issue.message,
+      field: issue.path[0].toString(),
+    })
+    return acc
+  }, [] as ValidationResult)
+}

--- a/server/views/pages/order/about-the-device-wearer/device-wearer.njk
+++ b/server/views/pages/order/about-the-device-wearer/device-wearer.njk
@@ -14,74 +14,6 @@
 
   {% call govukFieldset({
     legend: {
-      text: "Identity numbers",
-      classes: "govuk-fieldset__legend--m",
-      isPageHeading: false
-    }
-  }) %}
-    {{ govukInput({
-      label: {
-        text: "National Offender Management Information System (NOMIS) ID (optional)"
-      },
-      classes: "govuk-input--width-10",
-      id: "nomis-id",
-      name: "nomisId",
-      value: nomisId.value,
-      errorMessage: nomisId.error,
-      disabled: not isOrderEditable
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Police National Computer (PNC) ID (optional)"
-      },
-      classes: "govuk-input--width-10",
-      id: "pnc-id",
-      name: "pncId",
-      value: pncId.value,
-      errorMessage: pncId.error,
-      disabled: not isOrderEditable
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Delius ID (optional)"
-      },
-      classes: "govuk-input--width-10",
-      id: "delius-id",
-      name: "deliusId",
-      value: deliusId.value,
-      errorMessage: deliusId.error,
-      disabled: not isOrderEditable
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Prison Number (Optional)"
-      },
-      classes: "govuk-input--width-10",
-      id: "prison-number",
-      name: "prisonNumber",
-      value: prisonNumber.value,
-      errorMessage: prisonNumber.error,
-      disabled: not isOrderEditable
-    }) }}
-
-    {{ govukInput({
-      label: {
-        text: "Home Office Reference Number (Optional)"
-      },
-      classes: "govuk-input--width-10",
-      id: "home-office-reference-number",
-      name: "homeOfficeReferenceNumber",
-      value: homeOfficeReferenceNumber.value,
-      errorMessage: homeOfficeReferenceNumber.error,
-      disabled: not isOrderEditable
-    }) }}
-  {% endcall %}
-
-  {% call govukFieldset({
-    legend: {
       text: "Name of the device wearer",
       classes: "govuk-fieldset__legend--m",
       isPageHeading: false
@@ -94,8 +26,8 @@
       classes: "govuk-input--width-10",
       id: "first-name",
       name: "firstName",
-      value: firstName.value,
-      errorMessage: firstName.error,
+      value: firstName,
+      errorMessage: errors.firstName,
       disabled: not isOrderEditable
     }) }}
 
@@ -106,8 +38,8 @@
       classes: "govuk-input--width-10",
       id: "last-name",
       name: "lastName",
-      value: lastName.value,
-      errorMessage: lastName.error,
+      value: lastName,
+      errorMessage: errors.lastName,
       disabled: not isOrderEditable
     }) }}
 
@@ -121,8 +53,8 @@
       classes: "govuk-input--width-10",
       id: "alias",
       name: "alias",
-      value: alias.value,
-      errorMessage: alias.error,
+      value: alias,
+      errorMessage: errors.alias,
       disabled: not isOrderEditable
     }) }}
   {% endcall %}
@@ -131,7 +63,6 @@
 
   {{ govukDateInput({
     id: "dateOfBirth",
-    namePrefix: "dateOfBirth",
     fieldset: {
       legend: {
         text: "Date of birth",
@@ -144,25 +75,31 @@
     },
     items: [
       {
-        name: "day",
+        id: "dateOfBirth-day",
+        name: "dateOfBirth[day]",
+        label: "Day",
         classes: "govuk-input--width-2",
-        value: dateOfBirth_day.value,
+        value: dateOfBirth.day,
         attributes: isDisabled
       },
       {
-        name: "month",
+        id: "dateOfBirth-month",
+        name: "dateOfBirth[month]",
+        label: "Month",
         classes: "govuk-input--width-2",
-        value: dateOfBirth_month.value,
+        value: dateOfBirth.month,
         attributes: isDisabled
       },
       {
-        name: "year",
+        id: "dateOfBirth-year",
+        name: "dateOfBirth[year]",
+        label: "Year",
         classes: "govuk-input--width-4",
-        value: dateOfBirth_year.value,
+        value: dateOfBirth.year,
         attributes: isDisabled
       }
     ],
-    errorMessage: dateOfBirth.error
+    errorMessage: errors.dateOfBirth
   }) }}
 
   {{ govukRadios({
@@ -186,8 +123,8 @@
         disabled: not isOrderEditable
       }
     ],
-    value: adultAtTimeOfInstallation.value,
-    errorMessage: adultAtTimeOfInstallation.error,
+    value: adultAtTimeOfInstallation,
+    errorMessage: errors.adultAtTimeOfInstallation,
     disabled: not isOrderEditable
   }) }}
 
@@ -225,8 +162,8 @@
         disabled: not isOrderEditable
       }
     ],
-    value: sex.value,
-    errorMessage: sex.error,
+    value: sex,
+    errorMessage: errors.sex,
     disabled: not isOrderEditable
   }) }}
 
@@ -239,9 +176,9 @@
       id: "other-gender",
       name: "otherGender",
       classes: "govuk-!-width-one-third",
-      errorMessage: otherGender.error,
+      errorMessage: errors.otherGender,
       disabled: not isOrderEditable,
-      value: otherGender.value
+      value: otherGender
       })
     }}
   {% endset %}
@@ -288,8 +225,8 @@
         disabled: not isOrderEditable
       }
     ],
-    value: gender.value,
-    errorMessage: gender.error,
+    value: gender,
+    errorMessage: errors.gender,
     disabled: not isOrderEditable
   }) }}
 
@@ -302,9 +239,9 @@
       id: "disabilities-detail",
       name: "otherDisability",
       classes: "govuk-!-width-one-third",
-      errorMessage: otherDisability.error,
+      errorMessage: errors.otherDisability,
       disabled: not isOrderEditable,
-      value: otherDisability.value
+      value: otherDisability
       })
     }}
   {% endset %}
@@ -375,8 +312,8 @@
         text: "Prefer Not to Say"
       }
     ],
-    values: disabilities.values,
-    errorMessage: disabilities.error,
+    values: disabilities,
+    errorMessage: errors.disabilities,
     disabled: not isOrderEditable
   }) }}
 
@@ -505,8 +442,8 @@
         { text: "Yoruba", value: "Yoruba" },
         { text: "Zaghawa", value: "Zaghawa" }
       ],
-      value: language.value,
-      errorMessage: language.error,
+      value: language,
+      errorMessage: errors.language,
       disabled: not isOrderEditable
     }) }}
 
@@ -530,8 +467,8 @@
           disabled: not isOrderEditable
         }
       ],
-      value: interpreterRequired.value,
-      errorMessage: interpreterRequired.error,
+      value: interpreterRequired,
+      errorMessage: errors.interpreterRequired,
       disabled: not isOrderEditable
     }) }}
   {% endcall %}

--- a/server/views/pages/order/about-the-device-wearer/identity-numbers.njk
+++ b/server/views/pages/order/about-the-device-wearer/identity-numbers.njk
@@ -1,0 +1,70 @@
+{% extends "../../../partials/form-layout.njk" %}
+
+{% set pageTitle = "Device wearer details - Identity numbers - " + applicationName %}
+{% set mainClasses = "app-container govuk-body" %}
+{% set section = "Identity numbers" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% block formInputs %}
+
+  {{ govukInput({
+    label: {
+    text: "National Offender Management Information System (NOMIS) ID (optional)"
+    },
+    classes: "govuk-input--width-10",
+    id: "nomis-id",
+    name: "nomisId",
+    value: nomisId,
+    errorMessage: errors.nomisId,
+    disabled: not isOrderEditable
+  }) }}
+
+  {{ govukInput({
+    label: {
+    text: "Police National Computer (PNC) ID (optional)"
+    },
+    classes: "govuk-input--width-10",
+    id: "pnc-id",
+    name: "pncId",
+    value: pncId,
+    errorMessage: errors.pncId,
+    disabled: not isOrderEditable
+  }) }}
+
+  {{ govukInput({
+    label: {
+    text: "Delius ID (optional)"
+    },
+    classes: "govuk-input--width-10",
+    id: "delius-id",
+    name: "deliusId",
+    value: deliusId,
+    errorMessage: errors.deliusId,
+    disabled: not isOrderEditable
+  }) }}
+
+  {{ govukInput({
+    label: {
+    text: "Prison Number (Optional)"
+    },
+    classes: "govuk-input--width-10",
+    id: "prison-number",
+    name: "prisonNumber",
+    value: prisonNumber,
+    errorMessage: errors.prisonNumber,
+    disabled: not isOrderEditable
+  }) }}
+
+  {{ govukInput({
+    label: {
+    text: "Home Office Reference Number (Optional)"
+    },
+    classes: "govuk-input--width-10",
+    id: "home-office-reference-number",
+    name: "homeOfficeReferenceNumber",
+    value: homeOfficeReferenceNumber,
+    errorMessage: errors.homeOfficeReferenceNumber,
+    disabled: not isOrderEditable
+  }) }}
+
+{% endblock %}


### PR DESCRIPTION
- Separate identity numbers into their own page
  - Including updated integration and scenario tests to match the new form flow
- Implemented full client side validation for the device wearer page (using zod)
  - Previously only date of birth was validated client side leading to scenarios where you would only get one error if the date of birth was invalid and then possibly more errors once the date of birth was valid and the form data submitted to the API
