### PR TITLE
Enable variations in deployed environments

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-create-an-order/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-create-an-order/values.yaml
@@ -34,6 +34,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/'
     AUDIT_SQS_REGION: 'eu-west-2'
     AUDIT_SERVICE_NAME: 'HMPPS529' # Your audit service name
+    VARIATIONS_ENABLED: 'true'
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:


### PR DESCRIPTION
- Users need to be able to create variations when we go live.

Dev environment currently:
![Screenshot 2025-05-06 at 14 45 08](https://github.com/user-attachments/assets/ad752396-716a-40be-8af7-db5e3782fc77)

With flag enabled:
![Screenshot 2025-05-06 at 14 47 11](https://github.com/user-attachments/assets/9c8bf680-9d8e-48eb-b0a3-50f2de2922ef)

