### PR TITLE
Allow prisons to access the prod environment

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,5 +12,11 @@ generic-service:
     AUDIT_ENABLED: "false"
     CEMO_API_URL: "https://hmpps-electronic-monitoring-create-an-order-api.hmpps.service.justice.gov.uk"
 
+  allowlist:
+    groups:
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+      - prisons
+
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service


### PR DESCRIPTION
- Overrides the allowlist in `helm_deploy/hmpps-electronic-monitoring-create-an-order/values.yaml` with the same values but also adds the `prison` allow list.