### PR TITLE
Update risk category list to match API

### DIFF
--- a/server/i18n/en/index.ts
+++ b/server/i18n/en/index.ts
@@ -20,6 +20,7 @@ import tertiaryAddressPageContent from './pages/tertiaryAddress'
 import trailMonitoringPageContent from './pages/trailMonitoring'
 import uploadLicencePageContent from './pages/uploadLicence'
 import uploadPhotoIdPageContent from './pages/uploadPhotoId'
+import riskCategories from './reference/riskCategories'
 
 const en: I18n = {
   pages: {
@@ -44,6 +45,9 @@ const en: I18n = {
     trailMonitoring: trailMonitoringPageContent,
     uploadLicense: uploadLicencePageContent,
     uploadPhotoId: uploadPhotoIdPageContent,
+  },
+  reference: {
+    riskCategories,
   },
 }
 

--- a/server/i18n/en/reference/riskCategories.ts
+++ b/server/i18n/en/reference/riskCategories.ts
@@ -1,0 +1,19 @@
+import RiskCategories from '../../../types/i18n/reference/riskCategories'
+
+const riskCategories: RiskCategories = {
+  THREATS_OF_VIOLENCE: 'Violent behaviour or threats of violence',
+  SEXUAL_OFFENCES: 'Sex offender',
+  RISK_TO_GENDER: 'Offensive towards someone because of their sex or gender',
+  RACIAL_ABUSE_OR_THREATS: 'Offensive towards someone because of their race, nationality, ethnicity or national origin',
+  HOMOPHOBIC_VIEWS: 'Offensive towards someone because of their sexual orientation',
+  HISTORY_OF_SUBSTANCE_ABUSE: 'History of substance abuse',
+  DIVERSITY_CONCERNS: 'Diversity concerns (mental health issues, learning difficulties etc)',
+  IOM: 'Managed through IOM',
+  SAFEGUARDING_ISSUE: 'Safeguarding Issues',
+  OTHER_OCCUPANTS: 'Another person or people living at the property who are threatening or violent',
+  UNDER_18: 'Children under the age of 18 are living at the property',
+  DANGEROUS_ANIMALS: 'Animals at the property, for example dogs',
+  OTHER_RISKS: 'Other known risks',
+}
+
+export default riskCategories

--- a/server/types/i18n/index.ts
+++ b/server/types/i18n/index.ts
@@ -15,6 +15,7 @@ import NoFixedAbodePageContent from './pages/noFixedAbode'
 import ResponsibleAdultPageContent from './pages/responsibleAdult'
 import TrailMonitoringPageContent from './pages/trailMonitoring'
 import UploadDocumentPageContent from './pages/uploadDocument'
+import RiskCategories from './reference/riskCategories'
 
 type I18n = {
   pages: {
@@ -39,6 +40,9 @@ type I18n = {
     trailMonitoring: TrailMonitoringPageContent
     uploadLicense: UploadDocumentPageContent
     uploadPhotoId: UploadDocumentPageContent
+  }
+  reference: {
+    riskCategories: RiskCategories
   }
 }
 

--- a/server/types/i18n/reference/riskCategories.ts
+++ b/server/types/i18n/reference/riskCategories.ts
@@ -1,0 +1,18 @@
+type RiskCategories = Record<
+  | 'DANGEROUS_ANIMALS'
+  | 'DIVERSITY_CONCERNS'
+  | 'HISTORY_OF_SUBSTANCE_ABUSE'
+  | 'HOMOPHOBIC_VIEWS'
+  | 'IOM'
+  | 'OTHER_OCCUPANTS'
+  | 'OTHER_RISKS'
+  | 'RACIAL_ABUSE_OR_THREATS'
+  | 'RISK_TO_GENDER'
+  | 'SAFEGUARDING_ISSUE'
+  | 'SEXUAL_OFFENCES'
+  | 'THREATS_OF_VIOLENCE'
+  | 'UNDER_18',
+  string
+>
+
+export default RiskCategories

--- a/server/views/pages/order/installation-and-risk/index.njk
+++ b/server/views/pages/order/installation-and-risk/index.njk
@@ -61,7 +61,7 @@
     hint: {
       text: content.pages.installationAndRisk.questions.riskCategory.hint
     },
-    items: content.reference.riskCategories | toOptions(false),
+    items: content.reference.riskCategories | toOptions(not isOrderEditable),
     errorMessage: riskCategory.error,
     values: riskCategory.values
   }) }}

--- a/server/views/pages/order/installation-and-risk/index.njk
+++ b/server/views/pages/order/installation-and-risk/index.njk
@@ -61,73 +61,7 @@
     hint: {
       text: content.pages.installationAndRisk.questions.riskCategory.hint
     },
-    items: [
-      {
-        text: 'Violent behaviour or threats of violence',
-        value: 'VIOLENCE',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Sex offender',
-        value: 'SEXUAL_OFFENCES',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Offensive towards someone because of their sex or gender',
-        value: 'GENDER',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Offensive towards someone because of their race, nationality, ethnicity or national origin',
-        value: 'RACIAL',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Offensive towards someone because of their sexual orientation',
-        value: 'SEXUAL_ORIENTATION',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'History of substance abuse',
-        value: 'SUBSTANCE_ABUSE',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Diversity concerns (mental health issues, learning difficulties etc)',
-        value: 'DIVERSITY',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Managed through IOM',
-        value: 'IOM',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Safeguarding Issues',
-        value: 'SAFEGUARDING',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Another person or people living at the property who are threatening or violent',
-        value: 'VIOLENT_OTHER',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Children under the age of 18 are living at the property',
-        value: 'UNDER_18',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Animals at the property, for example dogs',
-        value: 'ANIMALS',
-        disabled: not isOrderEditable
-      },
-      {
-        text: 'Other known risks',
-        value: 'OTHER_RISKS',
-        disabled: not isOrderEditable
-      }
-    ],
+    items: content.reference.riskCategories | toOptions(false),
     errorMessage: riskCategory.error,
     values: riskCategory.values
   }) }}


### PR DESCRIPTION
- I've placed the riskCategory reference data in the i18n directory as we'll need to support different display text for reference data if at some point we add Welsh language support. (I will move the other bits of reference data in a future pull request to maintain consistency).
- The view has been updated to use the reference data rather than hard-code values in the nunjucks template.