### PR TITLE
ELM-3594: Remove reference number from submit success page

### DIFF
--- a/server/views/pages/order/submit-success.njk
+++ b/server/views/pages/order/submit-success.njk
@@ -16,7 +16,6 @@
 
   {{ govukPanel({
   titleText: "Application successfully submitted",
-  html: "Your reference number is <br><strong>EXAMPLE</strong>",
   attributes: {
     "data-qa": "confirmation-panel"
   }


### PR DESCRIPTION
UR showed it confused and bemused users when reference number is shown on submit success page. 

The order id is shown on the order summary page instead.