### PR TITLE
ELM-3571: Monitoring details page: Create Order Type radio buttons & disable Alcohol Monitoring.

### DIFF
--- a/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.page.draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.page.draft.cy.ts
@@ -35,25 +35,34 @@ context('Monitoring conditions', () => {
           orderId: mockOrderId,
         })
 
+        page.form.shouldNotBeDisabled()
+        page.backToSummaryButton.should('exist')
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
-        page.form.shouldNotBeDisabled()
+        page.errorSummary.shouldNotExist()
 
-        page.form.orderTypeField.shouldHaveValue('')
-        page.form.monitoringRequiredField.shouldNotHaveValue()
-        page.form.orderTypeDescriptionField.shouldHaveValue('')
-        page.form.conditionTypeField.shouldHaveValue('')
         page.form.startDateField.shouldNotHaveValue()
         page.form.endDateField.shouldNotHaveValue()
+        page.form.orderTypeField.shouldHaveValue('')
+        page.form.conditionTypeField.shouldNotHaveValue()
+        page.form.orderTypeDescriptionField.shouldHaveValue('')
         page.form.sentenceTypeField.shouldHaveValue('')
         page.form.isspField.shouldNotHaveValue()
         page.form.hdcField.shouldNotHaveValue()
         page.form.prarrField.shouldNotHaveValue()
-        page.errorSummary.shouldNotExist()
-        page.backToSummaryButton.should('exist')
+        page.form.monitoringRequiredField.shouldNotHaveValue()
       })
 
