### PR TITLE
Update scenario tests to expect calls to the updateDW endpoint

### DIFF
--- a/integration_tests/mockApis/fms.ts
+++ b/integration_tests/mockApis/fms.ts
@@ -37,6 +37,19 @@ const stubFMSCreateMonitoringOrder = (options: CreateStubOptions) =>
     },
   })
 
+const stubFMSUpdateDeviceWearer = (options: CreateStubOptions) =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPattern: '/fms/x_seem_cemo/device_wearer/updateDW',
+    },
+    response: {
+      status: options.httpStatus,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: options?.response || '',
+    },
+  })
+
 const stubFMSUpdateMonitoringOrder = (options: CreateStubOptions) =>
   stubFor({
     request: {
@@ -198,6 +211,7 @@ const verifyFMSAttachmentRequestReceived = (options: VerifyStubbedFMSRequestPara
 export default {
   stubFMSCreateDeviceWearer,
   stubFMSCreateMonitoringOrder,
+  stubFMSUpdateDeviceWearer,
   stubFMSUpdateMonitoringOrder,
   stubFmsUploadAttachment,
   verifyFMSCreateDeviceWearerRequestReceived,

--- a/integration_tests/mockApis/fms.ts
+++ b/integration_tests/mockApis/fms.ts
@@ -174,6 +174,13 @@ const verifyFMSCreateMonitoringOrderRequestReceived = (options: VerifyStubbedFMS
     uri: '/fms/x_seem_cemo/monitoring_order/createMO',
   })
 
+const verifyFMSUpdateDeviceWearerRequestReceived = (options: VerifyStubbedFMSRequestParams) =>
+  stubFMSVerifyRequestReceived({
+    index: 0,
+    ...options,
+    uri: '/fms/x_seem_cemo/device_wearer/updateDW',
+  })
+
 const verifyFMSUpdateMonitoringOrderRequestReceived = (options: VerifyStubbedFMSRequestParams) =>
   stubFMSVerifyRequestReceived({
     index: 0,
@@ -195,6 +202,7 @@ export default {
   stubFmsUploadAttachment,
   verifyFMSCreateDeviceWearerRequestReceived,
   verifyFMSCreateMonitoringOrderRequestReceived,
+  verifyFMSUpdateDeviceWearerRequestReceived,
   verifyFMSUpdateMonitoringOrderRequestReceived,
   verifyFMSAttachmentRequestReceived,
 }

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO018 - pre-trial bail - curfew 7pm-10am 7 nights - variation of curfew address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO018 - pre-trial bail - curfew 7pm-10am 7 nights - variation of curfew address.cy.ts
@@ -138,7 +138,7 @@ context('Scenarios', () => {
         })
         orderSummaryPage.submitOrderButton.click()
 
-        cy.task('verifyFMSCreateDeviceWearerRequestReceived', {
+        cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO018',
           index: 1,
           httpStatus: 200,

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO018 - pre-trial bail - curfew 7pm-10am 7 nights - variation of curfew address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO018 - pre-trial bail - curfew 7pm-10am 7 nights - variation of curfew address.cy.ts
@@ -37,6 +37,11 @@ context('Scenarios', () => {
       response: { result: [{ id: uuidv4(), message: '' }] },
     })
 
+    cy.task('stubFMSUpdateDeviceWearer', {
+      httpStatus: 200,
+      response: { result: [{ id: fmsCaseId, message: '' }] },
+    })
+
     cy.task('stubFMSUpdateMonitoringOrder', {
       httpStatus: 200,
       response: { result: [{ id: uuidv4(), message: '' }] },
@@ -140,7 +145,6 @@ context('Scenarios', () => {
 
         cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO018',
-          index: 1,
           httpStatus: 200,
           body: {
             title: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO020 - pre-trial bail - curfew 7pm-3am 7 nights - variation of additional address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO020 - pre-trial bail - curfew 7pm-3am 7 nights - variation of additional address.cy.ts
@@ -37,6 +37,11 @@ context('Scenarios', () => {
       response: { result: [{ id: uuidv4(), message: '' }] },
     })
 
+    cy.task('stubFMSUpdateDeviceWearer', {
+      httpStatus: 200,
+      response: { result: [{ id: fmsCaseId, message: '' }] },
+    })
+
     cy.task('stubFMSUpdateMonitoringOrder', {
       httpStatus: 200,
       response: { result: [{ id: uuidv4(), message: '' }] },
@@ -153,7 +158,6 @@ context('Scenarios', () => {
 
         cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO020',
-          index: 1,
           httpStatus: 200,
           body: {
             title: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO020 - pre-trial bail - curfew 7pm-3am 7 nights - variation of additional address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO020 - pre-trial bail - curfew 7pm-3am 7 nights - variation of additional address.cy.ts
@@ -151,7 +151,7 @@ context('Scenarios', () => {
         })
         orderSummaryPage.submitOrderButton.click()
 
-        cy.task('verifyFMSCreateDeviceWearerRequestReceived', {
+        cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO020',
           index: 1,
           httpStatus: 200,

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO023 - community suspended sentence - curfew 7pm-7am 7 nights - variation of curfew 7pm-7am week nights only.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO023 - community suspended sentence - curfew 7pm-7am 7 nights - variation of curfew 7pm-7am week nights only.cy.ts
@@ -37,6 +37,11 @@ context('Scenarios', () => {
       response: { result: [{ id: uuidv4(), message: '' }] },
     })
 
+    cy.task('stubFMSUpdateDeviceWearer', {
+      httpStatus: 200,
+      response: { result: [{ id: fmsCaseId, message: '' }] },
+    })
+
     cy.task('stubFMSUpdateMonitoringOrder', {
       httpStatus: 200,
       response: { result: [{ id: uuidv4(), message: '' }] },
@@ -153,7 +158,6 @@ context('Scenarios', () => {
 
         cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO023',
-          index: 1,
           httpStatus: 200,
           body: {
             title: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO023 - community suspended sentence - curfew 7pm-7am 7 nights - variation of curfew 7pm-7am week nights only.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO023 - community suspended sentence - curfew 7pm-7am 7 nights - variation of curfew 7pm-7am week nights only.cy.ts
@@ -151,7 +151,7 @@ context('Scenarios', () => {
         })
         orderSummaryPage.submitOrderButton.click()
 
-        cy.task('verifyFMSCreateDeviceWearerRequestReceived', {
+        cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO023',
           index: 1,
           httpStatus: 200,

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO024 - post release supervision - curfew 7pm-7am weekend only - variation of curfew 7pm-7am week days only.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO024 - post release supervision - curfew 7pm-7am weekend only - variation of curfew 7pm-7am week days only.cy.ts
@@ -151,7 +151,7 @@ context('Scenarios', () => {
         })
         orderSummaryPage.submitOrderButton.click()
 
-        cy.task('verifyFMSCreateDeviceWearerRequestReceived', {
+        cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO024',
           index: 1,
           httpStatus: 200,

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO024 - post release supervision - curfew 7pm-7am weekend only - variation of curfew 7pm-7am week days only.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO024 - post release supervision - curfew 7pm-7am weekend only - variation of curfew 7pm-7am week days only.cy.ts
@@ -37,6 +37,11 @@ context('Scenarios', () => {
       response: { result: [{ id: uuidv4(), message: '' }] },
     })
 
+    cy.task('stubFMSUpdateDeviceWearer', {
+      httpStatus: 200,
+      response: { result: [{ id: fmsCaseId, message: '' }] },
+    })
+
     cy.task('stubFMSUpdateMonitoringOrder', {
       httpStatus: 200,
       response: { result: [{ id: uuidv4(), message: '' }] },
@@ -153,7 +158,6 @@ context('Scenarios', () => {
 
         cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO024',
-          index: 1,
           httpStatus: 200,
           body: {
             title: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO019 - post release - single inclusion zone - variation of home address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO019 - post release - single inclusion zone - variation of home address.cy.ts
@@ -42,6 +42,11 @@ context('Scenarios', () => {
       response: { result: [{ id: uuidv4(), message: '' }] },
     })
 
+    cy.task('stubFMSUpdateDeviceWearer', {
+      httpStatus: 200,
+      response: { result: [{ id: fmsCaseId, message: '' }] },
+    })
+
     cy.task('stubFMSUpdateMonitoringOrder', {
       httpStatus: 200,
       response: { result: [{ id: uuidv4(), message: '' }] },
@@ -161,7 +166,6 @@ context('Scenarios', () => {
 
         cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO019',
-          index: 1,
           httpStatus: 200,
           body: {
             title: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO019 - post release - single inclusion zone - variation of home address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO019 - post release - single inclusion zone - variation of home address.cy.ts
@@ -159,7 +159,7 @@ context('Scenarios', () => {
         })
         orderSummaryPage.submitOrderButton.click()
 
-        cy.task('verifyFMSCreateDeviceWearerRequestReceived', {
+        cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO019',
           index: 1,
           httpStatus: 200,

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO022 - post release - single inclusion zone - variation of additional address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO022 - post release - single inclusion zone - variation of additional address.cy.ts
@@ -42,6 +42,11 @@ context('Scenarios', () => {
       response: { result: [{ id: uuidv4(), message: '' }] },
     })
 
+    cy.task('stubFMSUpdateDeviceWearer', {
+      httpStatus: 200,
+      response: { result: [{ id: fmsCaseId, message: '' }] },
+    })
+
     cy.task('stubFMSUpdateMonitoringOrder', {
       httpStatus: 200,
       response: { result: [{ id: uuidv4(), message: '' }] },
@@ -161,7 +166,6 @@ context('Scenarios', () => {
 
         cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO022',
-          index: 1,
           httpStatus: 200,
           body: {
             title: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO022 - post release - single inclusion zone - variation of additional address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO022 - post release - single inclusion zone - variation of additional address.cy.ts
@@ -159,7 +159,7 @@ context('Scenarios', () => {
         })
         orderSummaryPage.submitOrderButton.click()
 
-        cy.task('verifyFMSCreateDeviceWearerRequestReceived', {
+        cy.task('verifyFMSUpdateDeviceWearerRequestReceived', {
           responseRecordFilename: 'CEMO022',
           index: 1,
           httpStatus: 200,


### PR DESCRIPTION
Updates scenarios tests to reflect changes to the API in [#184](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order-api/pull/184)