### PR TITLE
Update delete page content

### DIFF
--- a/integration_tests/e2e/order/delete-confirm.cy.ts
+++ b/integration_tests/e2e/order/delete-confirm.cy.ts
@@ -1,0 +1,57 @@
+import { v4 as uuidv4 } from 'uuid'
+import DeleteConfirmPage from '../../pages/order/delete-confirm'
+import DeleteFailedPage from '../../pages/order/delete-failed'
+import Page from '../../pages/page'
+import OrderTasksPage from '../../pages/order/summary'
+import IndexPage from '../../pages'
+import DeleteSuccessPage from '../../pages/order/delete-success'
+
+const mockOrderId = uuidv4()
+
+context('Confirm delete', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+    cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
+
+    cy.signIn()
+  })
+
+  it('Should display the page', () => {
+    cy.visit(`/order/${mockOrderId}/delete`)
+    const page = Page.verifyOnPage(DeleteConfirmPage)
+    page.header.userName().should('contain.text', 'J. Smith')
+  })
+
+  it('should have a button that links to request form summary page for download', () => {
+    cy.visit(`/order/${mockOrderId}/delete`)
+    const page = Page.verifyOnPage(DeleteConfirmPage)
+    page.backButton().should('exist')
+    page.backButton().click()
+    Page.verifyOnPage(OrderTasksPage)
+  })
+
+  it('Should redirect to delete failed page when failed to delete form', () => {
+    cy.visit(`/order/${mockOrderId}/delete`)
+    cy.task('stubDeleteOrder', { httpStatus: 500, id: mockOrderId, error: 'Error delete order' })
+    const page = Page.verifyOnPage(DeleteConfirmPage)
+    page.confirmDeleteButton().should('exist')
+    page.confirmDeleteButton().click()
+    const deleteFailedPage = Page.verifyOnPage(DeleteFailedPage)
+    deleteFailedPage.backButton().should('exist')
+    deleteFailedPage.backButton().click()
+    Page.verifyOnPage(IndexPage)
+  })
+
+  it('Should redirect to delete successful page when form deleted', () => {
+    cy.visit(`/order/${mockOrderId}/delete`)
+    cy.task('stubDeleteOrder', { httpStatus: 200, id: mockOrderId, error: '' })
+    const page = Page.verifyOnPage(DeleteConfirmPage)
+    page.confirmDeleteButton().should('exist')
+    page.confirmDeleteButton().click()
+    const deleteSuccessPage = Page.verifyOnPage(DeleteSuccessPage)
+    deleteSuccessPage.backButton().should('exist')
+    deleteSuccessPage.backButton().click()
+    Page.verifyOnPage(IndexPage)
+  })
+})

--- a/integration_tests/mockApis/cemo.ts
+++ b/integration_tests/mockApis/cemo.ts
@@ -242,6 +242,28 @@ const submitOrder = (options: SubmitOrderStubOptions) =>
     },
   })
 
