### PR TITLE
Add delete attachment endpoint

### DIFF
--- a/integration_tests/mockApis/cemo.ts
+++ b/integration_tests/mockApis/cemo.ts
@@ -259,6 +259,19 @@ const uploadAttachment = (options: UploadAttachmentStubOptions = defaultUploadAt
     },
   })
 
+const deleteAttachment = (options: UploadAttachmentStubOptions = defaultUploadAttachmentOptions) =>
+  stubFor({
+    request: {
+      method: 'DELETE',
+      urlPattern: `/cemo/api/orders/${options.id}/document-type/${options.type}`,
+    },
+    response: {
+      status: options.httpStatus,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: options.httpStatus === 200 ? {} : { status: 400, userMessage: 'Mock Error', developerMessage: '' },
+    },
+  })
+
 type ValidationErrors = Array<{
   erorr: string
   field: string
@@ -551,6 +564,7 @@ export default {
   stubCemoUpdateContactDetails: updateContactDetails,
   stubCemoPutResponsibleAdult: putResponsibleAdult,
   stubUploadAttachment: uploadAttachment,
+  stubDeleteAttachment: deleteAttachment,
   getStubbedRequest,
   stubCemoVerifyRequestReceived,
 

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -49,6 +49,7 @@ const paths = {
     DOWNLOAD_LICENCE: '/order/:orderId/attachments/licence/:filename',
     DOWNLOAD_PHOTO_ID: '/order/:orderId/attachments/photoId/:filename',
     DELETE_LICENCE: '/order/:orderId/attachments/licence/delete',
+    DELETE_PHOTO_ID: '/order/:orderId/attachments/photoId/delete',
   },
 }
 

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -48,6 +48,7 @@ const paths = {
     PHOTO_ID: '/order/:orderId/attachments/photoId',
     DOWNLOAD_LICENCE: '/order/:orderId/attachments/licence/:filename',
     DOWNLOAD_PHOTO_ID: '/order/:orderId/attachments/photoId/:filename',
+    DELETE_LICENCE: '/order/:orderId/attachments/licence/delete',
   },
 }
 

--- a/server/controllers/attachments/attachmentController.test.ts
+++ b/server/controllers/attachments/attachmentController.test.ts
@@ -237,10 +237,13 @@ describe('AttachmentController', () => {
           orderId: mockOrder.id,
           fileType: 'LICENCE',
         })
+        expect(mockAuditService.logAuditEvent).toHaveBeenCalledWith({
+          who: 'fakeUserName',
+          correlationId: req.order?.id,
+          what: 'Delete attachment : LICENCE',
+        })
         expect(res.redirect).toHaveBeenCalledWith(`/order/${mockOrder.id}/attachments`)
       })
-
-      // TODO: Add auditing for deletion? Is this required?
     })
 
     it('should redirect to the attachments page if the user does not confirm the delete', async () => {

--- a/server/controllers/attachments/attachmentController.test.ts
+++ b/server/controllers/attachments/attachmentController.test.ts
@@ -59,6 +59,7 @@ describe('AttachmentController', () => {
         token: 'fakeUserToken',
         authSource: 'auth',
       },
+      flash: jest.fn(),
     }
 
     // @ts-expect-error stubbing res.render
@@ -269,7 +270,7 @@ describe('AttachmentController', () => {
         fileType: 'LICENCE',
       })
       expect(res.redirect).toHaveBeenCalledWith(`/order/${mockOrder.id}/attachments`)
-      expect(req.flash).toHaveBeenNthCalledWith(1, 'deletionError', 'mock error message')
+      expect(req.flash).toHaveBeenNthCalledWith(1, 'attachmentDeletionErrors', 'mock error message')
     })
   })
 })

--- a/server/controllers/attachments/attachmentController.test.ts
+++ b/server/controllers/attachments/attachmentController.test.ts
@@ -218,7 +218,7 @@ describe('AttachmentController', () => {
         expect(res.render).toHaveBeenCalledWith(
           'pages/order/attachments/delete-confirm',
           expect.objectContaining({
-            fileType: 'LICENCE',
+            fileType: 'licence',
           }),
         )
       })

