### PR TITLE
Update the about the device wearer check your answer page with the new content

### DIFF
--- a/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.cy.ts
@@ -51,23 +51,23 @@ context('Device wearer - check your answers', () => {
         status: 'IN_PROGRESS',
         order: {
           deviceWearer: {
-            nomisId: null,
-            pncId: null,
-            deliusId: null,
-            prisonNumber: null,
-            homeOfficeReferenceNumber: null,
+            nomisId: 'nomis',
+            pncId: 'pnc',
+            deliusId: 'delius',
+            prisonNumber: 'prison',
+            homeOfficeReferenceNumber: 'ho',
             firstName: 'test',
             lastName: 'tester',
-            alias: null,
-            dateOfBirth: null,
+            alias: 'tes',
+            dateOfBirth: '2000-01-01T00:00:00Z',
             adultAtTimeOfInstallation: true,
-            sex: null,
-            gender: 'self-identify',
-            otherGender: 'Furby',
-            disabilities: 'OTHER',
-            otherDisability: 'Broken arm',
+            sex: 'male',
+            gender: 'male',
+            otherGender: null,
+            disabilities: 'MENTAL_HEALTH',
+            otherDisability: null,
             noFixedAbode: null,
-            interpreterRequired: null,
+            interpreterRequired: false,
           },
           DeviceWearerResponsibleAdult: null,
         },
@@ -80,7 +80,102 @@ context('Device wearer - check your answers', () => {
       const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
 
       page.personDetailsSection.shouldExist()
+      page.personDetailsSection.shouldHaveItems([
+        { key: "What is the device wearer's first name?", value: 'test' },
+        { key: "What is the device wearer's last name?", value: 'tester' },
+        { key: "What is the device wearer's preferred name or names? (optional)", value: 'tes' },
+        { key: "What is the device wearer's date of birth?", value: '01/01/2000' },
+        { key: 'Is a responsible adult required?', value: 'Yes' },
+        { key: 'What is the sex of the device wearer?', value: 'Male' },
+        { key: "What is the device wearer's gender?", value: 'Male' },
+        {
+          key: 'Does the device wearer have any of the disabilities or health conditions listed? (optional)',
+          value: 'Mental health',
+        },
+        { key: 'What language does the interpreter need to use? (optional)', value: '' },
+        { key: 'Is an interpreter needed?', value: 'No' },
+      ])
+      page.personDetailsSection.shouldNotHaveItems([
+        "What is the device wearer's disability or health condition? (optional)",
+        "What is the device wearer's chosen identity?",
+      ])
       page.identityNumbersSection.shouldExist()
+      page.identityNumbersSection.shouldHaveItems([
+        { key: 'National Offender Management Information System (NOMIS) ID (optional)', value: 'nomis' },
+        { key: 'Police National Computer (PNC) ID (optional)', value: 'pnc' },
+        { key: 'Delius ID (optional)', value: 'delius' },
+        { key: 'Prison number (optional)', value: 'prison' },
+        { key: 'Home Office Reference Number (optional)', value: 'ho' },
+      ])
+      page.responsibleAdultSection.shouldNotExist()
+    })
+  })
+
+  context('Device wearer has an unlisted disability and gender', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+        order: {
+          deviceWearer: {
+            nomisId: 'nomis',
+            pncId: 'pnc',
+            deliusId: 'delius',
+            prisonNumber: 'prison',
+            homeOfficeReferenceNumber: 'ho',
+            firstName: 'test',
+            lastName: 'tester',
+            alias: 'tes',
+            dateOfBirth: '2000-01-01T00:00:00Z',
+            adultAtTimeOfInstallation: true,
+            sex: 'male',
+            gender: 'self-identify',
+            otherGender: 'Furby',
+            disabilities: 'OTHER',
+            otherDisability: 'Broken arm',
+            noFixedAbode: null,
+            interpreterRequired: false,
+          },
+          DeviceWearerResponsibleAdult: null,
+        },
+      })
+
+      cy.signIn()
+    })
+
+    it('should show otherDisability and otherGender questions and answers', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
+
+      page.personDetailsSection.shouldExist()
+      page.personDetailsSection.shouldHaveItems([
+        { key: "What is the device wearer's first name?", value: 'test' },
+        { key: "What is the device wearer's last name?", value: 'tester' },
+        { key: "What is the device wearer's preferred name or names? (optional)", value: 'tes' },
+        { key: "What is the device wearer's date of birth?", value: '01/01/2000' },
+        { key: 'Is a responsible adult required?', value: 'Yes' },
+        { key: 'What is the sex of the device wearer?', value: 'Male' },
+        { key: "What is the device wearer's gender?", value: 'Self identify' },
+        { key: "What is the device wearer's chosen identity?", value: 'Furby' },
+        {
+          key: 'Does the device wearer have any of the disabilities or health conditions listed? (optional)',
+          value: 'Other',
+        },
+        { key: "What is the device wearer's disability or health condition? (optional)", value: 'Broken arm' },
+        { key: 'What language does the interpreter need to use? (optional)', value: '' },
+        { key: 'Is an interpreter needed?', value: 'No' },
+      ])
+      page.identityNumbersSection.shouldExist()
+      page.identityNumbersSection.shouldHaveItems([
+        { key: 'National Offender Management Information System (NOMIS) ID (optional)', value: 'nomis' },
+        { key: 'Police National Computer (PNC) ID (optional)', value: 'pnc' },
+        { key: 'Delius ID (optional)', value: 'delius' },
+        { key: 'Prison number (optional)', value: 'prison' },
+        { key: 'Home Office Reference Number (optional)', value: 'ho' },
+      ])
       page.responsibleAdultSection.shouldNotExist()
     })
   })