+type DeleteOrderStubOptions = {
+  httpStatus: number
+  id: string
+  error: string
+}
+
+const deleteOrder = (options: DeleteOrderStubOptions) =>
+  stubFor({
+    request: {
+      method: 'DELETE',
+      urlPattern: `/cemo/api/orders/${options.id}`,
+    },
+    response: {
+      status: options.httpStatus,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody:
+        options.httpStatus === 200
+          ? {}
+          : { status: options.httpStatus, userMessage: options.error, developerMessage: '' },
+    },
+  })
+
 type UploadAttachmentStubOptions = {
   httpStatus: number
   id?: string
@@ -575,6 +597,6 @@ export default {
   stubDeleteAttachment: deleteAttachment,
   getStubbedRequest,
   stubCemoVerifyRequestReceived,
-
+  stubDeleteOrder: deleteOrder,
   resetDB,
 }

--- a/integration_tests/pages/order/delete-confirm.ts
+++ b/integration_tests/pages/order/delete-confirm.ts
@@ -1,0 +1,14 @@
+import AppPage from '../appPage'
+
+import paths from '../../../server/constants/paths'
+import { PageElement } from '../page'
+
+export default class DeleteConfirmPage extends AppPage {
+  constructor() {
+    super(' Are you sure you want to delete this form?', paths.ORDER.DELETE)
+  }
+
+  confirmDeleteButton = (): PageElement => cy.get('#confirm-delete-button')
+
+  backButton = (): PageElement => cy.get('#back-button')
+}

--- a/integration_tests/pages/order/delete-failed.ts
+++ b/integration_tests/pages/order/delete-failed.ts
@@ -1,0 +1,12 @@
+import AppPage from '../appPage'
+
+import paths from '../../../server/constants/paths'
+import { PageElement } from '../page'
+
+export default class DeleteFailedPage extends AppPage {
+  constructor() {
+    super('You cannot delete an application that has been submitted', paths.ORDER.DELETE)
+  }
+
+  backButton = (): PageElement => cy.get('#back-button')
+}

--- a/integration_tests/pages/order/delete-success.ts
+++ b/integration_tests/pages/order/delete-success.ts
@@ -1,0 +1,12 @@
+import AppPage from '../appPage'
+
+import paths from '../../../server/constants/paths'
+import { PageElement } from '../page'
+
+export default class DeleteSuccessPage extends AppPage {
+  constructor() {
+    super('Application form successfully deleted', paths.ORDER.DELETE)
+  }
+
+  backButton = (): PageElement => cy.get('#back-button')
+}

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -20,10 +20,10 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
     if (res.locals?.user?.token) {
       const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
 
-      // if (authorisedAuthorities.length && !roles.some(role => authorisedAuthorities.includes(role))) {
-      //   logger.error('User is not authorised to access this')
-      //   return res.redirect('/authError')
-      // }
+      if (authorisedAuthorities.length && !roles.some(role => authorisedAuthorities.includes(role))) {
+        logger.error('User is not authorised to access this')
+        return res.redirect('/authError')
+      }
 
       return next()
     }

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -20,10 +20,10 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
     if (res.locals?.user?.token) {
       const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
 
-      if (authorisedAuthorities.length && !roles.some(role => authorisedAuthorities.includes(role))) {
-        logger.error('User is not authorised to access this')
-        return res.redirect('/authError')
-      }
+      // if (authorisedAuthorities.length && !roles.some(role => authorisedAuthorities.includes(role))) {
+      //   logger.error('User is not authorised to access this')
+      //   return res.redirect('/authError')
+      // }
 
       return next()
     }

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -138,7 +138,7 @@ describe('authorised user', () => {
         .get('/order/delete/success')
         .expect('Content-Type', /html/)
         .expect(res => {
-          expect(res.text).toContain('The application form has been successfully deleted')
+          expect(res.text).toContain('Application form successfully deleted')
         })
     })
   })

--- a/server/views/pages/order/delete-confirm.njk
+++ b/server/views/pages/order/delete-confirm.njk
@@ -20,19 +20,22 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     <div class="govuk-button-group">
-      {{ govukButton({
-        text: "Back",
-        classes: "govuk-button--secondary",
-        name: "action",
-        value: "back"
-      })}}
-
-      {{ govukButton({
-        text: "Delete",
+       {{ govukButton({
+        text: "Yes, delete form",
         classes: "govuk-button--warning",
         name: "action",
-        value: "continue"
+        value: "continue",
+        id: "confirm-delete-button"
       })}}
+      {{ govukButton({
+        text: "Cancel and return to form",
+        classes: "govuk-button--secondary",
+        name: "action",
+        value: "back",
+        id: "back-button"
+      })}}
+
+     
     </div>
   </form>
 {% endblock %}

--- a/server/views/pages/order/delete-failed.njk
+++ b/server/views/pages/order/delete-failed.njk
@@ -21,7 +21,8 @@
   <div class="govuk-button-group">
     {{ govukButton({
       text: "Back to your applications",
-      href: "/"
+      href: "/",
+      id: "back-button"
     }) }}
   </div>
 {% endblock %}

--- a/server/views/pages/order/delete-success.njk
+++ b/server/views/pages/order/delete-success.njk
@@ -13,13 +13,14 @@
   }) }}
 
   {{ govukPanel({
-    titleText: "The application form has been successfully deleted"
+    titleText: "Application form successfully deleted"
   }) }}
 
   <div class="govuk-button-group">
     {{ govukButton({
-      text: "Back to your applications",
-      href: "/"
+      text: "Back to start",
+      href: "/",
+      id: "back-button"
     }) }}
   </div>
 {% endblock %}

--- a/server/views/pages/order/delete-success.njk
+++ b/server/views/pages/order/delete-success.njk
@@ -16,10 +16,7 @@
     titleText: "Application form successfully deleted"
   }) }}
 
-    {{ govukButton({
-      text: "Back to start",
-      href: "/",
-      id: "back-to-applications-button"
+    {{ govukButton({    
       text: "Back to start",
       href: "/",
       id: "back-button"


### PR DESCRIPTION

Update the order and content of buttons in delete confirm page:
![image](https://github.com/user-attachments/assets/a313b52b-8ce9-4dc1-bee1-967f04e8245f)

Update heading and button text for delete success page:
![image](https://github.com/user-attachments/assets/a55d5af0-a796-4ee0-ba9c-fa05d18b5704)
