### PR TITLE
Add attachments to all relevant scenarios

### DIFF
--- a/integration_tests/mockApis/fms.ts
+++ b/integration_tests/mockApis/fms.ts
@@ -109,13 +109,12 @@ type RequestHeaders = {
 
 type VerifyStubbedRequestParams = {
   uri: string
-  request: Record<string, unknown>
   body?: unknown
   fileContents?: string
 }
 
 const stubFMSVerifyRequestReceived = (options: VerifyStubbedRequestParams) =>
-  getMatchingRequests({ ...options.request, urlPath: options.uri })
+  getMatchingRequests({ urlPath: options.uri })
     .then(response => {
       if (response?.body.requests && Array.isArray(response?.body.requests)) {
         return response.body.requests.map((request: Record<string, unknown>) => {

--- a/integration_tests/mockApis/fms.ts
+++ b/integration_tests/mockApis/fms.ts
@@ -59,7 +59,7 @@ const stubFmsUploadAttachment = (options: UploadAttachmentStubOptions) =>
         },
         file_name: {
           equalTo: options.fileName,
-        }
+        },
       },
     },
     response: {
@@ -183,18 +183,10 @@ const verifyFMSCreateMonitoringOrderRequestReceived = (options: VerifyStubbedFMS
     uri: '/fms/x_seem_cemo/monitoring_order/createMO',
   })
 
-const verifyFmsCreateAttachmentRequestReceived = (options: VerifyStubbedFMSRequestParams) => 
-  stubFMSVerifyRequestReceived({
-    ...options,
-    uri: '/fms/now/v1/attachment_csm/file',
-  })
-
-
 export default {
   stubFMSCreateDeviceWearer,
   stubFMSCreateMonitoringOrder,
   stubFmsUploadAttachment,
   verifyFMSCreateDeviceWearerRequestReceived,
   verifyFMSCreateMonitoringOrderRequestReceived,
-  verifyFmsCreateAttachmentRequestReceived
 }

--- a/integration_tests/mockApis/fms.ts
+++ b/integration_tests/mockApis/fms.ts
@@ -165,7 +165,6 @@ ${jsonDiff.diffString(expected, requests[0], { color: false })}
     })
 
 type VerifyStubbedFMSRequestParams = {
-  request: Record<string, unknown>
   body?: unknown
   fileContents?: string
 }

--- a/integration_tests/mockApis/hmppsDocumentManagement.ts
+++ b/integration_tests/mockApis/hmppsDocumentManagement.ts
@@ -5,6 +5,11 @@ import jsonDiff from 'json-diff'
 import { getMatchingRequests, stubFor } from './wiremock'
 
 type DocumentStubOptions = {
+  scenario?: {
+    name: string
+    requiredState: string
+    nextState: string
+  }
   id: string
   httpStatus: number
   response: Record<string, unknown>
@@ -23,8 +28,25 @@ const stubUploadDocument = (options: DocumentStubOptions) =>
     },
   })
 
