### PR TITLE
Allow firstname to be overriden in scenarios

### DIFF
--- a/integration_tests/mockApis/faker.ts
+++ b/integration_tests/mockApis/faker.ts
@@ -99,9 +99,8 @@ export const createFakeUkPhoneNumber = (): string => {
   return format[1] + `00${faker.number.int({ min: format[2] as number, max: format[3] as number })}`.slice(-3)
 }
 
-export const createFakePerson = (dob: Date): Partial<PersonOfInterest> => {
+export const createFakePerson = (dob: Date, firstName?: string): Partial<PersonOfInterest> => {
   const sexType = faker.person.sexType()
-  const firstName = faker.person.firstName(sexType)
   const middleName = faker.person.middleName(sexType)
   const lastName = faker.person.lastName()
   const alias = faker.animal.bird()
@@ -110,6 +109,10 @@ export const createFakePerson = (dob: Date): Partial<PersonOfInterest> => {
 
   const contactNumber = createFakeUkPhoneNumber()
   const emailAddress = faker.internet.email({ firstName, lastName })
+
+  if (firstName === null) {
+    firstName = faker.person.firstName(sexType)
+  }
 
   return {
     firstName,
@@ -206,26 +209,26 @@ export const createFakeInterestedParties = (
   }
 }
 
-export const createFakeYouth = (): PersonOfInterest => {
+export const createFakeYouth = (firstName?: string): PersonOfInterest => {
   const dob = faker.date.birthdate({ mode: 'age', min: 13, max: 17 })
 
   return {
-    ...createFakePerson(dob),
+    ...createFakePerson(dob,firstName),
     is18: false,
   } as PersonOfInterest
 }
 
-export const createFakeAdult = (): PersonOfInterest => {
+export const createFakeAdult = (firstName?: string): PersonOfInterest => {
   const dob = faker.date.birthdate({ mode: 'age', min: 18, max: 49 }) // anyone over 50 is apprently considered "older"
 
   return {
-    ...createFakePerson(dob),
+    ...createFakePerson(dob, firstName),
     is18: true,
   } as PersonOfInterest
 }
 
-export const createFakeAdultDeviceWearer = (): PersonOfInterest => {
-  const fakeAdult = createFakeAdult()
+export const createFakeAdultDeviceWearer = (firstName?: string): PersonOfInterest => {
+  const fakeAdult = createFakeAdult(firstName)
   const nomisId = faker.helpers.replaceSymbols('?####??')
   const pncId = faker.helpers.replaceSymbols('??##/######?')
   const deliusId = faker.helpers.replaceSymbols('X#####')
@@ -242,8 +245,8 @@ export const createFakeAdultDeviceWearer = (): PersonOfInterest => {
   } as PersonOfInterest
 }
 
-export const createFakeYouthDeviceWearer = (): PersonOfInterest => {
-  const fakeYouth = createFakeYouth()
+export const createFakeYouthDeviceWearer = (firstName?: string): PersonOfInterest => {
+  const fakeYouth = createFakeYouth(firstName)
   const nomisId = faker.helpers.replaceSymbols('?####??')
   const pncId = faker.helpers.replaceSymbols('??##/######?')
   const deliusId = faker.helpers.replaceSymbols('X#####')


### PR DESCRIPTION
Serco have asked that scenario tests use the id of the test as either the firstName or lastName. This change allows the automatically generated firstName to be overrriden
