### PR TITLE
ELM-3489: Display the responsible organisation phone number when viewing the interested parties page

### DIFF
--- a/integration_tests/e2e/order/contact-information/interested-parties.page.submitted.cy.ts
+++ b/integration_tests/e2e/order/contact-information/interested-parties.page.submitted.cy.ts
@@ -11,33 +11,73 @@ context('Contact information', () => {
         cy.task('reset')
         cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
 
-        cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'SUBMITTED' })
+        cy.task('stubCemoGetOrder', {
+          httpStatus: 200,
+          id: mockOrderId,
+          status: 'SUBMITTED',
+          order: {
+            interestedParties: {
+              notifyingOrganisation: 'PRISON',
+              notifyingOrganisationName: 'FELTHAM_YOUNG_OFFENDER_INSTITUTION',
+              notifyingOrganisationEmail: 'test@test.com',
+              responsibleOfficerName: 'John Smith',
+              responsibleOfficerPhoneNumber: '01234567890',
+              responsibleOrganisation: 'PROBATION',
+              responsibleOrganisationRegion: 'NORTH_EAST',
+              responsibleOrganisationAddress: {
+                addressType: 'RESPONSIBLE_ORGANISATION',
+                addressLine1: 'line1',
+                addressLine2: 'line2',
+                addressLine3: 'line3',
+                addressLine4: 'line4',
+                postcode: 'postcode',
+              },
+              responsibleOrganisationPhoneNumber: '01234567891',
+              responsibleOrganisationEmail: 'test2@test.com',
+            },
+          },
+        })
 
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('should correctly display the page', () => {
         const page = Page.visit(InterestedPartiesPage, { orderId: mockOrderId })
+
+        // Should show the header
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(InterestedPartiesPage, { orderId: mockOrderId })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
 
-      it('Should display the submitted order notification', () => {
-        const page = Page.visit(InterestedPartiesPage, { orderId: mockOrderId })
+        // Should indicate the page is submitted
         page.submittedBanner.should('contain', 'You are viewing a submitted order.')
-      })
 
-      it('Should not allow the user to update the no fixed abode details', () => {
-        const page = Page.visit(InterestedPartiesPage, { orderId: mockOrderId })
+        // Should display the saved data
+        page.form.notifyingOrganisationField.shouldHaveValue('Prison')
+        page.form.prisonField.shouldHaveValue('FELTHAM_YOUNG_OFFENDER_INSTITUTION')
+        page.form.notifyOrganisationEmailAddressField.shouldHaveValue('test@test.com')
+        page.form.responsibleOfficerNameField.shouldHaveValue('John Smith')
+        page.form.responsibleOfficerContactNumberField.shouldHaveValue('01234567890')
+        page.form.responsibleOrganisationField.shouldHaveValue('Probation')
+        page.form.probationRegionField.shouldHaveValue('NORTH_EAST')
+        page.form.responsibleOrganisationAddressField.shouldHaveValue({
+          line1: 'line1',
+          line2: 'line2',
+          line3: 'line3',
+          line4: 'line4',
+          postcode: 'postcode',
+        })
+        page.form.responsibleOrganisationContactNumberField.shouldHaveValue('01234567891')
+        page.form.responsibleOrganisationEmailAddressField.shouldHaveValue('test2@test.com')
 
+        // Should have the correct buttons
         page.form.saveAndContinueButton.should('not.exist')
         page.form.saveAndReturnButton.should('not.exist')
         page.backToSummaryButton.should('exist').should('have.attr', 'href', `/order/${mockOrderId}/summary`)
+
+        // Should not be editable
         page.form.shouldBeDisabled()
+
+        // Should not have errors
         page.errorSummary.shouldNotExist()
       })
     })

--- a/server/views/pages/order/contact-information/interested-parties.njk
+++ b/server/views/pages/order/contact-information/interested-parties.njk
@@ -326,7 +326,7 @@
       id: "responsibleOrganisationPhoneNumber",
       name: "responsibleOrganisationPhoneNumber",
       type: "tel",
-      value: responsibleOrganisationPhoneNumber.values,
+      value: responsibleOrganisationPhoneNumber.value,
       errorMessage: responsibleOrganisationPhoneNumber.error,
       disabled: not isOrderEditable
     }) }}


### PR DESCRIPTION
The responsible organisation phone number wasn't correctly displaying when viewing the interested parties page with already saved data. This meant that clicking save and continue would cause a validation error to appear. 

This change:
- Fixes the problem
- Adds integration test to ensure display of data is correct