### PR TITLE
Update alarm resolution in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,4 @@ generic-service:
     unrestricted: "0.0.0.0/0"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
-
-
+  alertSeverity: hmpps-electronic-monitoring-create-an-order-dev


### PR DESCRIPTION
This will update AlertManager to use the `hmpps-electronic-monitoring-create-an-order-dev` rule to forward alarms in dev to our slack channel.
