### PR TITLE
Allow private prisons to access the prod environment

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,6 +17,7 @@ generic-service:
       - digital_staff_and_mojo
       - moj_cloud_platform
       - prisons
+      - private_prisons
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service


### PR DESCRIPTION
- Adds the private prisons allow list to prod environment.
- [Allowlists](https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml#L110)