### PR TITLE
ELM-3432: Update is a responsible adult required answers to match question

### DIFF
--- a/integration_tests/e2e/order/about-the-device-wearer/device-wearer.validation.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/device-wearer.validation.cy.ts
@@ -43,7 +43,7 @@ context('About the device wearer', () => {
         page.form.firstNamesField.shouldHaveValidationMessage(expectedValidationErrors.firstName)
         page.form.lastNameField.shouldHaveValidationMessage(expectedValidationErrors.lastName)
         page.form.dateOfBirthField.shouldHaveValidationMessage(expectedValidationErrors.dob)
-        page.form.is18Field.shouldHaveValidationMessage(expectedValidationErrors.is18)
+        page.form.responsibleAdultRequiredField.shouldHaveValidationMessage(expectedValidationErrors.is18)
         page.form.sexField.shouldHaveValidationMessage(expectedValidationErrors.sex)
         page.form.genderIdentityField.shouldHaveValidationMessage(expectedValidationErrors.gender)
         page.form.interpreterRequiredField.shouldHaveValidationMessage(expectedValidationErrors.interpreter)

--- a/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerForm.ts
+++ b/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerForm.ts
@@ -45,7 +45,7 @@ export default class AboutDeviceWearerFormComponent extends FormComponent {
 
   // IS 18
 
-  get is18Field(): FormRadiosComponent {
+  get responsibleAdultRequiredField(): FormRadiosComponent {
     const label = 'Is a responsible adult required?'
     return new FormRadiosComponent(this.form, label, ['Yes', 'No'])
   }
@@ -245,7 +245,7 @@ export default class AboutDeviceWearerFormComponent extends FormComponent {
     }
 
     if (profile.is18 !== undefined) {
-      this.is18Field.set(profile.is18 ? 'Yes' : 'No')
+      this.responsibleAdultRequiredField.set(profile.is18 ? 'No' : 'Yes')
     }
 
     if (profile.sex) {
@@ -270,7 +270,7 @@ export default class AboutDeviceWearerFormComponent extends FormComponent {
     this.lastNameField.shouldNotHaveValidationMessage()
     this.aliasField.shouldNotHaveValidationMessage()
     this.dateOfBirthField.shouldNotHaveValidationMessage()
-    this.is18Field.shouldNotHaveValidationMessage()
+    this.responsibleAdultRequiredField.shouldNotHaveValidationMessage()
     this.sexField.shouldNotHaveValidationMessage()
     this.genderIdentityField.shouldNotHaveValidationMessage()
     this.interpreterRequiredField.shouldNotHaveValidationMessage()
@@ -282,7 +282,7 @@ export default class AboutDeviceWearerFormComponent extends FormComponent {
     this.lastNameField.shouldBeDisabled()
     this.aliasField.shouldBeDisabled()
     this.dateOfBirthField.shouldBeDisabled()
-    this.is18Field.shouldBeDisabled()
+    this.responsibleAdultRequiredField.shouldBeDisabled()
     this.sexField.shouldBeDisabled()
     this.genderIdentityField.shouldBeDisabled()
     this.interpreterRequiredField.shouldBeDisabled()
@@ -294,7 +294,7 @@ export default class AboutDeviceWearerFormComponent extends FormComponent {
     this.lastNameField.shouldNotBeDisabled()
     this.aliasField.shouldNotBeDisabled()
     this.dateOfBirthField.shouldNotBeDisabled()
-    this.is18Field.shouldNotBeDisabled()
+    this.responsibleAdultRequiredField.shouldNotBeDisabled()
     this.sexField.shouldNotBeDisabled()
     this.genderIdentityField.shouldNotBeDisabled()
     this.interpreterRequiredField.shouldNotBeDisabled()

--- a/server/views/pages/order/about-the-device-wearer/device-wearer.njk
+++ b/server/views/pages/order/about-the-device-wearer/device-wearer.njk
@@ -113,12 +113,12 @@
     },
     items: [
       {
-        value: "true",
+        value: "false",
         text: "Yes",
         disabled: not isOrderEditable
       },
       {
-        value: "false",
+        value: "true",
         text: "No",
         disabled: not isOrderEditable
       }


### PR DESCRIPTION
See problem description in ticket.

The "Is a responsible adult required?" question used to ask something to the effect of “will the device wearer be over 18”. A “yes” answer indicated that they are an adult. A “no” answer indicated they are a child. 

After the content update the label of the question was changed. Now, selecting “yes” indicates they are a child, selecting “no” indicates they are an adult.