### PR TITLE
ELM-3626: Fix installation address cya link

### DIFF
--- a/server/controllers/monitoringConditions/checkAnswersController.test.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.test.ts
@@ -267,7 +267,10 @@ describe('MonitoringConditionsCheckAnswersController', () => {
             actions: {
               items: [
                 {
-                  href: paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(':orderId', order.id),
+                  href: paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(':orderId', order.id).replace(
+                    ':addressType(installation)',
+                    'installation',
+                  ),
                   text: 'Change',
                   visuallyHiddenText: 'where will the installation of the electronic monitoring device take place?',
                 },
@@ -666,7 +669,10 @@ describe('MonitoringConditionsCheckAnswersController', () => {
             actions: {
               items: [
                 {
-                  href: paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(':orderId', order.id),
+                  href: paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(':orderId', order.id).replace(
+                    ':addressType(installation)',
+                    'installation',
+                  ),
                   text: 'Change',
                   visuallyHiddenText: 'where will the installation of the electronic monitoring device take place?',
                 },

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -63,7 +63,10 @@ const createMonitoringConditionsAnswers = (order: Order, content: I18n) => {
 }
 
 const createInstallationAddressAnswers = (order: Order, content: I18n) => {
-  const uri = paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(':orderId', order.id)
+  const uri = paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(':orderId', order.id).replace(
+    ':addressType(installation)',
+    'installation',
+  )
   const installationAddress = order.addresses.find(
     ({ addressType }) => addressType === AddressTypeEnum.Enum.INSTALLATION,
   )


### PR DESCRIPTION
Update view model to replace `:addressType(installation)` with `installation`