### PR TITLE
Update ingress allowlists

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-create-an-order/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-create-an-order/values.yaml
@@ -58,6 +58,7 @@ generic-service:
   allowlist:
     groups:
       - digital_staff_and_mojo
+      - moj_cloud_platform
 
 generic-prometheus-alerts:
   targetApplication: hmpps-electronic-monitoring-create-an-order

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,9 +14,6 @@ generic-service:
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "false"
     CEMO_API_URL: "https://hmpps-electronic-monitoring-create-an-order-api-dev.hmpps.service.justice.gov.uk"
-  
-  allowlist:
-    unrestricted: "0.0.0.0/0"
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-electronic-monitoring-create-an-order-dev


### PR DESCRIPTION
When we replaced the deprecated `internal` allowlist with `digital_staff_and_mojo`, some tools lost access to the `/health` and `/info` endpoints. As a result, the [developer portal](https://developer-portal.hmpps.service.justice.gov.uk/drift-radiator/products/electronic-monitoring-servicetech-assurance) thinks that we haven't deployed to pre-prod or prod in quite some time. This has lead to us being chased to solve our "drift" problem. This problem didn't exist in dev because we added the default route to support user research.

## Changes
- Remove default route ingress for dev as no longer needed for user research
- Add moj_cloud_platform to enable internal services to access which should allow other internal services to access all environments.