@@ -96,27 +191,27 @@ context('Device wearer - check your answers', () => {
         status: 'IN_PROGRESS',
         order: {
           deviceWearer: {
-            nomisId: null,
-            pncId: null,
-            deliusId: null,
-            prisonNumber: null,
-            homeOfficeReferenceNumber: null,
+            nomisId: 'nomis',
+            pncId: 'pnc',
+            deliusId: 'delius',
+            prisonNumber: 'prison',
+            homeOfficeReferenceNumber: 'ho',
             firstName: 'test',
             lastName: 'tester',
-            alias: null,
-            dateOfBirth: null,
+            alias: 'tes',
+            dateOfBirth: '2000-01-01T00:00:00Z',
             adultAtTimeOfInstallation: false,
-            sex: null,
-            gender: 'self-identify',
-            otherGender: 'Furby',
-            disabilities: 'OTHER',
-            otherDisability: 'Broken arm',
+            sex: 'male',
+            gender: 'male',
+            otherGender: null,
+            disabilities: 'MENTAL_HEALTH',
+            otherDisability: null,
             noFixedAbode: null,
-            interpreterRequired: null,
+            interpreterRequired: false,
           },
           deviceWearerResponsibleAdult: {
-            relationship: 'Other',
-            otherRelationshipDetails: 'Partner',
+            relationship: 'parent',
+            otherRelationshipDetails: '',
             fullName: 'Audrey Taylor',
             contactNumber: '07101 123 456',
           },
@@ -126,12 +221,118 @@ context('Device wearer - check your answers', () => {
       cy.signIn()
     })
 
-    it('should not show responsible adult section', () => {
+    it('should show responsible adult section', () => {
       const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
 
       page.personDetailsSection.shouldExist()
+      page.personDetailsSection.shouldHaveItems([
+        { key: "What is the device wearer's first name?", value: 'test' },
+        { key: "What is the device wearer's last name?", value: 'tester' },
+        { key: "What is the device wearer's preferred name or names? (optional)", value: 'tes' },
+        { key: "What is the device wearer's date of birth?", value: '01/01/2000' },
+        { key: 'Is a responsible adult required?', value: 'No' },
+        { key: 'What is the sex of the device wearer?', value: 'Male' },
+        { key: "What is the device wearer's gender?", value: 'Male' },
+        {
+          key: 'Does the device wearer have any of the disabilities or health conditions listed? (optional)',
+          value: 'Mental health',
+        },
+        { key: 'What language does the interpreter need to use? (optional)', value: '' },
+        { key: 'Is an interpreter needed?', value: 'No' },
+      ])
       page.identityNumbersSection.shouldExist()
+      page.identityNumbersSection.shouldHaveItems([
+        { key: 'National Offender Management Information System (NOMIS) ID (optional)', value: 'nomis' },
+        { key: 'Police National Computer (PNC) ID (optional)', value: 'pnc' },
+        { key: 'Delius ID (optional)', value: 'delius' },
+        { key: 'Prison number (optional)', value: 'prison' },
+        { key: 'Home Office Reference Number (optional)', value: 'ho' },
+      ])
       page.responsibleAdultSection.shouldExist()
+      page.responsibleAdultSection.shouldHaveItems([
+        { key: "What is the responsible adult's relationship to the device wearer?", value: 'Parent' },
+        { key: "What is the responsible adult's full name?", value: 'Audrey Taylor' },
+        { key: "What is the responsible adult's telephone number? (optional)", value: '07101 123 456' },
+      ])
+      page.responsibleAdultSection.shouldNotHaveItems(['Relationship to device wearer'])
+    })
+  })
+
+  context('Device Wearer is under 18 and the responsible adult has an unlisted relationship', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+        order: {
+          deviceWearer: {
+            nomisId: 'nomis',
+            pncId: 'pnc',
+            deliusId: 'delius',
+            prisonNumber: 'prison',
+            homeOfficeReferenceNumber: 'ho',
+            firstName: 'test',
+            lastName: 'tester',
+            alias: 'tes',
+            dateOfBirth: '2000-01-01T00:00:00Z',
+            adultAtTimeOfInstallation: false,
+            sex: 'male',
+            gender: 'male',
+            otherGender: null,
+            disabilities: 'MENTAL_HEALTH',
+            otherDisability: null,
+            noFixedAbode: null,
+            interpreterRequired: false,
+          },
+          deviceWearerResponsibleAdult: {
+            relationship: 'other',
+            otherRelationshipDetails: 'Sibling',
+            fullName: 'Audrey Taylor',
+            contactNumber: '07101 123 456',
+          },
+        },
+      })
+
+      cy.signIn()
+    })
+
+    it('should show responsible adult section and otherRelationshipDeatils question and answer', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
+
+      page.personDetailsSection.shouldExist()
+      page.personDetailsSection.shouldHaveItems([
+        { key: "What is the device wearer's first name?", value: 'test' },
+        { key: "What is the device wearer's last name?", value: 'tester' },
+        { key: "What is the device wearer's preferred name or names? (optional)", value: 'tes' },
+        { key: "What is the device wearer's date of birth?", value: '01/01/2000' },
+        { key: 'Is a responsible adult required?', value: 'No' },
+        { key: 'What is the sex of the device wearer?', value: 'Male' },
+        { key: "What is the device wearer's gender?", value: 'Male' },
+        {
+          key: 'Does the device wearer have any of the disabilities or health conditions listed? (optional)',
+          value: 'Mental health',
+        },
+        { key: 'What language does the interpreter need to use? (optional)', value: '' },
+        { key: 'Is an interpreter needed?', value: 'No' },
+      ])
+      page.identityNumbersSection.shouldExist()
+      page.identityNumbersSection.shouldHaveItems([
+        { key: 'National Offender Management Information System (NOMIS) ID (optional)', value: 'nomis' },
+        { key: 'Police National Computer (PNC) ID (optional)', value: 'pnc' },
+        { key: 'Delius ID (optional)', value: 'delius' },
+        { key: 'Prison number (optional)', value: 'prison' },
+        { key: 'Home Office Reference Number (optional)', value: 'ho' },
+      ])
+      page.responsibleAdultSection.shouldExist()
+      page.responsibleAdultSection.shouldHaveItems([
+        { key: "What is the responsible adult's relationship to the device wearer?", value: 'Other' },
+        { key: 'Relationship to device wearer', value: 'Sibling' },
+        { key: "What is the responsible adult's full name?", value: 'Audrey Taylor' },
+        { key: "What is the responsible adult's telephone number? (optional)", value: '07101 123 456' },
+      ])
     })
   })
 

--- a/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.cy.ts
@@ -79,7 +79,9 @@ context('Device wearer - check your answers', () => {
     it('should not show responsible adult section', () => {
       const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
 
-      page.responsibleAdultSection().should('not.exist')
+      page.personDetailsSection.shouldExist()
+      page.identityNumbersSection.shouldExist()
+      page.responsibleAdultSection.shouldNotExist()
     })
   })
 
@@ -127,7 +129,9 @@ context('Device wearer - check your answers', () => {
     it('should not show responsible adult section', () => {
       const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId })
 
-      page.responsibleAdultSection().should('exist')
+      page.personDetailsSection.shouldExist()
+      page.identityNumbersSection.shouldExist()
+      page.responsibleAdultSection.shouldExist()
     })
   })
 

--- a/integration_tests/pages/checkYourAnswersPage.ts
+++ b/integration_tests/pages/checkYourAnswersPage.ts
@@ -1,0 +1,8 @@
+import AppPage from './appPage'
+import { PageElement } from './page'
+
+export default class CheckYourAnswersPage extends AppPage {
+  continueButton = (): PageElement => cy.contains('Save and go to next section')
+
+  returnButton = (): PageElement => cy.contains('Save as draft')
+}

--- a/integration_tests/pages/components/summaryListComponent.ts
+++ b/integration_tests/pages/components/summaryListComponent.ts
@@ -1,0 +1,23 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import { PageElement } from '../page'
+
+export default class SummaryListComponent {
+  private elementCacheId: string = uuidv4()
+
+  constructor(private readonly label: string) {}
+
+  get element(): PageElement {
+    return cy.contains('h2', this.label)
+  }
+
+  // Helpers
+
+  shouldExist() {
+    this.element.should('exist')
+  }
+
+  shouldNotExist() {
+    this.element.should('not.exist')
+  }
+}

