### PR TITLE
Update all page headings

### DIFF
--- a/integration_tests/e2e/order/contact-information/primary-address.submission.cy.ts
+++ b/integration_tests/e2e/order/contact-information/primary-address.submission.cy.ts
@@ -15,27 +15,30 @@ context('Contact information', () => {
         cy.task('reset')
         cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
 
-        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS',
+        cy.task('stubCemoGetOrder', {
+          httpStatus: 200,
+          id: mockOrderId,
+          status: 'IN_PROGRESS',
           order: {
             deviceWearer: {
               nomisId: null,
-            pncId: null,
-            deliusId: null,
-            prisonNumber: null,
-            homeOfficeReferenceNumber: null,
-            firstName: null,
-            lastName: null,
-            alias: null,
-            dateOfBirth: null,
-            adultAtTimeOfInstallation: false,
-            sex: null,
-            gender: null,
-            disabilities: '',
-            noFixedAbode: false,
-            interpreterRequired: null,
+              pncId: null,
+              deliusId: null,
+              prisonNumber: null,
+              homeOfficeReferenceNumber: null,
+              firstName: null,
+              lastName: null,
+              alias: null,
+              dateOfBirth: null,
+              adultAtTimeOfInstallation: false,
+              sex: null,
+              gender: null,
+              disabilities: '',
+              noFixedAbode: false,
+              interpreterRequired: null,
             },
           },
-         })
+        })
 
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 200,

--- a/integration_tests/e2e/order/contact-information/primary-address.submission.cy.ts
+++ b/integration_tests/e2e/order/contact-information/primary-address.submission.cy.ts
@@ -15,7 +15,28 @@ context('Contact information', () => {
         cy.task('reset')
         cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
 
-        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
+        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS',
+          order: {
+            deviceWearer: {
+              nomisId: null,
+            pncId: null,
+            deliusId: null,
+            prisonNumber: null,
+            homeOfficeReferenceNumber: null,
+            firstName: null,
+            lastName: null,
+            alias: null,
+            dateOfBirth: null,
+            adultAtTimeOfInstallation: false,
+            sex: null,
+            gender: null,
+            disabilities: '',
+            noFixedAbode: false,
+            interpreterRequired: null,
+            },
+          },
+         })
+
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 200,
           id: mockOrderId,

--- a/integration_tests/e2e/order/contact-information/secondary-address.submission.cy.ts
+++ b/integration_tests/e2e/order/contact-information/secondary-address.submission.cy.ts
@@ -15,7 +15,27 @@ context('Contact information', () => {
         cy.task('reset')
         cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
 
-        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
+        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS',
+          order: {
+            deviceWearer: {
+              nomisId: null,
+            pncId: null,
+            deliusId: null,
+            prisonNumber: null,
+            homeOfficeReferenceNumber: null,
+            firstName: null,
+            lastName: null,
+            alias: null,
+            dateOfBirth: null,
+            adultAtTimeOfInstallation: false,
+            sex: null,
+            gender: null,
+            disabilities: '',
+            noFixedAbode: false,
+            interpreterRequired: null,
+            },
+          },
+         })
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 200,
           id: mockOrderId,

--- a/integration_tests/e2e/order/contact-information/secondary-address.submission.cy.ts
+++ b/integration_tests/e2e/order/contact-information/secondary-address.submission.cy.ts
@@ -15,27 +15,30 @@ context('Contact information', () => {
         cy.task('reset')
         cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
 
-        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS',
+        cy.task('stubCemoGetOrder', {
+          httpStatus: 200,
+          id: mockOrderId,
+          status: 'IN_PROGRESS',
           order: {
             deviceWearer: {
               nomisId: null,
-            pncId: null,
-            deliusId: null,
-            prisonNumber: null,
-            homeOfficeReferenceNumber: null,
-            firstName: null,
-            lastName: null,
-            alias: null,
-            dateOfBirth: null,
-            adultAtTimeOfInstallation: false,
-            sex: null,
-            gender: null,
-            disabilities: '',
-            noFixedAbode: false,
-            interpreterRequired: null,
+              pncId: null,
+              deliusId: null,
+              prisonNumber: null,
+              homeOfficeReferenceNumber: null,
+              firstName: null,
+              lastName: null,
+              alias: null,
+              dateOfBirth: null,
+              adultAtTimeOfInstallation: false,
+              sex: null,
+              gender: null,
+              disabilities: '',
+              noFixedAbode: false,
+              interpreterRequired: null,
             },
           },
-         })
+        })
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 200,
           id: mockOrderId,

