### PR TITLE
Use correct HMPPS Auth URL in header HMPPS link.

### DIFF
--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -28,6 +28,7 @@ export default function setUpAuth(): Router {
       failureRedirect: '/autherror',
     })(req, res, next),
   )
+
   const authUrl = config.apis.hmppsAuth.url
   const authParameters = `client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${config.domain}`
 

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -28,8 +28,7 @@ export default function setUpAuth(): Router {
       failureRedirect: '/autherror',
     })(req, res, next),
   )
-
-  const authUrl = config.apis.hmppsAuth.externalUrl
+  const authUrl = config.apis.hmppsAuth.url
   const authParameters = `client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${config.domain}`
 
   router.use('/sign-out', (req, res, next) => {


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3666

- Most of the work for this ticket was done previously.
- An incorrect environment variable is used to define the HMPPS Auth URL.
- This change corrects that.
