### PR TITLE
Fix bug where no file upload causes error

### DIFF
--- a/server/controllers/attachments/attachmentController.ts
+++ b/server/controllers/attachments/attachmentController.ts
@@ -42,12 +42,12 @@ export default class AttachmentsController {
       })
     } else {
       res.redirect(`/order/${orderId}/attachments`)
+      this.auditService.logAuditEvent({
+        who: res.locals.user.username,
+        correlationId: orderId,
+        what: `Upload new attachment : ${attachment.filename}`,
+      })
     }
-    this.auditService.logAuditEvent({
-      who: res.locals.user.username,
-      correlationId: orderId,
-      what: `Upload new attachment : ${attachment.filename}`,
-    })
   }
 
   async download(req: Request, res: Response, fileType: AttachmentType) {

--- a/server/services/attachmentService.test.ts
+++ b/server/services/attachmentService.test.ts
@@ -1,0 +1,37 @@
+import RestClient from '../data/restClient'
+import AttachmentService from './attachmentService'
+
+jest.mock('../data/restClient')
+
+describe('Attachment service', () => {
+  let mockRestClient: jest.Mocked<RestClient>
+
+  beforeEach(() => {
+    mockRestClient = new RestClient('cemoApi', {
+      url: '',
+      timeout: { response: 0, deadline: 0 },
+      agent: { timeout: 0 },
+    }) as jest.Mocked<RestClient>
+  })
+
+  describe('uploadAttachment', () => {
+    it('returns an error when the user does not provide a file for upload', async () => {
+      const attachmentService = new AttachmentService(mockRestClient)
+      const uploadAttachmentRequestInput = {
+        accessToken: 'mockToken',
+        orderId: 'mockUid',
+        fileType: 'LICENCE',
+        file: undefined,
+      }
+
+      const response = await attachmentService.uploadAttachment(uploadAttachmentRequestInput)
+
+      expect(mockRestClient.post).not.toHaveBeenCalled()
+      expect(response).toEqual({
+        status: 400,
+        userMessage: 'No file uploaded.',
+        developerMessage: 'User did not upload a file.',
+      })
+    })
+  })
+})

--- a/server/services/attachmentService.ts
+++ b/server/services/attachmentService.ts
@@ -10,13 +10,21 @@ type AttachmentRequestInpput = AuthenticatedRequestInput & {
   fileType: string
 }
 type UploadAttachmentRequestInput = AttachmentRequestInpput & {
-  file: Express.Multer.File
+  file: Express.Multer.File | undefined
 }
 
 export default class AttachmentService {
   constructor(private readonly apiClient: RestClient) {}
 
   async uploadAttachment(input: UploadAttachmentRequestInput): Promise<ErrorResponse> {
+    if (input.file === undefined) {
+      return {
+        status: 400,
+        userMessage: 'No file uploaded.',
+        developerMessage: 'User did not upload a file.',
+      }
+    }
+
     try {
       await this.apiClient.postMultiPart({
         path: `/api/orders/${input.orderId}/document-type/${input.fileType}`,


### PR DESCRIPTION
### Context

Before, when no file was uploaded and save and continue was pressed, the application gave a generic error.

https://github.com/user-attachments/assets/fe1c9b7b-bd1a-4ce7-8377-dd065c72bdd3

### Changes proposed in this pull request

This PR updates the application to provide a user-friendly error message when no file is uploaded.

https://github.com/user-attachments/assets/f8f530b0-4627-4a60-9a77-9860efdbe042