--- a/integration_tests/e2e/order/contact-information/tertiary-address.submission.cy.ts
+++ b/integration_tests/e2e/order/contact-information/tertiary-address.submission.cy.ts
@@ -14,27 +14,30 @@ context('Contact information', () => {
         cy.task('reset')
         cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
 
-        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS',
+        cy.task('stubCemoGetOrder', {
+          httpStatus: 200,
+          id: mockOrderId,
+          status: 'IN_PROGRESS',
           order: {
             deviceWearer: {
               nomisId: null,
-            pncId: null,
-            deliusId: null,
-            prisonNumber: null,
-            homeOfficeReferenceNumber: null,
-            firstName: null,
-            lastName: null,
-            alias: null,
-            dateOfBirth: null,
-            adultAtTimeOfInstallation: false,
-            sex: null,
-            gender: null,
-            disabilities: '',
-            noFixedAbode: false,
-            interpreterRequired: null,
+              pncId: null,
+              deliusId: null,
+              prisonNumber: null,
+              homeOfficeReferenceNumber: null,
+              firstName: null,
+              lastName: null,
+              alias: null,
+              dateOfBirth: null,
+              adultAtTimeOfInstallation: false,
+              sex: null,
+              gender: null,
+              disabilities: '',
+              noFixedAbode: false,
+              interpreterRequired: null,
             },
           },
-         })
+        })
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 200,
           id: mockOrderId,

--- a/integration_tests/e2e/order/contact-information/tertiary-address.submission.cy.ts
+++ b/integration_tests/e2e/order/contact-information/tertiary-address.submission.cy.ts
@@ -14,7 +14,27 @@ context('Contact information', () => {
         cy.task('reset')
         cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
 
-        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
+        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS',
+          order: {
+            deviceWearer: {
+              nomisId: null,
+            pncId: null,
+            deliusId: null,
+            prisonNumber: null,
+            homeOfficeReferenceNumber: null,
+            firstName: null,
+            lastName: null,
+            alias: null,
+            dateOfBirth: null,
+            adultAtTimeOfInstallation: false,
+            sex: null,
+            gender: null,
+            disabilities: '',
+            noFixedAbode: false,
+            interpreterRequired: null,
+            },
+          },
+         })
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 200,
           id: mockOrderId,

