### PR TITLE
Populate content with english i18n content

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,6 @@
 import { HmppsUser } from '../../interfaces/hmppsUser'
 import { Order } from '../../models/Order'
+import I18n from '../../types/i18n'
 
 export declare module 'express-session' {
   // Declare that the session will potentially contain these additional fields
@@ -29,6 +30,7 @@ export declare global {
       user: HmppsUser
       isOrderEditable?: boolean
       orderId?: string
+      content?: I18n
     }
   }
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -18,6 +18,7 @@ import setUpWebSession from './middleware/setUpWebSession'
 
 import routes from './routes'
 import type { Services } from './services'
+import populateContent from './middleware/populateContent'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -38,6 +39,7 @@ export default function createApp(services: Services): express.Application {
   app.use(multer().single('file'))
   app.use(setUpCsrf())
   app.use(setUpCurrentUser())
+  app.use(populateContent)
   app.use(routes(services))
 
   app.use((req, res, next) => next(createError(404, 'Not Found')))

--- a/server/i18n/en/index.ts
+++ b/server/i18n/en/index.ts
@@ -1,0 +1,48 @@
+import I18n from '../../types/i18n'
+import alcoholPageContent from './pages/alcohol'
+import attendancePageContent from './pages/attendance'
+import contactDetailsPageContent from './pages/contactDetails'
+import curfewConditionsPageContent from './pages/curfewConditions'
+import curfewReleaseDatePageContent from './pages/curfewReleaseDate'
+import curfewTimeTablePageContent from './pages/curfewTimetable'
+import deviceWearerPageContent from './pages/deviceWearer'
+import exclusionZonePageContent from './pages/exclusionZone'
+import identityNumbersPageContent from './pages/identityNumbers'
+import installationAddressPageContent from './pages/installationAddress'
+import interestedPartiesPageContent from './pages/interestedParties'
+import monitoringConditionsPageContent from './pages/monitoringConditions'
+import noFixedAbodePageContent from './pages/noFixedAbode'
+import primaryAddressPageContent from './pages/primaryAddress'
+import responsibleAdultPageContent from './pages/responsibleAdult'
+import secondaryAddressPageContent from './pages/secondaryAddress'
+import tertiaryAddressPageContent from './pages/tertiaryAddress'
+import trailMonitoringPageContent from './pages/trailMonitoring'
+import uploadLicencePageContent from './pages/uploadLicence'
+import uploadPhotoIdPageContent from './pages/uploadPhotoId'
+
+const en: I18n = {
+  pages: {
+    alcohol: alcoholPageContent,
+    attendance: attendancePageContent,
+    contactDetails: contactDetailsPageContent,
+    curfewConditions: curfewConditionsPageContent,
+    curfewReleaseDate: curfewReleaseDatePageContent,
+    curfewTimetable: curfewTimeTablePageContent,
+    deviceWearer: deviceWearerPageContent,
+    exclusionZone: exclusionZonePageContent,
+    identityNumbers: identityNumbersPageContent,
+    installationAddress: installationAddressPageContent,
+    interestedParties: interestedPartiesPageContent,
+    monitoringConditions: monitoringConditionsPageContent,
+    noFixedAbode: noFixedAbodePageContent,
+    primaryAddress: primaryAddressPageContent,
+    responsibleAdult: responsibleAdultPageContent,
+    secondaryAddress: secondaryAddressPageContent,
+    tertiaryAddress: tertiaryAddressPageContent,
+    trailMonitoring: trailMonitoringPageContent,
+    uploadLicense: uploadLicencePageContent,
+    uploadPhotoId: uploadPhotoIdPageContent,
+  },
+}
+
+export default en

--- a/server/i18n/index.ts
+++ b/server/i18n/index.ts
@@ -1,0 +1,7 @@
+import en from './en'
+
+const i18n = {
+  en,
+}
+
+export default i18n

--- a/server/middleware/populateContent.test.ts
+++ b/server/middleware/populateContent.test.ts
@@ -1,0 +1,18 @@
+import { createMockRequest, createMockResponse } from '../../test/mocks/mockExpress'
+import populateContent from './populateContent'
+
+describe('populateContent', () => {
+  it('should populate res.locals with content', async () => {
+    // Given
+    const req = createMockRequest()
+    const res = createMockResponse()
+    const next = jest.fn()
+
+    // When
+    await populateContent(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(res.locals.content).not.toBeUndefined()
+  })
+})

--- a/server/middleware/populateContent.ts
+++ b/server/middleware/populateContent.ts
@@ -1,0 +1,9 @@
+import { NextFunction, Request, Response } from 'express'
+import i18n from '../i18n'
+
+const populateContent = async (req: Request, res: Response, next: NextFunction) => {
+  res.locals.content = i18n.en
+  next()
+}
+
+export default populateContent

--- a/server/types/i18n/index.ts
+++ b/server/types/i18n/index.ts
@@ -1,0 +1,43 @@
+import AddressPageContent from './pages/address'
+import AlcoholPageContent from './pages/alcohol'
+import AttendancePageContent from './pages/attendance'
+import ContactDetailsPageContent from './pages/contactDetails'
+import CurfewConditionsPageContent from './pages/curfewConditions'
+import CurfewReleaseDatePageContent from './pages/curfewReleaseDate'
+import CurfewTimeTablePageContent from './pages/curfewTimeTable'
+import DeviceWearerPageContent from './pages/deviceWearer'
+import ExclusionZonePageContent from './pages/exclusionZone'
+import IdentityNumbersPageContent from './pages/identityNumbers'
+import InterestedPartiesPageContent from './pages/interestedParties'
+import MonitoringConditionsPageContent from './pages/monitoringConditions'
+import NoFixedAbodePageContent from './pages/noFixedAbode'
+import ResponsibleAdultPageContent from './pages/responsibleAdult'
+import TrailMonitoringPageContent from './pages/trailMonitoring'
+import UploadDocumentPageContent from './pages/uploadDocument'
+
+type I18n = {
+  pages: {
+    alcohol: AlcoholPageContent
+    attendance: AttendancePageContent
+    contactDetails: ContactDetailsPageContent
+    curfewConditions: CurfewConditionsPageContent
+    curfewReleaseDate: CurfewReleaseDatePageContent
+    curfewTimetable: CurfewTimeTablePageContent
+    deviceWearer: DeviceWearerPageContent
+    exclusionZone: ExclusionZonePageContent
+    identityNumbers: IdentityNumbersPageContent
+    installationAddress: AddressPageContent
+    interestedParties: InterestedPartiesPageContent
+    monitoringConditions: MonitoringConditionsPageContent
+    noFixedAbode: NoFixedAbodePageContent
+    primaryAddress: AddressPageContent
+    responsibleAdult: ResponsibleAdultPageContent
+    secondaryAddress: AddressPageContent
+    tertiaryAddress: AddressPageContent
+    trailMonitoring: TrailMonitoringPageContent
+    uploadLicense: UploadDocumentPageContent
+    uploadPhotoId: UploadDocumentPageContent
+  }
+}
+
+export default I18n

--- a/server/types/i18n/locale.ts
+++ b/server/types/i18n/locale.ts
@@ -1,0 +1,3 @@
+type Locale = 'en' | 'cy'
+
+export default Locale


### PR DESCRIPTION
- Populate `res.locals.content` with english i18n content
- Allows extending with Welsh(cy) content in the future but leave decision open on how we do that
- Simple usage within views e.g.

```njk
{{ content.pages.contactDetails.title }}
```