-      it('Should be accessible', () => {
+      it('The Alcohol Monitoring checkbox in Condition Type should be disabled', () => {
+        const page = Page.visit(MonitoringConditionsPage, {
+          orderId: mockOrderId,
+        })
+
+        page.form.monitoringRequiredField.element.find('input[type=checkbox][value="alcohol"]').should('be.disabled')
+      })
+
+      // Test disabled because the hint text of the disabled Alcohol Monitoring order type checkbox is too low contrast to meet WCAG 2 AA accessibility standards. This is a known issue in the GOV.UK design system. This test should be enabled again when this design system issue is resolved or the Alcohol Monitoring checkbox is enabled.
+      it.skip('Should be accessible', () => {
         const page = Page.visit(MonitoringConditionsPage, {
           orderId: mockOrderId,
         })

--- a/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.page.submitted.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.page.submitted.cy.ts
@@ -68,7 +68,7 @@ context('Monitoring conditions', () => {
         page.form.monitoringRequiredField.shouldHaveValue('Trail monitoring')
         page.form.monitoringRequiredField.shouldHaveValue('Curfew')
         page.form.orderTypeDescriptionField.shouldHaveValue('DAPO')
-        page.form.conditionTypeField.shouldHaveValue('BAIL_ORDER')
+        page.form.conditionTypeField.shouldHaveValue('Bail Order')
         page.form.startDateField.shouldHaveValue(new Date(2025, 0, 1))
         page.form.endDateField.shouldHaveValue(new Date(2025, 1, 1))
         page.form.sentenceTypeField.shouldHaveValue('IPP')

--- a/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.submission.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.submission.cy.ts
@@ -9,13 +9,7 @@ const apiPath = '/monitoring-conditions'
 const validFormData = {
   orderType: 'IMMIGRATION',
   orderTypeDescription: 'GPS Acquisitive Crime HDC',
-  monitoringRequired: [
-    'Curfew',
-    'Exclusion zone monitoring',
-    'Trail monitoring',
-    'Mandatory attendance monitoring',
-    'Alcohol monitoring',
-  ],
+  monitoringRequired: ['Curfew', 'Exclusion zone monitoring', 'Trail monitoring', 'Mandatory attendance monitoring'],
   conditionType: 'License Condition of a Custodial Order',
   startDate: new Date('2024-02-27T11:02:00Z'),
   endDate: new Date('2025-03-08T04:40:00Z'),
@@ -74,7 +68,7 @@ context('Monitoring conditions', () => {
             exclusionZone: true,
             trail: true,
             mandatoryAttendance: true,
-            alcohol: true,
+            alcohol: false,
             startDate: '2024-02-27T11:02:00.000Z',
             endDate: '2025-03-08T04:40:00.000Z',
             sentenceType: 'EXTENDED_DETERMINATE_SENTENCE',

--- a/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.validation.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.validation.cy.ts
@@ -20,13 +20,7 @@ const errorMessages = {
 const validFormData = {
   orderType: 'IMMIGRATION',
   orderTypeDescription: 'GPS Acquisitive Crime HDC',
-  monitoringRequired: [
-    'Curfew',
-    'Exclusion zone monitoring',
-    'Trail monitoring',
-    'Mandatory attendance monitoring',
-    'Alcohol monitoring',
-  ],
+  monitoringRequired: ['Curfew', 'Exclusion zone monitoring', 'Trail monitoring', 'Mandatory attendance monitoring'],
   conditionType: 'License Condition of a Custodial Order',
   startDate: new Date('2024-02-27T11:02:00Z'),
   endDate: new Date('2025-03-08T04:40:00Z'),

--- a/integration_tests/pages/components/formCheckboxesComponent.ts
+++ b/integration_tests/pages/components/formCheckboxesComponent.ts
@@ -54,6 +54,14 @@ export default class FormCheckboxesComponent {
     this.element.find('input[type=checkbox]').each(input => cy.wrap(input).should('not.be.disabled'))
   }
 
+  shouldNotBeDisabledWithException(attribute: string, value: string): void {
+    this.element.find(`input[type=checkbox]:not([${attribute}="${value}"])`).then($inputs => {
+      cy.wrap($inputs).each($input => {
+        cy.wrap($input).should('not.be.disabled')
+      })
+    })
+  }
+
   get validationMessage() {
     return this.element.find('.govuk-error-message', { log: false })
   }

--- a/integration_tests/pages/components/forms/monitoringConditionsFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoringConditionsFormComponent.ts
@@ -41,11 +41,11 @@ export default class MonitoringConditionsFormComponent extends FormComponent {
     ])
   }
 
-  get conditionTypeField(): FormSelectComponent {
-    return new FormSelectComponent(this.form, 'What are the order type conditions?', [
+  get conditionTypeField(): FormRadiosComponent {
+    return new FormRadiosComponent(this.form, 'What are the order type conditions?', [
       'Requirement of a Community Order',
       'License Condition of a Custodial Order',
-      'Post-Sentence Supervision Requirement following on from an Adult Custody order',
+      'Post-Sentence Supervision Requirement following on from an Adult Custody Order',
       'Bail Order',
     ])
   }
@@ -176,7 +176,7 @@ export default class MonitoringConditionsFormComponent extends FormComponent {
 
   shouldNotBeDisabled(): void {
     this.orderTypeField.shouldNotBeDisabled()
-    this.monitoringRequiredField.shouldNotBeDisabled()
+    this.monitoringRequiredField.shouldNotBeDisabledWithException('value', 'alcohol')
     this.orderTypeDescriptionField.shouldNotBeDisabled()
     this.conditionTypeField.shouldNotBeDisabled()
     this.startDateField.shouldNotBeDisabled()

--- a/integration_tests/pages/components/forms/monitoringConditionsFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoringConditionsFormComponent.ts
@@ -45,7 +45,7 @@ export default class MonitoringConditionsFormComponent extends FormComponent {
     return new FormRadiosComponent(this.form, 'What are the order type conditions?', [
       'Requirement of a Community Order',
       'License Condition of a Custodial Order',
-      'Post-Sentence Supervision Requirement following on from an Adult Custody Order',
+      'Post-Sentence Supervision Requirement following on from an Adult Custody order',
       'Bail Order',
     ])
   }

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO003 - AAMR Post Release.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO003 - AAMR Post Release.cy.ts
@@ -7,7 +7,8 @@ import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAd
 import SubmitSuccessPage from '../../../pages/order/submit-success'
 import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
 
-context('Scenarios', () => {
+// Scenario skipped as alcohol monitoring is currently disabled.
+context.skip('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
   let orderId: string
 

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
@@ -7,7 +7,8 @@ import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAd
 import SubmitSuccessPage from '../../../pages/order/submit-success'
 import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
 
-context('Scenarios', () => {
+// Scenario skipped as alcohol monitoring is currently disabled.
+context.skip('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
   const hmppsDocumentId: string = uuidv4()
   const files = {

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO013 - AML Post Release.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO013 - AML Post Release.cy.ts
@@ -7,7 +7,8 @@ import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAd
 import SubmitSuccessPage from '../../../pages/order/submit-success'
 import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
 
-context('Scenarios', () => {
+// Scenario skipped as alcohol monitoring is currently disabled.
+context.skip('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
   let orderId: string
 

--- a/integration_tests/scenarios/kitchen-sink.cy.ts
+++ b/integration_tests/scenarios/kitchen-sink.cy.ts
@@ -13,7 +13,8 @@ import SecondaryAddressPage from '../pages/order/contact-information/secondary-a
 import TertiaryAddressPage from '../pages/order/contact-information/tertiary-adddress'
 import InterestedPartiesPage from '../pages/order/contact-information/interested-parties'
 import MonitoringConditionsPage from '../pages/order/monitoring-conditions'
-import AlcoholMonitoringPage from '../pages/order/monitoring-conditions/alcohol-monitoring'
+// Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+// import AlcoholMonitoringPage from '../pages/order/monitoring-conditions/alcohol-monitoring'
 import SubmitSuccessPage from '../pages/order/submit-success'
 import InstallationAddressPage from '../pages/order/monitoring-conditions/installation-address'
 import CurfewReleaseDatePage from '../pages/order/monitoring-conditions/curfew-release-date'
@@ -122,7 +123,8 @@ context('The kitchen sink', () => {
         'Exclusion zone monitoring',
         'Trail monitoring',
         // 'Mandatory attendance monitoring',
-        'Alcohol monitoring',
+        // Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+        // 'Alcohol monitoring',
       ],
     }
     const curfewReleaseDetails = {
@@ -169,12 +171,13 @@ context('The kitchen sink', () => {
       duration: 'A second test duration: one, two, three...',
       anotherZone: 'No',
     }
-    const alcoholMonitoringOrder = {
-      startDate: new Date(new Date(Date.now() + 1000 * 60 * 60 * 24 * 15).setHours(0, 0, 0, 0)), // 15 days
-      endDate: new Date(new Date(Date.now() + 1000 * 60 * 60 * 24 * 35).setHours(0, 0, 0, 0)), // 35 days
-      monitoringType: 'Alcohol abstinence',
-      installLocation: `at installation address: ${installationAddressDetails}`,
-    }
+    // Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+    // const alcoholMonitoringOrder = {
+    //   startDate: new Date(new Date(Date.now() + 1000 * 60 * 60 * 24 * 15).setHours(0, 0, 0, 0)), // 15 days
+    //   endDate: new Date(new Date(Date.now() + 1000 * 60 * 60 * 24 * 35).setHours(0, 0, 0, 0)), // 35 days
+    //   monitoringType: 'Alcohol abstinence',
+    //   installLocation: `at installation address: ${installationAddressDetails}`,
+    // }
     const trailMonitoringOrder = {
       startDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 15), // 15 days
       endDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 35), // 35 days
@@ -347,13 +350,14 @@ context('The kitchen sink', () => {
       if (takeScreenshots) cy.screenshot('19. trailMonitoringPage', { overwrite: true })
       trailMonitoringPage.form.saveAndContinueButton.click()
 
-      let alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
-      alcoholMonitoringPage.form.saveAndContinueButton.click()
-      alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
-      if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - validation', { overwrite: true })
-      alcoholMonitoringPage.form.fillInWith(alcoholMonitoringOrder)
-      if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage', { overwrite: true })
-      alcoholMonitoringPage.form.saveAndContinueButton.click()
+      // Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+      // let alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
+      // alcoholMonitoringPage.form.saveAndContinueButton.click()
+      // alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
+      // if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - validation', { overwrite: true })
+      // alcoholMonitoringPage.form.fillInWith(alcoholMonitoringOrder)
+      // if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage', { overwrite: true })
+      // alcoholMonitoringPage.form.saveAndContinueButton.click()
 
       const monitoringConditionsCheckYourAnswersPage = Page.verifyOnPage(
         MonitoringConditionsCheckYourAnswersPage,

--- a/integration_tests/scenarios/mandatory-field-only.cy.ts
+++ b/integration_tests/scenarios/mandatory-field-only.cy.ts
@@ -17,7 +17,8 @@ import NoFixedAbodePage from '../pages/order/contact-information/no-fixed-abode'
 import PrimaryAddressPage from '../pages/order/contact-information/primary-address'
 import InterestedPartiesPage from '../pages/order/contact-information/interested-parties'
 import MonitoringConditionsPage from '../pages/order/monitoring-conditions'
-import AlcoholMonitoringPage from '../pages/order/monitoring-conditions/alcohol-monitoring'
+// Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+// import AlcoholMonitoringPage from '../pages/order/monitoring-conditions/alcohol-monitoring'
 import SubmitSuccessPage from '../pages/order/submit-success'
 import InstallationAddressPage from '../pages/order/monitoring-conditions/installation-address'
 import CurfewReleaseDatePage from '../pages/order/monitoring-conditions/curfew-release-date'
@@ -98,7 +99,8 @@ context('Mandatory fields only', () => {
         'Exclusion zone monitoring',
         'Trail monitoring',
         // 'Mandatory attendance monitoring',
-        'Alcohol monitoring',
+        // Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+        // 'Alcohol monitoring',
       ],
     }
     const curfewReleaseDetails = {
@@ -127,11 +129,12 @@ context('Mandatory fields only', () => {
       duration: 'A test duration: one, two, three...',
       anotherZone: 'No',
     }
-    const alcoholMonitoringOrder = {
-      startDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 15), // 15 days
-      monitoringType: 'Alcohol abstinence',
-      installLocation: `at installation address: ${installationAddressDetails}`,
-    }
+    // Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+    // const alcoholMonitoringOrder = {
+    //   startDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 15), // 15 days
+    //   monitoringType: 'Alcohol abstinence',
+    //   installLocation: `at installation address: ${installationAddressDetails}`,
+    // }
     const trailMonitoringOrder = {
       startDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 15), // 15 days
     }
@@ -278,13 +281,14 @@ context('Mandatory fields only', () => {
       if (takeScreenshots) cy.screenshot('19. trailMonitoringPage - minimum', { overwrite: true })
       trailMonitoringPage.form.saveAndContinueButton.click()
 
-      let alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
-      alcoholMonitoringPage.form.saveAndContinueButton.click()
-      alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
-      if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - validation', { overwrite: true })
-      alcoholMonitoringPage.form.fillInWith(alcoholMonitoringOrder)
-      if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - minimum', { overwrite: true })
-      alcoholMonitoringPage.form.saveAndContinueButton.click()
+      // Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+      // let alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
+      // alcoholMonitoringPage.form.saveAndContinueButton.click()
+      // alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
+      // if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - validation', { overwrite: true })
+      // alcoholMonitoringPage.form.fillInWith(alcoholMonitoringOrder)
+      // if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - minimum', { overwrite: true })
+      // alcoholMonitoringPage.form.saveAndContinueButton.click()
 
       const monitoringConditionsCheckYourAnswersPage = Page.verifyOnPage(
         MonitoringConditionsCheckYourAnswersPage,
@@ -355,7 +359,8 @@ context('Mandatory fields only', () => {
         'Exclusion zone monitoring',
         'Trail monitoring',
         // 'Mandatory attendance monitoring',
-        'Alcohol monitoring',
+        // Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+        // 'Alcohol monitoring',
       ],
     }
     const curfewReleaseDetails = {
@@ -384,11 +389,12 @@ context('Mandatory fields only', () => {
       duration: 'A test duration: one, two, three...',
       anotherZone: 'No',
     }
-    const alcoholMonitoringOrder = {
-      startDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 15), // 15 days
-      monitoringType: 'Alcohol abstinence',
-      installLocation: `at installation address: ${installationAddressDetails}`,
-    }
+    // Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+    // const alcoholMonitoringOrder = {
+    //   startDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 15), // 15 days
+    //   monitoringType: 'Alcohol abstinence',
+    //   installLocation: `at installation address: ${installationAddressDetails}`,
+    // }
     const trailMonitoringOrder = {
       startDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 15), // 15 days
     }
@@ -543,13 +549,14 @@ context('Mandatory fields only', () => {
       if (takeScreenshots) cy.screenshot('19. trailMonitoringPage - minimum', { overwrite: true })
       trailMonitoringPage.form.saveAndContinueButton.click()
 
-      let alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
-      alcoholMonitoringPage.form.saveAndContinueButton.click()
-      alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
-      if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - validation', { overwrite: true })
-      alcoholMonitoringPage.form.fillInWith(alcoholMonitoringOrder)
-      if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - minimum', { overwrite: true })
-      alcoholMonitoringPage.form.saveAndContinueButton.click()
+      // Disabled as alcohol monitoring can't currently be selected as a monitoring type.
+      // let alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
+      // alcoholMonitoringPage.form.saveAndContinueButton.click()
+      // alcoholMonitoringPage = Page.verifyOnPage(AlcoholMonitoringPage)
+      // if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - validation', { overwrite: true })
+      // alcoholMonitoringPage.form.fillInWith(alcoholMonitoringOrder)
+      // if (takeScreenshots) cy.screenshot('20. alcoholMonitoringPage - minimum', { overwrite: true })
+      // alcoholMonitoringPage.form.saveAndContinueButton.click()
 
       const monitoringConditionsCheckYourAnswersPage = Page.verifyOnPage(
         MonitoringConditionsCheckYourAnswersPage,

--- a/server/models/form-data/monitoringConditions.ts
+++ b/server/models/form-data/monitoringConditions.ts
@@ -9,7 +9,11 @@ const MonitoringConditionsFormDataParser = z.object({
     .union([z.string(), z.array(z.string()).default([])])
     .transform(val => (Array.isArray(val) ? val : [val])),
   orderTypeDescription: z.coerce.string(),
-  conditionType: z.coerce.string(),
+  conditionType: z
+    .string()
+    .nullable()
+    .default(null)
+    .transform(val => (val === null ? '' : val)),
   startDate: z.object({
     day: z.string().default(''),
     month: z.string().default(''),
@@ -61,10 +65,9 @@ const MonitoringConditionsFormDataValidator = z
     hdc: z.string(),
     prarr: z.string(),
   })
-  .transform(({ monitoringRequired, orderType, orderTypeDescription, conditionType, ...formData }) => ({
+  .transform(({ monitoringRequired, orderType, orderTypeDescription, ...formData }) => ({
     orderType: orderType === '' ? null : orderType,
     orderTypeDescription: orderTypeDescription === '' ? null : orderTypeDescription,
-    conditionType: conditionType === '' ? null : conditionType,
     curfew: monitoringRequired.includes('curfew'),
     exclusionZone: monitoringRequired.includes('exclusionZone'),
     trail: monitoringRequired.includes('trail'),

--- a/server/views/pages/order/monitoring-conditions/index.njk
+++ b/server/views/pages/order/monitoring-conditions/index.njk
@@ -124,7 +124,7 @@
         },
         {
           value: "POST_SENTENCE_SUPERVISION_REQUIREMENT",
-          text: "Post-Sentence Supervision Requirement following on from an Adult Custody Order",
+          text: "Post-Sentence Supervision Requirement following on from an Adult Custody order",
           hint: {
             text: "Device wearer licence period is complete. They are being released from a standard determinate custodial sentence of less than 2 years. They are subject to post-sentence supervision requirements that include monitoring conditions."
           },

--- a/server/views/pages/order/monitoring-conditions/index.njk
+++ b/server/views/pages/order/monitoring-conditions/index.njk
@@ -322,10 +322,10 @@
           value: "alcohol",
           text: "Alcohol monitoring",
           hint: {
-            text: "Measuring alcohol levels of the device wearer or recording they are abstaining from drinking alcohol."
+            text: "This service does not yet offer Alcohol Monitoring as a monitoring requirement. If you need to create an order including an Alcohol Monitoring requirement, or a multiple monitoring requirement order (for example, Alcohol Monitoring and Curfew), continue to use your current process."
           },
           checked: monitoringRequired.values | select("equalto", "alcohol") | length,
-          disabled: not isOrderEditable
+          disabled: true
         }
       ],
       errorMessage: monitoringRequired.error,

--- a/server/views/pages/order/monitoring-conditions/index.njk
+++ b/server/views/pages/order/monitoring-conditions/index.njk
@@ -95,23 +95,52 @@
       disabled: not isOrderEditable
     }) }}
 
-    {{ govukSelect({
-      id: "conditionType",
+    {{ govukRadios({
+      classes: "govuk-radios",
       name: "conditionType",
-      label: {
-       text: questions.conditionType.text,
-       classes: "govuk-fieldset__legend--s"
+      fieldset: {
+        legend: {
+          text: questions.conditionType.text,
+          isPageHeading: false,
+          classes: "govuk-fieldset__legend--s"
+        }
       },
       items: [
-        { text: 'Select', value: '' },
-        { text: 'Requirement of a Community Order', value: 'REQUIREMENT_OF_A_COMMUNITY_ORDER' },
-        { text: 'License Condition of a Custodial Order', value: 'LICENSE_CONDITION_OF_A_CUSTODIAL_ORDER' },
-        { text: 'Post-Sentence Supervision Requirement following on from an Adult Custody order', value: 'POST_SENTENCE_SUPERVISION_REQUIREMENT' },
-        { text: 'Bail Order', value: 'BAIL_ORDER' }
+        {
+          value: "REQUIREMENT_OF_A_COMMUNITY_ORDER",
+          text: "Requirement of a community order",
+          hint: {
+            text: "Monitoring conditions are part of a Community Order, a Suspended Sentence Order, or a Youth Rehabilitation Order."
+          },
+          disabled: not isOrderEditable
+        },
+        {
+          value: "LICENSE_CONDITION_OF_A_CUSTODIAL_ORDER",
+          text: "Licence condition of a custodial order",
+          hint: {
+            text: "Device wearer is being released from prison before their sentence is complete. They are subject to specific licence conditions that include monitoring conditions."
+          },
+          disabled: not isOrderEditable
+        },
+        {
+          value: "POST_SENTENCE_SUPERVISION_REQUIREMENT",
+          text: "Post-Sentence Supervision Requirement following on from an Adult Custody order",
+          hint: {
+            text: "Device wearer licence period is complete. They are being released from a standard determinate custodial sentence of less than 2 years. They are subject to post-sentence supervision requirements that include monitoring conditions."
+          },
+          disabled: not isOrderEditable
+        },
+        {
+          value: "BAIL_ORDER",
+          text: "Bail order",
+          hint: {
+            text: "Monitoring conditions are being imposed on the device wearer prior to trial."
+          },
+          disabled: not isOrderEditable
+        }
       ],
       value: conditionType.value,
-      errorMessage: conditionType.error,
-      disabled: not isOrderEditable
+      errorMessage: conditionType.error
     }) }}
 
     {{ govukSelect({

--- a/server/views/pages/order/monitoring-conditions/index.njk
+++ b/server/views/pages/order/monitoring-conditions/index.njk
@@ -108,7 +108,7 @@
       items: [
         {
           value: "REQUIREMENT_OF_A_COMMUNITY_ORDER",
-          text: "Requirement of a community order",
+          text: "Requirement of a Community Order",
           hint: {
             text: "Monitoring conditions are part of a Community Order, a Suspended Sentence Order, or a Youth Rehabilitation Order."
           },
@@ -116,7 +116,7 @@
         },
         {
           value: "LICENSE_CONDITION_OF_A_CUSTODIAL_ORDER",
-          text: "Licence condition of a custodial order",
+          text: "License Condition of a Custodial Order",
           hint: {
             text: "Device wearer is being released from prison before their sentence is complete. They are subject to specific licence conditions that include monitoring conditions."
           },
@@ -124,7 +124,7 @@
         },
         {
           value: "POST_SENTENCE_SUPERVISION_REQUIREMENT",
-          text: "Post-Sentence Supervision Requirement following on from an Adult Custody order",
+          text: "Post-Sentence Supervision Requirement following on from an Adult Custody Order",
           hint: {
             text: "Device wearer licence period is complete. They are being released from a standard determinate custodial sentence of less than 2 years. They are subject to post-sentence supervision requirements that include monitoring conditions."
           },
@@ -132,7 +132,7 @@
         },
         {
           value: "BAIL_ORDER",
-          text: "Bail order",
+          text: "Bail Order",
           hint: {
             text: "Monitoring conditions are being imposed on the device wearer prior to trial."
           },


### PR DESCRIPTION
**Changes for [ELM-3571](https://dsdmoj.atlassian.net/browse/ELM-3571)**

In the Monitoring Conditions page:

- Replace the Order Type Conditions select component with a radio buttons component, that includes a descriptive hint for each option.
- Disable the Alcohol Monitoring option in the Monitoring Required section. Add text explaining why the option is disabled.


[ELM-3571]: https://dsdmoj.atlassian.net/browse/ELM-3571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