--- a/integration_tests/pages/components/summaryListComponent.ts
+++ b/integration_tests/pages/components/summaryListComponent.ts
@@ -11,6 +11,10 @@ export default class SummaryListComponent {
     return cy.contains('h2', this.label)
   }
 
+  get list(): PageElement {
+    return this.element.siblings('.govuk-summary-list')
+  }
+
   // Helpers
 
   shouldExist() {
@@ -19,5 +23,24 @@ export default class SummaryListComponent {
 
   shouldNotExist() {
     this.element.should('not.exist')
+  }
+
+  shouldHaveItem(key: string, value: string) {
+    return this.list
+      .contains('.govuk-summary-list__key', key)
+      .siblings('.govuk-summary-list__value')
+      .should('contain.text', value)
+  }
+
+  shouldHaveItems(items: Array<{ key: string; value: string }>) {
+    return items.map(({ key, value }) => this.shouldHaveItem(key, value))
+  }
+
+  shouldNotHaveItem(key: string) {
+    return this.list.should('not.contain.text', key)
+  }
+
+  shouldNotHaveItems(keys: Array<string>) {
+    return keys.map(key => this.shouldNotHaveItem(key))
   }
 }

--- a/integration_tests/pages/order/about-the-device-wearer/check-your-answers.ts
+++ b/integration_tests/pages/order/about-the-device-wearer/check-your-answers.ts
@@ -1,17 +1,26 @@
-import AppPage from '../../appPage'
 import paths from '../../../../server/constants/paths'
-import { PageElement } from '../../page'
+import SummaryListComponent from '../../components/summaryListComponent'
+import CheckYourAnswersPage from '../../checkYourAnswersPage'
 
-export default class DeviceWearerCheckYourAnswersPage extends AppPage {
+export default class DeviceWearerCheckYourAnswersPage extends CheckYourAnswersPage {
   constructor() {
     super('Check your answers', paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS)
   }
 
-  phaseBanner = (): PageElement => cy.get('[data-qa=header-phase-banner]')
+  // SECTIONS
 
-  continueButton = (): PageElement => cy.contains('Continue')
+  get personDetailsSection(): SummaryListComponent {
+    const label = 'Personal details'
+    return new SummaryListComponent(label)
+  }
 
-  returnButton = (): PageElement => cy.contains('Return back to form section menu')
+  get identityNumbersSection(): SummaryListComponent {
+    const label = 'Identity numbers'
+    return new SummaryListComponent(label)
+  }
 
-  responsibleAdultSection = (): PageElement => cy.contains('Responsible adult')
+  get responsibleAdultSection(): SummaryListComponent {
+    const label = 'Responsible adult details'
+    return new SummaryListComponent(label)
+  }
 }

--- a/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.test.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.test.ts
@@ -72,7 +72,7 @@ describe('DeviceWearerCheckAnswersController', () => {
       deviceWearer: [
         {
           key: {
-            text: 'First names',
+            text: "What is the device wearer's first name?",
           },
           value: {
             text: '',
@@ -82,14 +82,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'first names',
+                visuallyHiddenText: "what is the device wearer's first name?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Last name',
+            text: "What is the device wearer's last name?",
           },
           value: {
             text: '',
@@ -99,14 +99,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'last name',
+                visuallyHiddenText: "what is the device wearer's last name?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Preferred name or alias (optional)',
+            text: "What is the device wearer's preferred name or names? (optional)",
           },
           value: {
             text: '',
@@ -116,14 +116,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'preferred name or alias (optional)',
+                visuallyHiddenText: "what is the device wearer's preferred name or names? (optional)",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Date of birth',
+            text: "What is the device wearer's date of birth?",
           },
           value: {
             text: '',
@@ -133,14 +133,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'date of birth',
+                visuallyHiddenText: "what is the device wearer's date of birth?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Will the device wearer be 18 years old when the device is installed?',
+            text: 'Is a responsible adult required?',
           },
           value: {
             text: '',
@@ -150,14 +150,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'will the device wearer be 18 years old when the device is installed?',
+                visuallyHiddenText: 'is a responsible adult required?',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Sex',
+            text: 'What is the sex of the device wearer?',
           },
           value: {
             text: '',
@@ -167,14 +167,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'sex',
+                visuallyHiddenText: 'what is the sex of the device wearer?',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Gender',
+            text: "What is the device wearer's gender?",
           },
           value: {
             text: '',
@@ -184,14 +184,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'gender',
+                visuallyHiddenText: "what is the device wearer's gender?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Disabilities (optional)',
+            text: 'Does the device wearer have any of the disabilities or health conditions listed? (optional)',
           },
           value: {
             html: '',
@@ -201,14 +201,15 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'disabilities (optional)',
+                visuallyHiddenText:
+                  'does the device wearer have any of the disabilities or health conditions listed? (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Disability, if other (optional)',
+            text: "What is the device wearer's disability or health condition? (optional)",
           },
           value: {
             text: '',
@@ -218,14 +219,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'disability, if other (optional)',
+                visuallyHiddenText: "what is the device wearer's disability or health condition? (optional)",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Main language',
+            text: 'What language does the interpreter need to use? (optional)',
           },
           value: {
             text: '',
@@ -235,14 +236,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'main language',
+                visuallyHiddenText: 'what language does the interpreter need to use? (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Is an interpreter required?',
+            text: 'Is an interpreter needed?',
           },
           value: {
             text: '',
@@ -252,7 +253,7 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'is an interpreter required?',
+                visuallyHiddenText: 'is an interpreter needed?',
               },
             ],
           },
@@ -261,7 +262,7 @@ describe('DeviceWearerCheckAnswersController', () => {
       personIdentifiers: [
         {
           key: {
-            text: 'NOMIS ID (optional)',
+            text: 'National Offender Management Information System (NOMIS) ID (optional)',
           },
           value: {
             text: '',
@@ -271,14 +272,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'nomis id (optional)',
+                visuallyHiddenText: 'national offender management information system (nomis) id (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'PNC ID (optional)',
+            text: 'Police National Computer (PNC) ID (optional)',
           },
           value: {
             text: '',
@@ -288,14 +289,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'pnc id (optional)',
+                visuallyHiddenText: 'police national computer (pnc) id (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'DELIUS ID (optional)',
+            text: 'Delius ID (optional)',
           },
           value: {
             text: '',
@@ -329,7 +330,7 @@ describe('DeviceWearerCheckAnswersController', () => {
         },
         {
           key: {
-            text: 'Home Office reference number (optional)',
+            text: 'Home Office Reference Number (optional)',
           },
           value: {
             text: '',
@@ -364,7 +365,7 @@ describe('DeviceWearerCheckAnswersController', () => {
       deviceWearer: [
         {
           key: {
-            text: 'First names',
+            text: "What is the device wearer's first name?",
           },
           value: {
             text: 'tester',
@@ -374,14 +375,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'first names',
+                visuallyHiddenText: "what is the device wearer's first name?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Last name',
+            text: "What is the device wearer's last name?",
           },
           value: {
             text: 'testington',
@@ -391,14 +392,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'last name',
+                visuallyHiddenText: "what is the device wearer's last name?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Preferred name or alias (optional)',
+            text: "What is the device wearer's preferred name or names? (optional)",
           },
           value: {
             text: 'test',
@@ -408,14 +409,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'preferred name or alias (optional)',
+                visuallyHiddenText: "what is the device wearer's preferred name or names? (optional)",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Date of birth',
+            text: "What is the device wearer's date of birth?",
           },
           value: {
             text: '10/10/1980',
@@ -425,14 +426,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'date of birth',
+                visuallyHiddenText: "what is the device wearer's date of birth?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Will the device wearer be 18 years old when the device is installed?',
+            text: 'Is a responsible adult required?',
           },
           value: {
             text: 'Yes',
@@ -442,14 +443,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'will the device wearer be 18 years old when the device is installed?',
+                visuallyHiddenText: 'is a responsible adult required?',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Sex',
+            text: 'What is the sex of the device wearer?',
           },
           value: {
             text: 'Male',
@@ -459,14 +460,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'sex',
+                visuallyHiddenText: 'what is the sex of the device wearer?',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Gender',
+            text: "What is the device wearer's gender?",
           },
           value: {
             text: 'Male',
@@ -476,14 +477,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'gender',
+                visuallyHiddenText: "what is the device wearer's gender?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Disabilities (optional)',
+            text: 'Does the device wearer have any of the disabilities or health conditions listed? (optional)',
           },
           value: {
             html: 'Vision<br/>Mobility',
@@ -493,14 +494,15 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'disabilities (optional)',
+                visuallyHiddenText:
+                  'does the device wearer have any of the disabilities or health conditions listed? (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Disability, if other (optional)',
+            text: "What is the device wearer's disability or health condition? (optional)",
           },
           value: {
             text: '',
@@ -510,14 +512,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'disability, if other (optional)',
+                visuallyHiddenText: "what is the device wearer's disability or health condition? (optional)",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Main language',
+            text: 'What language does the interpreter need to use? (optional)',
           },
           value: {
             text: '',
@@ -527,14 +529,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'main language',
+                visuallyHiddenText: 'what language does the interpreter need to use? (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Is an interpreter required?',
+            text: 'Is an interpreter needed?',
           },
           value: {
             text: 'No',
@@ -544,7 +546,7 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'is an interpreter required?',
+                visuallyHiddenText: 'is an interpreter needed?',
               },
             ],
           },
@@ -553,7 +555,7 @@ describe('DeviceWearerCheckAnswersController', () => {
       personIdentifiers: [
         {
           key: {
-            text: 'NOMIS ID (optional)',
+            text: 'National Offender Management Information System (NOMIS) ID (optional)',
           },
           value: {
             text: 'nomis',
@@ -563,14 +565,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'nomis id (optional)',
+                visuallyHiddenText: 'national offender management information system (nomis) id (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'PNC ID (optional)',
+            text: 'Police National Computer (PNC) ID (optional)',
           },
           value: {
             text: 'pnc',
@@ -580,14 +582,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'pnc id (optional)',
+                visuallyHiddenText: 'police national computer (pnc) id (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'DELIUS ID (optional)',
+            text: 'Delius ID (optional)',
           },
           value: {
             text: 'delius',
@@ -621,7 +623,7 @@ describe('DeviceWearerCheckAnswersController', () => {
         },
         {
           key: {
-            text: 'Home Office reference number (optional)',
+            text: 'Home Office Reference Number (optional)',
           },
           value: {
             text: 'home office',
@@ -656,7 +658,7 @@ describe('DeviceWearerCheckAnswersController', () => {
       deviceWearer: [
         {
           key: {
-            text: 'First names',
+            text: "What is the device wearer's first name?",
           },
           value: {
             text: 'tester',
@@ -666,14 +668,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'first names',
+                visuallyHiddenText: "what is the device wearer's first name?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Last name',
+            text: "What is the device wearer's last name?",
           },
           value: {
             text: 'testington',
@@ -683,14 +685,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'last name',
+                visuallyHiddenText: "what is the device wearer's last name?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Preferred name or alias (optional)',
+            text: "What is the device wearer's preferred name or names? (optional)",
           },
           value: {
             text: 'test',
@@ -700,14 +702,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'preferred name or alias (optional)',
+                visuallyHiddenText: "what is the device wearer's preferred name or names? (optional)",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Date of birth',
+            text: "What is the device wearer's date of birth?",
           },
           value: {
             text: '10/10/1980',
@@ -717,14 +719,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'date of birth',
+                visuallyHiddenText: "what is the device wearer's date of birth?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Will the device wearer be 18 years old when the device is installed?',
+            text: 'Is a responsible adult required?',
           },
           value: {
             text: 'No',
@@ -734,14 +736,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'will the device wearer be 18 years old when the device is installed?',
+                visuallyHiddenText: 'is a responsible adult required?',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Sex',
+            text: 'What is the sex of the device wearer?',
           },
           value: {
             text: 'Male',
@@ -751,14 +753,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'sex',
+                visuallyHiddenText: 'what is the sex of the device wearer?',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Gender',
+            text: "What is the device wearer's gender?",
           },
           value: {
             text: 'Male',
@@ -768,14 +770,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'gender',
+                visuallyHiddenText: "what is the device wearer's gender?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Disabilities (optional)',
+            text: 'Does the device wearer have any of the disabilities or health conditions listed? (optional)',
           },
           value: {
             html: 'Vision<br/>Mobility',
@@ -785,14 +787,15 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'disabilities (optional)',
+                visuallyHiddenText:
+                  'does the device wearer have any of the disabilities or health conditions listed? (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Disability, if other (optional)',
+            text: "What is the device wearer's disability or health condition? (optional)",
           },
           value: {
             text: '',
@@ -802,14 +805,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'disability, if other (optional)',
+                visuallyHiddenText: "what is the device wearer's disability or health condition? (optional)",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Main language',
+            text: 'What language does the interpreter need to use? (optional)',
           },
           value: {
             text: '',
@@ -819,14 +822,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'main language',
+                visuallyHiddenText: 'what language does the interpreter need to use? (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Is an interpreter required?',
+            text: 'Is an interpreter needed?',
           },
           value: {
             text: 'No',
@@ -836,7 +839,7 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'is an interpreter required?',
+                visuallyHiddenText: 'is an interpreter needed?',
               },
             ],
           },
@@ -845,7 +848,7 @@ describe('DeviceWearerCheckAnswersController', () => {
       personIdentifiers: [
         {
           key: {
-            text: 'NOMIS ID (optional)',
+            text: 'National Offender Management Information System (NOMIS) ID (optional)',
           },
           value: {
             text: 'nomis',
@@ -855,14 +858,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'nomis id (optional)',
+                visuallyHiddenText: 'national offender management information system (nomis) id (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'PNC ID (optional)',
+            text: 'Police National Computer (PNC) ID (optional)',
           },
           value: {
             text: 'pnc',
@@ -872,14 +875,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'pnc id (optional)',
+                visuallyHiddenText: 'police national computer (pnc) id (optional)',
               },
             ],
           },
         },
         {
           key: {
-            text: 'DELIUS ID (optional)',
+            text: 'Delius ID (optional)',
           },
           value: {
             text: 'delius',
@@ -913,7 +916,7 @@ describe('DeviceWearerCheckAnswersController', () => {
         },
         {
           key: {
-            text: 'Home Office reference number (optional)',
+            text: 'Home Office Reference Number (optional)',
           },
           value: {
             text: 'home office',
@@ -932,7 +935,7 @@ describe('DeviceWearerCheckAnswersController', () => {
       responsibleAdult: [
         {
           key: {
-            text: 'Relationship',
+            text: "What is the responsible adult's relationship to the device wearer?",
           },
           value: {
             text: 'Parent',
@@ -942,14 +945,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'relationship',
+                visuallyHiddenText: "what is the responsible adult's relationship to the device wearer?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Relationship details, if other (optional)',
+            text: 'Relationship to device wearer',
           },
           value: {
             text: '',
@@ -959,14 +962,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'relationship details, if other (optional)',
+                visuallyHiddenText: 'relationship to device wearer',
               },
             ],
           },
         },
         {
           key: {
-            text: 'Full name',
+            text: "What is the responsible adult's full name?",
           },
           value: {
             text: 'Firstname Lastname',
@@ -976,14 +979,14 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'full name',
+                visuallyHiddenText: "what is the responsible adult's full name?",
               },
             ],
           },
         },
         {
           key: {
-            text: 'Contact number',
+            text: "What is the responsible adult's telephone number? (optional)",
           },
           value: {
             text: '07999999999',
@@ -993,7 +996,7 @@ describe('DeviceWearerCheckAnswersController', () => {
               {
                 href: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
                 text: 'Change',
-                visuallyHiddenText: 'contact number',
+                visuallyHiddenText: "what is the responsible adult's telephone number? (optional)",
               },
             ],
           },

--- a/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.test.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.test.ts
@@ -209,23 +209,6 @@ describe('DeviceWearerCheckAnswersController', () => {
         },
         {
           key: {
-            text: "What is the device wearer's disability or health condition? (optional)",
-          },
-          value: {
-            text: '',
-          },
-          actions: {
-            items: [
-              {
-                href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
-                text: 'Change',
-                visuallyHiddenText: "what is the device wearer's disability or health condition? (optional)",
-              },
-            ],
-          },
-        },
-        {
-          key: {
             text: 'What language does the interpreter need to use? (optional)',
           },
           value: {
@@ -496,23 +479,6 @@ describe('DeviceWearerCheckAnswersController', () => {
                 text: 'Change',
                 visuallyHiddenText:
                   'does the device wearer have any of the disabilities or health conditions listed? (optional)',
-              },
-            ],
-          },
-        },
-        {
-          key: {
-            text: "What is the device wearer's disability or health condition? (optional)",
-          },
-          value: {
-            text: '',
-          },
-          actions: {
-            items: [
-              {
-                href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
-                text: 'Change',
-                visuallyHiddenText: "what is the device wearer's disability or health condition? (optional)",
               },
             ],
           },
@@ -795,23 +761,6 @@ describe('DeviceWearerCheckAnswersController', () => {
         },
         {
           key: {
-            text: "What is the device wearer's disability or health condition? (optional)",
-          },
-          value: {
-            text: '',
-          },
-          actions: {
-            items: [
-              {
-                href: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
-                text: 'Change',
-                visuallyHiddenText: "what is the device wearer's disability or health condition? (optional)",
-              },
-            ],
-          },
-        },
-        {
-          key: {
             text: 'What language does the interpreter need to use? (optional)',
           },
           value: {
@@ -946,23 +895,6 @@ describe('DeviceWearerCheckAnswersController', () => {
                 href: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
                 text: 'Change',
                 visuallyHiddenText: "what is the responsible adult's relationship to the device wearer?",
-              },
-            ],
-          },
-        },
-        {
-          key: {
-            text: 'Relationship to device wearer',
-          },
-          value: {
-            text: '',
-          },
-          actions: {
-            items: [
-              {
-                href: paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id),
-                text: 'Change',
-                visuallyHiddenText: 'relationship to device wearer',
               },
             ],
           },

--- a/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.ts
@@ -18,7 +18,7 @@ export default class DeviceWearerCheckAnswersController {
   view: RequestHandler = async (req: Request, res: Response) => {
     const order = req.order!
 
-    res.render(`pages/order/about-the-device-wearer/check-your-answers`, createViewModel(order))
+    res.render(`pages/order/about-the-device-wearer/check-your-answers`, createViewModel(order, res.locals.content!!))
   }
 
   update: RequestHandler = async (req: Request, res: Response) => {

--- a/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.ts
@@ -18,7 +18,7 @@ export default class DeviceWearerCheckAnswersController {
   view: RequestHandler = async (req: Request, res: Response) => {
     const order = req.order!
 
-    res.render(`pages/order/about-the-device-wearer/check-your-answers`, createViewModel(order, res.locals.content!!))
+    res.render(`pages/order/about-the-device-wearer/check-your-answers`, createViewModel(order, res.locals.content!))
   }
 
   update: RequestHandler = async (req: Request, res: Response) => {

--- a/server/i18n/en/pages/deviceWearer.ts
+++ b/server/i18n/en/pages/deviceWearer.ts
@@ -38,7 +38,7 @@ const deviceWearerPageContent: DeviceWearerPageContent = {
       text: "What is the device wearer's last name?",
     },
     otherDisability: {
-      text: '',
+      text: "What is the device wearer's disability or health condition? (optional)",
     },
     sex: {
       text: 'What is the sex of the device wearer?',

--- a/server/i18n/en/pages/deviceWearer.ts
+++ b/server/i18n/en/pages/deviceWearer.ts
@@ -40,6 +40,9 @@ const deviceWearerPageContent: DeviceWearerPageContent = {
     otherDisability: {
       text: "What is the device wearer's disability or health condition? (optional)",
     },
+    otherGender: {
+      text: "What is the device wearer's chosen identity?",
+    },
     sex: {
       text: 'What is the sex of the device wearer?',
       hint: "Select the sex recorded on the device wearer's birth certificate.",

--- a/server/models/view-models/deviceWearerCheckAnswers.ts
+++ b/server/models/view-models/deviceWearerCheckAnswers.ts
@@ -11,6 +11,30 @@ import {
 import { lookup } from '../../utils/utils'
 import { Order } from '../Order'
 
+const createOtherDisabilityAnswer = (order: Order, content: I18n, uri: string) => {
+  if (order.deviceWearer.disabilities.includes('OTHER')) {
+    return [
+      createTextAnswer(
+        content.pages.deviceWearer.questions.otherDisability.text,
+        order.deviceWearer.otherDisability,
+        uri,
+      ),
+    ]
+  }
+
+  return []
+}
+
+const createOtherGenderAnswer = (order: Order, content: I18n, uri: string) => {
+  if (order.deviceWearer.gender === 'self-identify') {
+    return [
+      createTextAnswer(content.pages.deviceWearer.questions.otherGender.text, order.deviceWearer.otherGender, uri),
+    ]
+  }
+
+  return []
+}
+
 const createDeviceWearerAnswers = (order: Order, content: I18n) => {
   const uri = paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id)
   const disabilities = order.deviceWearer.disabilities.map(disability => lookup(disabilitiesMap, disability))
@@ -30,12 +54,9 @@ const createDeviceWearerAnswers = (order: Order, content: I18n) => {
       lookup(genderMap, order.deviceWearer.gender),
       uri,
     ),
+    ...createOtherGenderAnswer(order, content, uri),
     createMultipleChoiceAnswer(content.pages.deviceWearer.questions.disabilities.text, disabilities, uri),
-    createTextAnswer(
-      content.pages.deviceWearer.questions.otherDisability.text,
-      order.deviceWearer.otherDisability,
-      uri,
-    ),
+    ...createOtherDisabilityAnswer(order, content, uri),
     createTextAnswer(content.pages.deviceWearer.questions.language.text, order.deviceWearer.language, uri),
     createBooleanAnswer(
       content.pages.deviceWearer.questions.interpreterRequired.text,
@@ -60,6 +81,20 @@ const createPersonIdentifierAnswers = (order: Order, content: I18n) => {
   ]
 }
 
+const createOtherRelationshipAnswer = (order: Order, content: I18n, uri: string) => {
+  if (order.deviceWearerResponsibleAdult?.relationship === 'other') {
+    return [
+      createTextAnswer(
+        content.pages.responsibleAdult.questions.otherRelationship.text,
+        order.deviceWearerResponsibleAdult?.otherRelationshipDetails,
+        uri,
+      ),
+    ]
+  }
+
+  return []
+}
+
 const createResponsibeAdultAnswers = (order: Order, content: I18n) => {
   const uri = paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id)
 
@@ -77,11 +112,7 @@ const createResponsibeAdultAnswers = (order: Order, content: I18n) => {
       lookup(relationshipMap, order.deviceWearerResponsibleAdult?.relationship),
       uri,
     ),
-    createTextAnswer(
-      content.pages.responsibleAdult.questions.otherRelationship.text,
-      order.deviceWearerResponsibleAdult?.otherRelationshipDetails,
-      uri,
-    ),
+    ...createOtherRelationshipAnswer(order, content, uri),
     createTextAnswer(
       content.pages.responsibleAdult.questions.fullName.text,
       order.deviceWearerResponsibleAdult?.fullName,

--- a/server/models/view-models/deviceWearerCheckAnswers.ts
+++ b/server/models/view-models/deviceWearerCheckAnswers.ts
@@ -1,6 +1,7 @@
 import { disabilitiesMap, genderMap, sexMap } from '../../constants/about-the-device-wearer'
 import { relationshipMap } from '../../constants/about-the-device-wearer/responsibleAdult'
 import paths from '../../constants/paths'
+import I18n from '../../types/i18n'
 import {
   createBooleanAnswer,
   createDateAnswer,
@@ -10,40 +11,40 @@ import {
 import { lookup } from '../../utils/utils'
 import { Order } from '../Order'
 
-const createDeviceWearerAnswers = (order: Order) => {
+const createDeviceWearerAnswers = (order: Order, content: I18n) => {
   const uri = paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id)
   const disabilities = order.deviceWearer.disabilities.map(disability => lookup(disabilitiesMap, disability))
   return [
-    createTextAnswer('First names', order.deviceWearer.firstName, uri),
-    createTextAnswer('Last name', order.deviceWearer.lastName, uri),
-    createTextAnswer('Preferred name or alias (optional)', order.deviceWearer.alias, uri),
-    createDateAnswer('Date of birth', order.deviceWearer.dateOfBirth, uri),
+    createTextAnswer(content.pages.deviceWearer.questions.firstName.text, order.deviceWearer.firstName, uri),
+    createTextAnswer(content.pages.deviceWearer.questions.lastName.text, order.deviceWearer.lastName, uri),
+    createTextAnswer(content.pages.deviceWearer.questions.alias.text, order.deviceWearer.alias, uri),
+    createDateAnswer(content.pages.deviceWearer.questions.dateOfBirth.text, order.deviceWearer.dateOfBirth, uri),
     createBooleanAnswer(
-      'Will the device wearer be 18 years old when the device is installed?',
+      content.pages.deviceWearer.questions.adultAtTimeOfInstallation.text,
       order.deviceWearer.adultAtTimeOfInstallation,
       uri,
     ),
-    createTextAnswer('Sex', lookup(sexMap, order.deviceWearer.sex), uri),
-    createTextAnswer('Gender', lookup(genderMap, order.deviceWearer.gender), uri),
-    createMultipleChoiceAnswer('Disabilities (optional)', disabilities, uri),
-    createTextAnswer('Disability, if other (optional)', order.deviceWearer.otherDisability, uri),
-    createTextAnswer('Main language', order.deviceWearer.language, uri),
-    createBooleanAnswer('Is an interpreter required?', order.deviceWearer.interpreterRequired, uri),
+    createTextAnswer(content.pages.deviceWearer.questions.sex.text, lookup(sexMap, order.deviceWearer.sex), uri),
+    createTextAnswer(content.pages.deviceWearer.questions.gender.text, lookup(genderMap, order.deviceWearer.gender), uri),
+    createMultipleChoiceAnswer(content.pages.deviceWearer.questions.disabilities.text, disabilities, uri),
+    createTextAnswer(content.pages.deviceWearer.questions.disabilities.text, order.deviceWearer.otherDisability, uri),
+    createTextAnswer(content.pages.deviceWearer.questions.otherDisability.text, order.deviceWearer.language, uri),
+    createBooleanAnswer(content.pages.deviceWearer.questions.interpreterRequired.text, order.deviceWearer.interpreterRequired, uri),
   ]
 }
 
-const createPersonIdentifierAnswers = (order: Order) => {
+const createPersonIdentifierAnswers = (order: Order, content: I18n) => {
   const uri = paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id)
   return [
-    createTextAnswer('NOMIS ID (optional)', order.deviceWearer.nomisId, uri),
-    createTextAnswer('PNC ID (optional)', order.deviceWearer.pncId, uri),
-    createTextAnswer('DELIUS ID (optional)', order.deviceWearer.deliusId, uri),
-    createTextAnswer('Prison number (optional)', order.deviceWearer.prisonNumber, uri),
-    createTextAnswer('Home Office reference number (optional)', order.deviceWearer.homeOfficeReferenceNumber, uri),
+    createTextAnswer(content.pages.identityNumbers.questions.nomisId.text, order.deviceWearer.nomisId, uri),
+    createTextAnswer(content.pages.identityNumbers.questions.pncId.text, order.deviceWearer.pncId, uri),
+    createTextAnswer(content.pages.identityNumbers.questions.deliusId.text, order.deviceWearer.deliusId, uri),
+    createTextAnswer(content.pages.identityNumbers.questions.prisonNumber.text, order.deviceWearer.prisonNumber, uri),
+    createTextAnswer(content.pages.identityNumbers.questions.homeOfficeReferenceNumber.text, order.deviceWearer.homeOfficeReferenceNumber, uri),
   ]
 }
 
-const createResponsibeAdultAnswers = (order: Order) => {
+const createResponsibeAdultAnswers = (order: Order, content: I18n) => {
   const uri = paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT.replace(':orderId', order.id)
 
   if (order.deviceWearer.adultAtTimeOfInstallation === null) {
@@ -55,21 +56,21 @@ const createResponsibeAdultAnswers = (order: Order) => {
   }
 
   return [
-    createTextAnswer('Relationship', lookup(relationshipMap, order.deviceWearerResponsibleAdult?.relationship), uri),
+    createTextAnswer(content.pages.responsibleAdult.questions.relationship.text, lookup(relationshipMap, order.deviceWearerResponsibleAdult?.relationship), uri),
     createTextAnswer(
-      'Relationship details, if other (optional)',
+      content.pages.responsibleAdult.questions.otherRelationship.text,
       order.deviceWearerResponsibleAdult?.otherRelationshipDetails,
       uri,
     ),
-    createTextAnswer('Full name', order.deviceWearerResponsibleAdult?.fullName, uri),
-    createTextAnswer('Contact number', order.deviceWearerResponsibleAdult?.contactNumber, uri),
+    createTextAnswer(content.pages.responsibleAdult.questions.fullName.text, order.deviceWearerResponsibleAdult?.fullName, uri),
+    createTextAnswer(content.pages.responsibleAdult.questions.contactNumber.text, order.deviceWearerResponsibleAdult?.contactNumber, uri),
   ]
 }
 
-const createViewModel = (order: Order) => ({
-  deviceWearer: createDeviceWearerAnswers(order),
-  personIdentifiers: createPersonIdentifierAnswers(order),
-  responsibleAdult: createResponsibeAdultAnswers(order),
+const createViewModel = (order: Order, content: I18n) => ({
+  deviceWearer: createDeviceWearerAnswers(order, content),
+  personIdentifiers: createPersonIdentifierAnswers(order, content),
+  responsibleAdult: createResponsibeAdultAnswers(order, content),
 })
 
 export default createViewModel

--- a/server/models/view-models/deviceWearerCheckAnswers.ts
+++ b/server/models/view-models/deviceWearerCheckAnswers.ts
@@ -25,11 +25,23 @@ const createDeviceWearerAnswers = (order: Order, content: I18n) => {
       uri,
     ),
     createTextAnswer(content.pages.deviceWearer.questions.sex.text, lookup(sexMap, order.deviceWearer.sex), uri),
-    createTextAnswer(content.pages.deviceWearer.questions.gender.text, lookup(genderMap, order.deviceWearer.gender), uri),
+    createTextAnswer(
+      content.pages.deviceWearer.questions.gender.text,
+      lookup(genderMap, order.deviceWearer.gender),
+      uri,
+    ),
     createMultipleChoiceAnswer(content.pages.deviceWearer.questions.disabilities.text, disabilities, uri),
-    createTextAnswer(content.pages.deviceWearer.questions.otherDisability.text, order.deviceWearer.otherDisability, uri),
+    createTextAnswer(
+      content.pages.deviceWearer.questions.otherDisability.text,
+      order.deviceWearer.otherDisability,
+      uri,
+    ),
     createTextAnswer(content.pages.deviceWearer.questions.language.text, order.deviceWearer.language, uri),
-    createBooleanAnswer(content.pages.deviceWearer.questions.interpreterRequired.text, order.deviceWearer.interpreterRequired, uri),
+    createBooleanAnswer(
+      content.pages.deviceWearer.questions.interpreterRequired.text,
+      order.deviceWearer.interpreterRequired,
+      uri,
+    ),
   ]
 }
 
@@ -40,7 +52,11 @@ const createPersonIdentifierAnswers = (order: Order, content: I18n) => {
     createTextAnswer(content.pages.identityNumbers.questions.pncId.text, order.deviceWearer.pncId, uri),
     createTextAnswer(content.pages.identityNumbers.questions.deliusId.text, order.deviceWearer.deliusId, uri),
     createTextAnswer(content.pages.identityNumbers.questions.prisonNumber.text, order.deviceWearer.prisonNumber, uri),
-    createTextAnswer(content.pages.identityNumbers.questions.homeOfficeReferenceNumber.text, order.deviceWearer.homeOfficeReferenceNumber, uri),
+    createTextAnswer(
+      content.pages.identityNumbers.questions.homeOfficeReferenceNumber.text,
+      order.deviceWearer.homeOfficeReferenceNumber,
+      uri,
+    ),
   ]
 }
 
@@ -56,14 +72,26 @@ const createResponsibeAdultAnswers = (order: Order, content: I18n) => {
   }
 
   return [
-    createTextAnswer(content.pages.responsibleAdult.questions.relationship.text, lookup(relationshipMap, order.deviceWearerResponsibleAdult?.relationship), uri),
+    createTextAnswer(
+      content.pages.responsibleAdult.questions.relationship.text,
+      lookup(relationshipMap, order.deviceWearerResponsibleAdult?.relationship),
+      uri,
+    ),
     createTextAnswer(
       content.pages.responsibleAdult.questions.otherRelationship.text,
       order.deviceWearerResponsibleAdult?.otherRelationshipDetails,
       uri,
     ),
-    createTextAnswer(content.pages.responsibleAdult.questions.fullName.text, order.deviceWearerResponsibleAdult?.fullName, uri),
-    createTextAnswer(content.pages.responsibleAdult.questions.contactNumber.text, order.deviceWearerResponsibleAdult?.contactNumber, uri),
+    createTextAnswer(
+      content.pages.responsibleAdult.questions.fullName.text,
+      order.deviceWearerResponsibleAdult?.fullName,
+      uri,
+    ),
+    createTextAnswer(
+      content.pages.responsibleAdult.questions.contactNumber.text,
+      order.deviceWearerResponsibleAdult?.contactNumber,
+      uri,
+    ),
   ]
 }
 

--- a/server/models/view-models/deviceWearerCheckAnswers.ts
+++ b/server/models/view-models/deviceWearerCheckAnswers.ts
@@ -27,8 +27,8 @@ const createDeviceWearerAnswers = (order: Order, content: I18n) => {
     createTextAnswer(content.pages.deviceWearer.questions.sex.text, lookup(sexMap, order.deviceWearer.sex), uri),
     createTextAnswer(content.pages.deviceWearer.questions.gender.text, lookup(genderMap, order.deviceWearer.gender), uri),
     createMultipleChoiceAnswer(content.pages.deviceWearer.questions.disabilities.text, disabilities, uri),
-    createTextAnswer(content.pages.deviceWearer.questions.disabilities.text, order.deviceWearer.otherDisability, uri),
-    createTextAnswer(content.pages.deviceWearer.questions.otherDisability.text, order.deviceWearer.language, uri),
+    createTextAnswer(content.pages.deviceWearer.questions.otherDisability.text, order.deviceWearer.otherDisability, uri),
+    createTextAnswer(content.pages.deviceWearer.questions.language.text, order.deviceWearer.language, uri),
     createBooleanAnswer(content.pages.deviceWearer.questions.interpreterRequired.text, order.deviceWearer.interpreterRequired, uri),
   ]
 }

--- a/server/types/i18n/pages/deviceWearer.ts
+++ b/server/types/i18n/pages/deviceWearer.ts
@@ -11,6 +11,7 @@ type DeviceWearerPageContent = PageContent<
   | 'language'
   | 'lastName'
   | 'otherDisability'
+  | 'otherGender'
   | 'sex'
 >
 

--- a/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
+++ b/server/views/pages/order/about-the-device-wearer/check-your-answers.njk
@@ -1,39 +1,32 @@
 {% extends "../../../partials/check-your-answers-layout.njk" %}
 
-{% set section = "About the device wearer" %}
-{% set pageTitle = "Device wearer details - Check your answers - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
-
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% set section = "About the device wearer" %}
 
 {% block answers %}
 
+  <h2 class="govuk-heading-m">Personal details</h2>
+
   {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Device wearer"
-      }
-    },
+    classes: "govuk-!-margin-bottom-9",
     rows: deviceWearer
   }) }}
 
+  <h2 class="govuk-heading-m">Identity numbers</h2>
+
+
   {{ govukSummaryList({
-    card: {
-      title: {
-        text: "Person identifiers"
-      }
-    },
+    classes: "govuk-!-margin-bottom-9",
     rows: personIdentifiers
   }) }}
 
   {% if responsibleAdult | length > 0 %}
 
+   <h2 class="govuk-heading-m">Responsible adult details</h2>
+
     {{ govukSummaryList({
-      card: {
-        title: {
-          text: "Responsible adult"
-        }
-      },
+      classes: "govuk-!-margin-bottom-9",
       rows: responsibleAdult
     }) }}
 

--- a/server/views/pages/order/about-the-device-wearer/device-wearer.njk
+++ b/server/views/pages/order/about-the-device-wearer/device-wearer.njk
@@ -171,7 +171,7 @@
     {{
       govukInput({
       label: {
-        text: "What is the device wearer's chosen identity?"
+        text: content.pages.deviceWearer.questions.otherGender.text
       },
       id: "otherGender",
       name: "otherGender",

--- a/server/views/pages/order/about-the-device-wearer/device-wearer.njk
+++ b/server/views/pages/order/about-the-device-wearer/device-wearer.njk
@@ -237,7 +237,7 @@
     {{
       govukInput({
       label: {
-        text: "What is the device wearer's disability or health condition? (optional)"
+        text: content.pages.deviceWearer.questions.otherDisability.text
       },
       id: "otherDisability",
       name: "otherDisability",

--- a/server/views/partials/check-your-answers-layout.njk
+++ b/server/views/partials/check-your-answers-layout.njk
@@ -5,53 +5,58 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% block content %}
+{% set mainClasses = "app-container govuk-body" %}
+{% set pageTitle = section + " - Check your answers - " + applicationName %}
 
+{% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
     href: orderSummaryUri
   }) }}
+{% endblock %}
 
-  {% if not isOrderEditable %}
-      {% set html %}
-      <p class="govuk-notification-banner__heading">
-        You are viewing a submitted order.
-      </p>
-      {% endset %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if not isOrderEditable %}
+        {% set html %}
+          <p class="govuk-notification-banner__heading">
+            You are viewing a submitted order.
+          </p>
+        {% endset %}
 
-      {{ govukNotificationBanner({
-      html: html
-    }) }}
-  {% endif %}
+        {{ govukNotificationBanner({
+          html: html
+        }) }}
+      {% endif %}
 
-  {{ mojPageHeaderActions({
-    heading: {
-        text: "Check your answers"
-    }
-  }) }}
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ section }}</span>
+        Check your answers
+      </h1>
 
-  <h2 class="govuk-heading-l">{{ section }}</h2>
+      {% block answers %}
+      {% endblock %}
 
-  {% block answers %}
-  {% endblock %}
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-  <form method="post">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Save and go to next question",
+            name: "action",
+            value: "continue"
+          })}}
 
-    <div class="govuk-button-group">
-      {{ govukButton({
-        text: "Continue",
-        name: "action",
-        value: "continue"
-      })}}
-
-      {{ govukButton({
-        text: "Return back to form section menu",
-        classes: "govuk-button--secondary",
-        name: "action",
-        value: "back"
-      }) }}
+          {{ govukButton({
+            text: "Save as draft",
+            classes: "govuk-button--secondary",
+            name: "action",
+            value: "back"
+          }) }}
+        </div>
+      </form>
     </div>
-  </form>
+  </div>
 
 {% endblock %}

--- a/server/views/partials/check-your-answers-layout.njk
+++ b/server/views/partials/check-your-answers-layout.njk
@@ -43,7 +43,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
-            text: "Save and go to next question",
+            text: "Save and go to next section",
             name: "action",
             value: "continue"
           })}}

--- a/test/mocks/mockExpress.ts
+++ b/test/mocks/mockExpress.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express'
+import i18n from '../../server/i18n'
 
 export const createMockRequest = (
   overrideProperties: Partial<Request> = { params: { orderId: '123456789' } },
@@ -21,6 +22,7 @@ export const createMockResponse = (): Response => {
   // @ts-expect-error stubbing res.render
   return {
     locals: {
+      content: i18n.en,
       user: {
         username: 'fakeUserName',
         token: 'fakeUserToken',


### PR DESCRIPTION
- Updates the layout for all check your answers pages (e.g. heading, buttons)
- Update the about the device wearer page to use the summary list component without the `card` option
- Updates the question content on the check your answers page to use the i18n content
- Conditionally show otherGender, otherDisability, otherRelationship on the check your answers page
- Improve integration tests for check your answers