--- a/server/controllers/attachments/attachmentController.test.ts
+++ b/server/controllers/attachments/attachmentController.test.ts
@@ -218,7 +218,7 @@ describe('AttachmentController', () => {
         expect(res.render).toHaveBeenCalledWith(
           'pages/order/attachments/delete-confirm',
           expect.objectContaining({
-            fileType: 'licence',
+            fileType: 'LICENCE',
           }),
         )
       })
@@ -235,7 +235,7 @@ describe('AttachmentController', () => {
         expect(mockAttachmentService.deleteAttachment).toHaveBeenCalledWith({
           accessToken: 'fakeUserToken',
           orderId: mockOrder.id,
-          fileType: 'licence',
+          fileType: 'LICENCE',
         })
         expect(res.redirect).toHaveBeenCalledWith(`/order/${mockOrder.id}/attachments`)
       })
@@ -263,7 +263,7 @@ describe('AttachmentController', () => {
       expect(mockAttachmentService.deleteAttachment).toHaveBeenCalledWith({
         accessToken: 'fakeUserToken',
         orderId: mockOrder.id,
-        fileType: 'licence',
+        fileType: 'LICENCE',
       })
       expect(res.redirect).toHaveBeenCalledWith(`/order/${mockOrder.id}/attachments`)
       expect(req.flash).toHaveBeenNthCalledWith(1, 'deletionError', 'mock error message')

--- a/server/controllers/attachments/attachmentController.ts
+++ b/server/controllers/attachments/attachmentController.ts
@@ -88,14 +88,11 @@ export default class AttachmentsController {
           correlationId: order.id,
           what: `Delete attachment : ${fileType}`,
         })
-        res.redirect(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
       } else {
-        req.flash('deletionError', result.error)
-        res.redirect(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
+        req.flash('attachmentDeletionErrors', result.error)
       }
-    } else {
-      res.redirect(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
     }
+    res.redirect(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
   }
 
   deleteLicence: RequestHandler = async (req: Request, res: Response) => {
@@ -138,11 +135,13 @@ export default class AttachmentsController {
     const order = req.order!
     const licence = order.additionalDocuments.find(doc => doc.fileType === AttachmentType.LICENCE)
     const photo = order.additionalDocuments.find(doc => doc.fileType === AttachmentType.PHOTO_ID)
+    const error = req.flash('attachmentDeletionErrors')
 
     res.render(`pages/order/attachments/view`, {
       order: { id: order.id, status: order.status },
       licenceFileName: licence?.fileName,
       photoFileName: photo?.fileName,
+      error: error && error.length > 0 ? error[0] : undefined,
     })
   }
 }

--- a/server/controllers/attachments/attachmentController.ts
+++ b/server/controllers/attachments/attachmentController.ts
@@ -79,7 +79,7 @@ export default class AttachmentsController {
       const result = await this.attachmentService.deleteAttachment({
         orderId: order.id,
         accessToken: res.locals.user.token,
-        fileType: fileType.toLocaleLowerCase(),
+        fileType,
       })
 
       if (result.ok) {

--- a/server/controllers/attachments/attachmentController.ts
+++ b/server/controllers/attachments/attachmentController.ts
@@ -83,6 +83,11 @@ export default class AttachmentsController {
       })
 
       if (result.ok) {
+        this.auditService.logAuditEvent({
+          who: res.locals.user.username,
+          correlationId: order.id,
+          what: `Delete attachment : ${fileType}`,
+        })
         res.redirect(paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id))
       } else {
         req.flash('deletionError', result.error)
@@ -97,8 +102,16 @@ export default class AttachmentsController {
     await this.delete(req, res, AttachmentType.LICENCE)
   }
 
+  deletePhotoId: RequestHandler = async (req: Request, res: Response) => {
+    await this.delete(req, res, AttachmentType.PHOTO_ID)
+  }
+
   confirmDeleteLicence: RequestHandler = async (req: Request, res: Response) => {
     await this.confirmDeleteView(req, res, 'licence')
+  }
+
+  confirmDeletePhotoId: RequestHandler = async (req: Request, res: Response) => {
+    await this.confirmDeleteView(req, res, 'photo id')
   }
 
   downloadLicence: RequestHandler = async (req: Request, res: Response) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -232,11 +232,11 @@ export default function routes({
   get(paths.ATTACHMENT.PHOTO_ID, attachmentsController.photo)
   post(paths.ATTACHMENT.PHOTO_ID, attachmentsController.uploadPhoto)
   get(paths.ATTACHMENT.DELETE_LICENCE, attachmentsController.confirmDeleteLicence)
+  get(paths.ATTACHMENT.DELETE_PHOTO_ID, attachmentsController.confirmDeletePhotoId)
   post(paths.ATTACHMENT.DELETE_LICENCE, attachmentsController.deleteLicence)
+  post(paths.ATTACHMENT.DELETE_PHOTO_ID, attachmentsController.deletePhotoId)
   get(paths.ATTACHMENT.DOWNLOAD_LICENCE, attachmentsController.downloadLicence)
   get(paths.ATTACHMENT.DOWNLOAD_PHOTO_ID, attachmentsController.downloadPhoto)
-
-  // get(paths.ATTACHMENT.DELETE_LICENCE, attachmentsController.confirmDelete)
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -231,8 +231,12 @@ export default function routes({
   post(paths.ATTACHMENT.LICENCE, attachmentsController.uploadLicence)
   get(paths.ATTACHMENT.PHOTO_ID, attachmentsController.photo)
   post(paths.ATTACHMENT.PHOTO_ID, attachmentsController.uploadPhoto)
+  get(paths.ATTACHMENT.DELETE_LICENCE, attachmentsController.confirmDeleteLicence)
+  post(paths.ATTACHMENT.DELETE_LICENCE, attachmentsController.deleteLicence)
   get(paths.ATTACHMENT.DOWNLOAD_LICENCE, attachmentsController.downloadLicence)
   get(paths.ATTACHMENT.DOWNLOAD_PHOTO_ID, attachmentsController.downloadPhoto)
+
+  // get(paths.ATTACHMENT.DELETE_LICENCE, attachmentsController.confirmDelete)
 
   return router
 }

--- a/server/services/attachmentService.ts
+++ b/server/services/attachmentService.ts
@@ -56,12 +56,12 @@ export default class AttachmentService {
         ok: true,
       }
     } catch (e) {
-      const error = e as SanitisedError
-
-      if (error.status === 500) {
+      const sanitisedError = e as SanitisedError
+      const apiError = ErrorResponseModel.parse(sanitisedError.data)
+      if (apiError.status === 400) {
         return {
           ok: false,
-          error: error.message,
+          error: apiError.userMessage || '',
         }
       }
 

--- a/server/services/attachmentService.ts
+++ b/server/services/attachmentService.ts
@@ -5,17 +5,13 @@ import ErrorResponseModel, { ErrorResponse } from '../models/ErrorResponse'
 import { SanitisedError } from '../sanitisedError'
 import Result from '../interfaces/result'
 
-type DownloadAttachmentRequestInpput = AuthenticatedRequestInput & {
+type AttachmentRequestInpput = AuthenticatedRequestInput & {
   orderId: string
   fileType: string
 }
-type UploadAttachmentRequestInput = DownloadAttachmentRequestInpput & {
+type UploadAttachmentRequestInput = AttachmentRequestInpput & {
   file: Express.Multer.File
 }
-type DeleteAttachmentRequestInpput = AuthenticatedRequestInput & {
-  orderId: string
-  fileType: string
-} // TODO: This is a duplicate of the download one - consider deduplication
 
 export default class AttachmentService {
   constructor(private readonly apiClient: RestClient) {}
@@ -42,14 +38,14 @@ export default class AttachmentService {
     }
   }
 
-  async downloadAttachment(input: DownloadAttachmentRequestInpput): Promise<Readable> {
+  async downloadAttachment(input: AttachmentRequestInpput): Promise<Readable> {
     return this.apiClient.stream({
       path: `/api/orders/${input.orderId}/document-type/${input.fileType}/raw`,
       token: input.accessToken,
     })
   }
 
-  async deleteAttachment(input: DeleteAttachmentRequestInpput): Promise<Result<void, string>> {
+  async deleteAttachment(input: AttachmentRequestInpput): Promise<Result<void, string>> {
     try {
       await this.apiClient.delete({
         path: `/api/orders/${input.orderId}/document-type/${input.fileType}`,

--- a/server/views/pages/order/attachments/delete-confirm.njk
+++ b/server/views/pages/order/attachments/delete-confirm.njk
@@ -1,0 +1,38 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "Confirm delete attachment - " + fileType %}
+{% set mainClasses = "app-container govuk-body" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/order/" + order.id + "/summary"
+  }) }}
+
+  <h1 class="govuk-heading-l">
+    Are you sure you want to delete this {{ fileType }}?
+  </h1>
+
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Back",
+        classes: "govuk-button--secondary",
+        name: "action",
+        value: "back"
+      })}}
+
+      {{ govukButton({
+        text: "Delete",
+        classes: "govuk-button--warning",
+        name: "action",
+        value: "continue"
+      })}}
+    </div>
+  </form>
+{% endblock %}

--- a/server/views/pages/order/attachments/view.njk
+++ b/server/views/pages/order/attachments/view.njk
@@ -44,14 +44,18 @@
         <dd class="govuk-summary-list__value">
           <a href="/order/{{order.id}}/attachments/licence/{{licenceFileName}}" class="govuk-link">{{licenceFileName}}</a>
         </dd>
+        <dd class="govuk-summary-list__actions">
+        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence">Change<span class="govuk-visually-hidden"> license</span></a>
+      </dd>
       {% else %}
         <dd class="govuk-summary-list__value">
           No licence document uploaded
         </dd>
-      {% endif %}
-      <dd class="govuk-summary-list__actions">
-        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence">Change<span class="govuk-visually-hidden"> license</span></a>
+        <dd class="govuk-summary-list__actions">
+        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence">Add<span class="govuk-visually-hidden"> license</span></a>
+        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence/delete">Delete<span class="govuk-visually-hidden"> license</span></a>
       </dd>
+      {% endif %}
     </div>
 
     <div class="govuk-summary-list__row">
@@ -72,6 +76,12 @@
       </dd>
     </div>
   </dl>
+
+  {{ govukButton({
+        text: "DELETE",
+        classes: "govuk-button--secondary",
+        href: "/order/" + order.id + "/attachments/licence/delete"
+      }) }}
 
   <div class="govuk-button-group">
     {% if isOrderEditable %}

--- a/server/views/pages/order/attachments/view.njk
+++ b/server/views/pages/order/attachments/view.njk
@@ -46,14 +46,14 @@
         </dd>
         <dd class="govuk-summary-list__actions">
         <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence">Change<span class="govuk-visually-hidden"> license</span></a>
+        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence/delete">Delete<span class="govuk-visually-hidden"> license</span></a>
       </dd>
       {% else %}
         <dd class="govuk-summary-list__value">
           No licence document uploaded
         </dd>
         <dd class="govuk-summary-list__actions">
-        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence">Add<span class="govuk-visually-hidden"> license</span></a>
-        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence/delete">Delete<span class="govuk-visually-hidden"> license</span></a>
+        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence">Add<span class="govuk-visually-hidden"> license</span></a>       
       </dd>
       {% endif %}
     </div>
@@ -73,16 +73,10 @@
       {% endif %}
       <dd class="govuk-summary-list__actions">
         <a class="govuk-link" href="/order/{{order.id}}/attachments/photoId">Change<span class="govuk-visually-hidden"> photo ID</span></a>
+        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence/delete">Delete<span class="govuk-visually-hidden"> license</span></a>
       </dd>
     </div>
-  </dl>
-
-  {{ govukButton({
-        text: "DELETE",
-        classes: "govuk-button--secondary",
-        href: "/order/" + order.id + "/attachments/licence/delete"
-      }) }}
-
+  </dl> 
   <div class="govuk-button-group">
     {% if isOrderEditable %}
       {{ govukButton({

--- a/server/views/pages/order/attachments/view.njk
+++ b/server/views/pages/order/attachments/view.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% block content %}
   {{ govukBackLink({
     text: "Back",
@@ -25,6 +25,17 @@
     }) }}
   {% endif %}
 
+    {% if error %}
+    {{ govukErrorSummary({
+      titleText: "Error deleting attachment",
+      errorList: [
+        {
+          text: error
+         
+        }
+      ]
+    }) }}
+  {% endif %}
   {{ mojPageHeaderActions({
     heading: {
       text: "Attach a document"
@@ -44,9 +55,11 @@
         <dd class="govuk-summary-list__value">
           <a href="/order/{{order.id}}/attachments/licence/{{licenceFileName}}" class="govuk-link">{{licenceFileName}}</a>
         </dd>
-        <dd class="govuk-summary-list__actions">
-        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence">Change<span class="govuk-visually-hidden"> license</span></a>
-        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence/delete">Delete<span class="govuk-visually-hidden"> license</span></a>
+        <dd class="govuk-summary-list__actions">        
+        {% if isOrderEditable %}
+          <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence">Change<span class="govuk-visually-hidden"> license</span></a>
+          <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence/delete">Delete<span class="govuk-visually-hidden"> license</span></a>
+        {% endif %}
       </dd>
       {% else %}
         <dd class="govuk-summary-list__value">
@@ -66,15 +79,22 @@
         <dd class="govuk-summary-list__value">
           <a href="/order/{{order.id}}/attachments/photoId/{{photoFileName}}" class="govuk-link">{{photoFileName}}</a>
         </dd>
+        <dd class="govuk-summary-list__actions">          
+            {% if isOrderEditable %}
+              <a class="govuk-link" href="/order/{{order.id}}/attachments/photoId">Change<span class="govuk-visually-hidden"> photo ID</span></a>
+              <a class="govuk-link"  href="/order/{{order.id}}/attachments/photoId/delete">Delete<span class="govuk-visually-hidden"> photo ID</span></a>
+            {% endif %}
+          
+        </dd>
       {% else %}
         <dd class="govuk-summary-list__value">
           No photo ID document uploaded
         </dd>
+         <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="/order/{{order.id}}/attachments/photoId">Add<span class="govuk-visually-hidden"> photo ID</span></a>
+        </dd>
       {% endif %}
-      <dd class="govuk-summary-list__actions">
-        <a class="govuk-link" href="/order/{{order.id}}/attachments/photoId">Change<span class="govuk-visually-hidden"> photo ID</span></a>
-        <a class="govuk-link"  href="/order/{{order.id}}/attachments/licence/delete">Delete<span class="govuk-visually-hidden"> license</span></a>
-      </dd>
+     
     </div>
   </dl> 
   <div class="govuk-button-group">


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-2892

Change action link to "Add" if no attachment for give type exist: 

![image](https://github.com/user-attachments/assets/43c3278f-70b2-43e2-94c1-281545ab3ee4)

Add "Delete" action link  to existing attachment: 

![image](https://github.com/user-attachments/assets/13e7b54f-531d-4cb4-a330-d0e2a95ebaa8)

Add delete attachment confirmation page:

![image](https://github.com/user-attachments/assets/2775c6b9-3b14-4dc6-b1ee-c208c82152f7)

Display error on attachment summary page when failed to delete attachment: 

![image](https://github.com/user-attachments/assets/101861fd-29f6-493b-8bfb-34fe9ab16c50)