--- a/integration_tests/pages/appFormPage.ts
+++ b/integration_tests/pages/appFormPage.ts
@@ -10,7 +10,11 @@ export default class AppFormPage extends AppPage {
   form: FormComponent
 
   checkOnPage(): void {
-    super.checkOnPage()
+    cy.get('h1', { log: false }).contains(this.title)
+
+    if (this.subtitle) {
+      cy.get('h1 span', { log: false }).contains(this.subtitle)
+    }
 
     if (this.form) {
       this.form.checkHasForm()

--- a/integration_tests/pages/order/about-the-device-wearer/device-wearer.ts
+++ b/integration_tests/pages/order/about-the-device-wearer/device-wearer.ts
@@ -8,6 +8,6 @@ export default class AboutDeviceWearerPage extends AppFormPage {
   form = new AboutDeviceWearerFormComponent()
 
   constructor() {
-    super('About the device wearer', paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER, '')
+    super('Personal details', paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER, 'About the device wearer')
   }
 }

--- a/integration_tests/pages/order/about-the-device-wearer/identity-numbers.ts
+++ b/integration_tests/pages/order/about-the-device-wearer/identity-numbers.ts
@@ -8,6 +8,6 @@ export default class IdentityNumbersPage extends AppFormPage {
   form = new IdentityNumbersFormComponent()
 
   constructor() {
-    super('Identity numbers', paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS, '')
+    super('Identity numbers', paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS, 'About the device wearer')
   }
 }

--- a/integration_tests/pages/order/about-the-device-wearer/responsible-adult-details.ts
+++ b/integration_tests/pages/order/about-the-device-wearer/responsible-adult-details.ts
@@ -8,6 +8,6 @@ export default class ResponsibleAdultPage extends AppFormPage {
   form = new ResponsibleAdultFormComponent()
 
   constructor() {
-    super('About the device wearer', paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT, 'Responsible Adult')
+    super('Responsible adult details', paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT, 'About the device wearer')
   }
 }

--- a/integration_tests/pages/order/contact-information/contact-details.ts
+++ b/integration_tests/pages/order/contact-information/contact-details.ts
@@ -8,7 +8,7 @@ export default class ContactDetailsPage extends AppFormPage {
   public form = new ContactDetailsFormComponent()
 
   constructor() {
-    super('Contact information', paths.CONTACT_INFORMATION.CONTACT_DETAILS)
+    super('Telephone number', paths.CONTACT_INFORMATION.CONTACT_DETAILS, 'Contact information')
   }
 
   checkOnPage(): void {

--- a/integration_tests/pages/order/contact-information/interested-parties.ts
+++ b/integration_tests/pages/order/contact-information/interested-parties.ts
@@ -8,7 +8,7 @@ export default class InterestedPartiesPage extends AppFormPage {
   public form = new InterestedPartiesFormComponent()
 
   constructor() {
-    super('Contact information', paths.CONTACT_INFORMATION.INTERESTED_PARTIES, 'Notifying organisation')
+    super('Organisation details', paths.CONTACT_INFORMATION.INTERESTED_PARTIES, 'Contact information')
   }
 
   checkOnPage(): void {

--- a/integration_tests/pages/order/contact-information/no-fixed-abode.ts
+++ b/integration_tests/pages/order/contact-information/no-fixed-abode.ts
@@ -8,7 +8,7 @@ export default class NoFixedAbodePage extends AppFormPage {
   public form = new NoFixedAbodeFormComponent()
 
   constructor() {
-    super('Contact information', paths.CONTACT_INFORMATION.NO_FIXED_ABODE, 'Primary address')
+    super('Fixed address', paths.CONTACT_INFORMATION.NO_FIXED_ABODE, 'Contact information')
   }
 
   checkOnPage(): void {

--- a/integration_tests/pages/order/contact-information/primary-address.ts
+++ b/integration_tests/pages/order/contact-information/primary-address.ts
@@ -4,6 +4,6 @@ import paths from '../../../../server/constants/paths'
 
 export default class PrimaryAddressPage extends AddressPage {
   constructor() {
-    super('Contact information', paths.CONTACT_INFORMATION.ADDRESSES, 'Primary address')
+    super('Fixed address', paths.CONTACT_INFORMATION.ADDRESSES, 'Contact information')
   }
 }

--- a/integration_tests/pages/order/contact-information/secondary-address.ts
+++ b/integration_tests/pages/order/contact-information/secondary-address.ts
@@ -4,6 +4,6 @@ import paths from '../../../../server/constants/paths'
 
 export default class SecondaryAddressPage extends AddressPage {
   constructor() {
-    super('Contact information', paths.CONTACT_INFORMATION.ADDRESSES, 'Secondary address')
+    super("Device wearer's second address", paths.CONTACT_INFORMATION.ADDRESSES, 'Contact information')
   }
 }

--- a/integration_tests/pages/order/contact-information/tertiary-adddress.ts
+++ b/integration_tests/pages/order/contact-information/tertiary-adddress.ts
@@ -4,6 +4,6 @@ import paths from '../../../../server/constants/paths'
 
 export default class TertiaryAddressPage extends AddressPage {
   constructor() {
-    super('Contact information', paths.CONTACT_INFORMATION.ADDRESSES, 'Tertiary address', false)
+    super("Device wearer's third address", paths.CONTACT_INFORMATION.ADDRESSES, 'Contact information', false)
   }
 }

--- a/integration_tests/pages/order/installationAndRisk.ts
+++ b/integration_tests/pages/order/installationAndRisk.ts
@@ -8,6 +8,6 @@ export default class InstallationAndRiskPage extends AppFormPage {
   public form = new InstallationAndRiskFormComponent()
 
   constructor() {
-    super('Installation and risk information', paths.INSTALLATION_AND_RISK)
+    super('Risk information', paths.INSTALLATION_AND_RISK, 'Details for installation')
   }
 }

--- a/integration_tests/pages/order/monitoring-conditions.ts
+++ b/integration_tests/pages/order/monitoring-conditions.ts
@@ -8,6 +8,6 @@ export default class MonitoringConditionsPage extends AppFormPage {
   public form = new MonitoringConditionsFormComponent()
 
   constructor() {
-    super('Monitoring conditions', paths.MONITORING_CONDITIONS.BASE_URL, 'When should the monitoring take place')
+    super('Monitoring details', paths.MONITORING_CONDITIONS.BASE_URL, 'Electronic monitoring required')
   }
 }

--- a/integration_tests/pages/order/monitoring-conditions/alcohol-monitoring.ts
+++ b/integration_tests/pages/order/monitoring-conditions/alcohol-monitoring.ts
@@ -8,7 +8,7 @@ export default class AlcoholMonitoringPage extends AppFormPage {
   public form = new AlcoholMonitoringFormComponent()
 
   constructor() {
-    super('Monitoring conditions', paths.MONITORING_CONDITIONS.ALCOHOL, 'Alcohol monitoring')
+    super('Alcohol monitoring', paths.MONITORING_CONDITIONS.ALCOHOL, 'Electronic monitoring required')
   }
 
   fillInForm = (installLocation: string): void => {

--- a/integration_tests/pages/order/monitoring-conditions/attendance-monitoring.ts
+++ b/integration_tests/pages/order/monitoring-conditions/attendance-monitoring.ts
@@ -6,6 +6,6 @@ export default class AttendanceMonitoringPage extends AppFormPage {
   public form = new AttendanceMonitoringFormComponent()
 
   constructor() {
-    super('Monitoring conditions', paths.MONITORING_CONDITIONS.ATTENDANCE, 'Attendance monitoring')
+    super('Mandatory attendance monitoring', paths.MONITORING_CONDITIONS.ATTENDANCE, 'Electronic monitoring required')
   }
 }

--- a/integration_tests/pages/order/monitoring-conditions/curfew-conditions.ts
+++ b/integration_tests/pages/order/monitoring-conditions/curfew-conditions.ts
@@ -8,7 +8,7 @@ export default class CurfewConditionsPage extends AppFormPage {
   public form = new CurfewConditionsFormComponent()
 
   constructor() {
-    super('Monitoring conditions', paths.MONITORING_CONDITIONS.CURFEW_CONDITIONS, 'Curfew with electronic monitoring')
+    super('Curfew', paths.MONITORING_CONDITIONS.CURFEW_CONDITIONS, 'Electronic monitoring required')
   }
 
   fillInForm = (): void => {

--- a/integration_tests/pages/order/monitoring-conditions/curfew-release-date.ts
+++ b/integration_tests/pages/order/monitoring-conditions/curfew-release-date.ts
@@ -8,7 +8,7 @@ export default class CurfewReleaseDatePage extends AppFormPage {
   public form = new CurfewReleaseDateFormComponent()
 
   constructor() {
-    super('Monitoring conditions', paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE, 'Curfew for day of release')
+    super('Curfew on release day', paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE, 'Electronic monitoring required')
   }
 
   fillInForm = (): void => {

--- a/integration_tests/pages/order/monitoring-conditions/curfew-timetable.ts
+++ b/integration_tests/pages/order/monitoring-conditions/curfew-timetable.ts
@@ -8,10 +8,6 @@ export default class CurfewTimetablePage extends AppFormPage {
   public form = new CurfewTimetableFormComponent()
 
   constructor() {
-    super(
-      'Monitoring conditions',
-      paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE,
-      'Timetable for curfew with electronic monitoring',
-    )
+    super('Curfew timetable', paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE, 'Electronic monitoring details')
   }
 }

--- a/integration_tests/pages/order/monitoring-conditions/enforcement-zone.ts
+++ b/integration_tests/pages/order/monitoring-conditions/enforcement-zone.ts
@@ -8,6 +8,6 @@ export default class EnforcementZonePage extends AppFormPage {
   public form = new EnforcementZoneFormComponent()
 
   constructor() {
-    super('Monitoring conditions', paths.MONITORING_CONDITIONS.ZONE, 'Exclusion and inclusion zones')
+    super('Exclusion zone monitoring ', paths.MONITORING_CONDITIONS.ZONE, 'Electronic monitoring required')
   }
 }

--- a/integration_tests/pages/order/monitoring-conditions/installation-address.ts
+++ b/integration_tests/pages/order/monitoring-conditions/installation-address.ts
@@ -4,6 +4,11 @@ import paths from '../../../../server/constants/paths'
 
 export default class InstallationAddressPage extends AddressPage {
   constructor() {
-    super('Monitoring conditions', paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS, 'Installation address', false)
+    super(
+      'Installation address',
+      paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS,
+      'Electronic monitoring required',
+      false,
+    )
   }
 }

--- a/integration_tests/pages/order/monitoring-conditions/trail-monitoring.ts
+++ b/integration_tests/pages/order/monitoring-conditions/trail-monitoring.ts
@@ -8,6 +8,6 @@ export default class TrailMonitoringPage extends AppFormPage {
   public form = new TrailMonitoringFormComponent()
 
   constructor() {
-    super('Monitoring conditions', paths.MONITORING_CONDITIONS.TRAIL, 'Trail monitoring')
+    super('Trail monitoring', paths.MONITORING_CONDITIONS.TRAIL, 'Electronic monitoring required')
   }
 }

--- a/integration_tests/pages/order/summary.ts
+++ b/integration_tests/pages/order/summary.ts
@@ -25,6 +25,7 @@ import EnforcementZonePage from './monitoring-conditions/enforcement-zone'
 import AlcoholMonitoringPage from './monitoring-conditions/alcohol-monitoring'
 import UploadLicencePage from './attachments/uploadLicence'
 import TrailMonitoringPage from './monitoring-conditions/trail-monitoring'
+import SecondaryAddressPage from './contact-information/secondary-address'
 
 export default class OrderTasksPage extends AppPage {
   constructor() {
@@ -436,7 +437,7 @@ export default class OrderTasksPage extends AppPage {
     primaryAddressPage.form.saveAndContinueButton.click()
 
     if (secondaryAddressDetails !== undefined) {
-      const secondaryAddressPage = Page.verifyOnPage(PrimaryAddressPage)
+      const secondaryAddressPage = Page.verifyOnPage(SecondaryAddressPage)
       secondaryAddressPage.form.fillInWith({
         ...secondaryAddressDetails,
         hasAnotherAddress: 'No',

--- a/server/i18n/en/index.ts
+++ b/server/i18n/en/index.ts
@@ -9,6 +9,7 @@ import deviceWearerPageContent from './pages/deviceWearer'
 import exclusionZonePageContent from './pages/exclusionZone'
 import identityNumbersPageContent from './pages/identityNumbers'
 import installationAddressPageContent from './pages/installationAddress'
+import installationAndRiskPageContent from './pages/installationAndRisk'
 import interestedPartiesPageContent from './pages/interestedParties'
 import monitoringConditionsPageContent from './pages/monitoringConditions'
 import noFixedAbodePageContent from './pages/noFixedAbode'
@@ -32,6 +33,7 @@ const en: I18n = {
     exclusionZone: exclusionZonePageContent,
     identityNumbers: identityNumbersPageContent,
     installationAddress: installationAddressPageContent,
+    installationAndRisk: installationAndRiskPageContent,
     interestedParties: interestedPartiesPageContent,
     monitoringConditions: monitoringConditionsPageContent,
     noFixedAbode: noFixedAbodePageContent,

--- a/server/i18n/en/pages/attendance.ts
+++ b/server/i18n/en/pages/attendance.ts
@@ -33,7 +33,7 @@ const attendancePageContent: AttendancePageContent = {
     },
   },
   section: 'Electronic monitoring required',
-  title: 'Mandatory attendance monitoring ',
+  title: 'Mandatory attendance monitoring',
 }
 
 export default attendancePageContent

--- a/server/i18n/en/pages/exclusionZone.ts
+++ b/server/i18n/en/pages/exclusionZone.ts
@@ -32,7 +32,7 @@ const exclusionZonePageContent: ExclusionZonePageContent = {
     },
   },
   section: 'Electronic monitoring required',
-  title: 'Exclusion zone monitoring ',
+  title: 'Exclusion zone monitoring',
 }
 
 export default exclusionZonePageContent

--- a/server/i18n/en/pages/trailMonitoring.ts
+++ b/server/i18n/en/pages/trailMonitoring.ts
@@ -14,7 +14,7 @@ const trailMonitoringPageContent: TrailMonitoringPageContent = {
     },
   },
   section: 'Electronic monitoring required',
-  title: 'Trail monitoring ',
+  title: 'Trail monitoring',
 }
 
 export default trailMonitoringPageContent

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -12,6 +12,7 @@ import { HmppsUser } from '../../interfaces/hmppsUser'
 import setUpWebSession from '../../middleware/setUpWebSession'
 import HmppsAuditClient from '../../data/hmppsAuditClient'
 import authorisationMiddleware, { cemoAuthorisedRoles } from '../../middleware/authorisationMiddleware'
+import populateContent from '../../middleware/populateContent'
 
 jest.mock('../../services/auditService')
 jest.mock('../../data/hmppsAuditClient')
@@ -71,6 +72,7 @@ function appSetup(services: Services, production: boolean, userSupplier: () => H
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
   app.use(authorisationMiddleware(cemoAuthorisedRoles()))
+  app.use(populateContent)
   app.use(routes(services))
   app.use((req, res, next) => next(new NotFound()))
   app.use(errorHandler(production))

--- a/server/types/i18n/index.ts
+++ b/server/types/i18n/index.ts
@@ -8,6 +8,7 @@ import CurfewTimeTablePageContent from './pages/curfewTimeTable'
 import DeviceWearerPageContent from './pages/deviceWearer'
 import ExclusionZonePageContent from './pages/exclusionZone'
 import IdentityNumbersPageContent from './pages/identityNumbers'
+import InstallationAndRiskPageContent from './pages/installationAndRisk'
 import InterestedPartiesPageContent from './pages/interestedParties'
 import MonitoringConditionsPageContent from './pages/monitoringConditions'
 import NoFixedAbodePageContent from './pages/noFixedAbode'
@@ -27,6 +28,7 @@ type I18n = {
     exclusionZone: ExclusionZonePageContent
     identityNumbers: IdentityNumbersPageContent
     installationAddress: AddressPageContent
+    installationAndRisk: InstallationAndRiskPageContent
     interestedParties: InterestedPartiesPageContent
     monitoringConditions: MonitoringConditionsPageContent
     noFixedAbode: NoFixedAbodePageContent

--- a/server/views/pages/order/about-the-device-wearer/device-wearer.njk
+++ b/server/views/pages/order/about-the-device-wearer/device-wearer.njk
@@ -1,14 +1,16 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Device wearer details - About the device wearer - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "About the device wearer" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% set section = content.pages.deviceWearer.section %}
+{% set heading = content.pages.deviceWearer.title %}
+{% set legend = content.pages.deviceWearer.legend %}
+{% set helpText = content.pages.deviceWearer.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/about-the-device-wearer/identity-numbers.njk
+++ b/server/views/pages/order/about-the-device-wearer/identity-numbers.njk
@@ -1,9 +1,11 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Device wearer details - Identity numbers - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Identity numbers" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% set section = content.pages.identityNumbers.section %}
+{% set heading = content.pages.identityNumbers.title %}
+{% set legend = content.pages.identityNumbers.legend %}
+{% set helpText = content.pages.identityNumbers.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/about-the-device-wearer/responsible-adult-details.njk
+++ b/server/views/pages/order/about-the-device-wearer/responsible-adult-details.njk
@@ -1,11 +1,13 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Device wearer details - Responsible adult - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "About the device wearer" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% set section = content.pages.responsibleAdult.section %}
+{% set heading = content.pages.responsibleAdult.title %}
+{% set legend = content.pages.responsibleAdult.legend %}
+{% set helpText = content.pages.responsibleAdult.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/contact-information/address.njk
+++ b/server/views/pages/order/contact-information/address.njk
@@ -1,12 +1,31 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set section = "Monitoring conditions" if (addressType.value | lower) == "installation" else "Contact information" %}
-{% set pageTitle = section + " - " + (addressType.value | capitalize) + " address - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set subsection = addressType.value | capitalize + " address" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% if (addressType.value | lower) == "primary" %}
+
+  {% set pageContent = content.pages.primaryAddress %}
+
+{% elif (addressType.value | lower) == "secondary" %}
+
+  {% set pageContent = content.pages.secondaryAddress %}
+
+{% elif (addressType.value | lower) == "tertiary" %}
+
+  {% set pageContent = content.pages.tertiaryAddress %}
+
+{% elif (addressType.value | lower) == "installation" %}
+
+  {% set pageContent = content.pages.installationAddress %}
+
+{% endif %}
+
+{% set section = pageContent.section %}
+{% set heading = pageContent.title %}
+{% set legend = pageContent.legend %}
+{% set helpText = pageContent.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/contact-information/contact-details.njk
+++ b/server/views/pages/order/contact-information/contact-details.njk
@@ -1,10 +1,11 @@
 {% extends "../../../partials/form-layout.njk" %}
-
-{% set pageTitle = "Contact information - Contact details - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Contact information" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
+{% set section = content.pages.contactDetails.section %}
+{% set heading = content.pages.contactDetails.title %}
+{% set legend = content.pages.contactDetails.legend %}
+{% set helpText = content.pages.contactDetails.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/contact-information/interested-parties.njk
+++ b/server/views/pages/order/contact-information/interested-parties.njk
@@ -1,13 +1,15 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Contact information - Notifying organisation - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Contact information" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "../../../components/accessible-autocomplete/macro.njk" import accessibleAutocomplete %}
+
+{% set section = content.pages.interestedParties.section %}
+{% set heading = content.pages.interestedParties.title %}
+{% set legend = content.pages.interestedParties.legend %}
+{% set helpText = content.pages.interestedParties.helpText %}
 
 {% set crownCourtHtml %}
 

--- a/server/views/pages/order/contact-information/no-fixed-abode.njk
+++ b/server/views/pages/order/contact-information/no-fixed-abode.njk
@@ -1,10 +1,12 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Contact information - Fixed address - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Contact information" %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% set section = content.pages.noFixedAbode.section %}
+{% set heading = content.pages.noFixedAbode.title %}
+{% set legend = content.pages.noFixedAbode.legend %}
+{% set helpText = content.pages.noFixedAbode.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/installation-and-risk/index.njk
+++ b/server/views/pages/order/installation-and-risk/index.njk
@@ -1,8 +1,5 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Installation and risk - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Installation and risk information" %}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
@@ -12,6 +9,11 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% set section = content.pages.installationAndRisk.section %}
+{% set heading = content.pages.installationAndRisk.title %}
+{% set legend = content.pages.installationAndRisk.legend %}
+{% set helpText = content.pages.installationAndRisk.helpText %}
 
 {% block formInputs %}
   <p class="govuk-body">Provide risk information to help plan installation.</p>

--- a/server/views/pages/order/monitoring-conditions/alcohol-monitoring.njk
+++ b/server/views/pages/order/monitoring-conditions/alcohol-monitoring.njk
@@ -1,12 +1,13 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Monitoring conditions - Alcohol monitoring - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Monitoring conditions" %}
-{% set subsection = "Alcohol monitoring" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+
+{% set section = content.pages.alcohol.section %}
+{% set heading = content.pages.alcohol.title %}
+{% set legend = content.pages.alcohol.legend %}
+{% set helpText = content.pages.alcohol.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/monitoring-conditions/attendance-monitoring.njk
+++ b/server/views/pages/order/monitoring-conditions/attendance-monitoring.njk
@@ -1,14 +1,15 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Monitoring conditions - Attendance monitoring - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Monitoring conditions" %}
-{% set subsection = "Attendance monitoring" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "../../../partials/timeInput.njk" import timeInput %}
 {% from "../../../partials/addressInput.njk" import addressInput %}
+
+{% set section = content.pages.attendance.section %}
+{% set heading = content.pages.attendance.title %}
+{% set legend = content.pages.attendance.legend %}
+{% set helpText = content.pages.attendance.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/monitoring-conditions/curfew-conditions.njk
+++ b/server/views/pages/order/monitoring-conditions/curfew-conditions.njk
@@ -1,12 +1,13 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Monitoring conditions - Curfew conditions - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Monitoring conditions" %}
-{% set subsection = "Curfew with electronic monitoring" %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{% set section = content.pages.curfewConditions.section %}
+{% set heading = content.pages.curfewConditions.title %}
+{% set legend = content.pages.curfewConditions.legend %}
+{% set helpText = content.pages.curfewConditions.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/monitoring-conditions/curfew-release-date.njk
+++ b/server/views/pages/order/monitoring-conditions/curfew-release-date.njk
@@ -1,12 +1,13 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Monitoring conditions - Curfew release date - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Monitoring conditions" %}
-{% set subsection = "Curfew for day of release" %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "../../../partials/timeSpanInput.njk" import timeSpanInput %}
+
+{% set section = content.pages.curfewReleaseDate.section %}
+{% set heading = content.pages.curfewReleaseDate.title %}
+{% set legend = content.pages.curfewReleaseDate.legend %}
+{% set helpText = content.pages.curfewReleaseDate.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/monitoring-conditions/curfew-timetable.njk
+++ b/server/views/pages/order/monitoring-conditions/curfew-timetable.njk
@@ -1,11 +1,12 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Monitoring conditions - Curfew timetable - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Monitoring conditions" %}
-{% set subsection = "Timetable for curfew with electronic monitoring" %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "../../../partials/timeTable.njk" import timeTable %}
+
+{% set section = content.pages.curfewTimetable.section %}
+{% set heading = content.pages.curfewTimetable.title %}
+{% set legend = content.pages.curfewTimetable.legend %}
+{% set helpText = content.pages.curfewTimetable.helpText %}
 
 {% block formInputs %}
   {% call govukFieldset({

--- a/server/views/pages/order/monitoring-conditions/enforcement-zone.njk
+++ b/server/views/pages/order/monitoring-conditions/enforcement-zone.njk
@@ -1,15 +1,16 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Monitoring conditions - Enforcement zone - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Monitoring conditions" %}
-{% set subsection = "Exclusion and inclusion zones" %}
 {% set formEncoding = 'encType=multipart/form-data' %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% set section = content.pages.exclusionZone.section %}
+{% set heading = content.pages.exclusionZone.title %}
+{% set legend = content.pages.exclusionZone.legend %}
+{% set helpText = content.pages.exclusionZone.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/monitoring-conditions/index.njk
+++ b/server/views/pages/order/monitoring-conditions/index.njk
@@ -1,8 +1,5 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Monitoring conditions - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Monitoring conditions" %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
@@ -10,6 +7,11 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "../../../partials/timeInput.njk" import timeInput %}
 {% from "../../../partials/dateTimeInput.njk" import dateTimeInput %}
+
+{% set section = content.pages.monitoringConditions.section %}
+{% set heading = content.pages.monitoringConditions.title %}
+{% set legend = content.pages.monitoringConditions.legend %}
+{% set helpText = content.pages.monitoringConditions.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/pages/order/monitoring-conditions/trail-monitoring.njk
+++ b/server/views/pages/order/monitoring-conditions/trail-monitoring.njk
@@ -1,10 +1,11 @@
 {% extends "../../../partials/form-layout.njk" %}
 
-{% set pageTitle = "Monitoring conditions - Trail monitoring - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-{% set section = "Monitoring conditions" %}
-{% set subsection = "Trail monitoring" %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+
+{% set section = content.pages.trailMonitoring.section %}
+{% set heading = content.pages.trailMonitoring.title %}
+{% set legend = content.pages.trailMonitoring.legend %}
+{% set helpText = content.pages.trailMonitoring.helpText %}
 
 {% block formInputs %}
 

--- a/server/views/partials/form-layout.njk
+++ b/server/views/partials/form-layout.njk
@@ -8,6 +8,9 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
+{% set mainClasses = "app-container govuk-body" %}
+{% set pageTitle = heading + " - " + section + " - " + applicationName %}
+
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
@@ -34,16 +37,21 @@
         {{ govukErrorSummary(errorSummary) }}
       {% endif %}
 
-      {{ mojPageHeaderActions({
-        heading: {
-          text: section,
-          classes: "govuk-heading-l"
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ section }}</span>
+        {{ heading }}
+      </h1>
+
+      {{ govukFieldset({
+        legend: {
+          text: legend,
+          classes: "govuk-fieldset__legend--s"
         }
       }) }}
 
-      {% if subsection %}
-        <h2 class="govuk-heading-m">{{ subsection }}</h2>
-      {% endif %}
+      <p>
+        {{ helpText }}
+      </p>
 
       <form action="" method="post" {{ formEncoding }}>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">


### PR DESCRIPTION
- Update all heading to match new format / content
- Fixed the address submission tests that were previously setup incorrectly. This wasn't caught because the `SecondaryAddressPage` and `TertiaryAddressPage` were checking for the wrong page headings.