-const stubGetDocument = (options: DocumentStubOptions) =>
-  stubFor({
+const stubGetDocument = (options: DocumentStubOptions) => {
+  if (options.scenario) {
+    return stubFor({
+      scenarioName: options.scenario.name,
+      requiredScenarioState: options.scenario.requiredState,
+      newScenarioState: options.scenario.nextState,
+      request: {
+        method: 'GET',
+        urlPattern: `/hmpps/documents/${options.id}/file`,
+      },
+      response: {
+        status: options.httpStatus,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        body: options?.response ? JSON.stringify(options?.response, null, 2) : '',
+      },
+    })
+  }
+
+  return stubFor({
     request: {
       method: 'GET',
       urlPattern: `/hmpps/documents/${options.id}/file`,
@@ -35,6 +57,7 @@ const stubGetDocument = (options: DocumentStubOptions) =>
       body: options?.response ? JSON.stringify(options?.response, null, 2) : '',
     },
   })
+}
 
 const stubDeleteDocument = (options: DocumentStubOptions) =>
   stubFor({

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
@@ -390,17 +390,8 @@ context('Scenarios', () => {
         // Verify the attachments were sent to the FMS API
         cy.wrap(null)
           .then(() => getFmsAttachmentRequests())
-          .then(requests => {
-            expect(requests).to.have.length(2, 'Could not find correct number of attachment requests')
-            expect(requests[0].body).to.eq(
-              JSON.stringify(files.photoId.contents),
-              'Incorrect file content for uploaded photo id',
-            )
-            expect(requests[1].body).to.eq(
-              JSON.stringify(files.licence.contents),
-              'Incorrect file content for uploaded licence',
-            )
-          })
+          .then(requests => requests.map(request => request.body))
+          .should('deep.equal', [JSON.stringify(files.photoId.contents), JSON.stringify(files.licence.contents)])
 
         const submitSuccessPage = Page.verifyOnPage(SubmitSuccessPage)
         submitSuccessPage.backToYourApplications.click()

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - GPS fitted Post Release - multiple exclusion zones.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - GPS fitted Post Release - multiple exclusion zones.cy.ts
@@ -26,6 +26,7 @@ import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-dev
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
 import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
+import { getFmsAttachmentRequests } from '../../../support/wiremock'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -62,6 +63,16 @@ context('Scenarios', () => {
       response: { result: [{ id: uuidv4(), message: '' }] },
     })
 
+    cy.task('stubFmsUploadAttachment', {
+      httpStatus: 200,
+      fileName: uploadFile.fileName,
+      deviceWearerId: fmsCaseId,
+      response: {
+        status: 200,
+        result: {},
+      },
+    })
+
     cy.task('stubUploadDocument', {
       id: '(.*)',
       httpStatus: 200,
@@ -72,6 +83,12 @@ context('Scenarios', () => {
         fileExtension: uploadFile.fileName.split('.')[1],
         mimeType: 'application/pdf',
       },
+    })
+
+    cy.task('stubGetDocument', {
+      id: '(.*)',
+      httpStatus: 200,
+      response: uploadFile.contents,
     })
   })
 
@@ -342,6 +359,13 @@ context('Scenarios', () => {
             })
             .should('be.true')
         })
+
+        // Verify the attachments were sent to the FMS API 
+        // (disabled: enforcement zone attachments not currently uploaded to FMS)
+        // cy.wrap(null)
+        //   .then(() => getFmsAttachmentRequests())
+        //   .then(requests => requests.map(request => request.body))
+        //   .should('deep.equal', [JSON.stringify(uploadFile.contents)])
 
         const submitSuccessPage = Page.verifyOnPage(SubmitSuccessPage)
         submitSuccessPage.backToYourApplications.click()

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - GPS fitted Post Release - multiple exclusion zones.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - GPS fitted Post Release - multiple exclusion zones.cy.ts
@@ -26,7 +26,7 @@ import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-dev
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
 import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
-import { getFmsAttachmentRequests } from '../../../support/wiremock'
+// import { getFmsAttachmentRequests } from '../../../support/wiremock'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -360,7 +360,7 @@ context('Scenarios', () => {
             .should('be.true')
         })
 
-        // Verify the attachments were sent to the FMS API 
+        // Verify the attachments were sent to the FMS API
         // (disabled: enforcement zone attachments not currently uploaded to FMS)
         // cy.wrap(null)
         //   .then(() => getFmsAttachmentRequests())

--- a/integration_tests/support/wiremock.ts
+++ b/integration_tests/support/wiremock.ts
@@ -1,0 +1,30 @@
+import { getMatchingRequests } from '../mockApis/wiremock'
+
+type GetMatchingFmsAttachmentRequestOptions = {
+  sysId: string
+  fileName: string
+  fileContent: string
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export const getMatchingFmsAttachmentRequests = (options: GetMatchingFmsAttachmentRequestOptions) => {
+  return getMatchingRequests({
+    urlPath: '/fms/now/v1/attachment_csm/file',
+    queryParameters: {
+      table_name: {
+        equalTo: 'x_serg2_ems_csm_sr_mo_new',
+      },
+      table_sys_id: {
+        equalTo: options.sysId,
+      },
+      file_name: {
+        equalTo: options.fileName,
+      },
+    },
+    bodyPatterns: [
+      {
+        equalTo: JSON.stringify(options.fileContent),
+      },
+    ],
+  }).then(response => response.body.requests)
+}

--- a/integration_tests/support/wiremock.ts
+++ b/integration_tests/support/wiremock.ts
@@ -1,30 +1,8 @@
 import { getMatchingRequests } from '../mockApis/wiremock'
 
-type GetMatchingFmsAttachmentRequestOptions = {
-  sysId: string
-  fileName: string
-  fileContent: string
-}
-
 // eslint-disable-next-line import/prefer-default-export
-export const getMatchingFmsAttachmentRequests = (options: GetMatchingFmsAttachmentRequestOptions) => {
+export const getFmsAttachmentRequests = () => {
   return getMatchingRequests({
     urlPath: '/fms/now/v1/attachment_csm/file',
-    queryParameters: {
-      table_name: {
-        equalTo: 'x_serg2_ems_csm_sr_mo_new',
-      },
-      table_sys_id: {
-        equalTo: options.sysId,
-      },
-      file_name: {
-        equalTo: options.fileName,
-      },
-    },
-    bodyPatterns: [
-      {
-        equalTo: JSON.stringify(options.fileContent),
-      },
-    ],
   }).then(response => response.body.requests)
 }


### PR DESCRIPTION
- Adds attachments to the scenarios identified to include attachment uploads
  - 1, 2, 4, 7, 11, 14
  - N.B. 7 & 11 not implemented
- CEMO014 does not verify that the attachments were sent to FMS as this functionality is not implemented in the API
