### PR TITLE
ELM-3680: Modify status tag from Additional Documents in task list

### DIFF
--- a/integration_tests/e2e/order/summary.cy.ts
+++ b/integration_tests/e2e/order/summary.cy.ts
@@ -24,7 +24,7 @@ context('Order Summary', () => {
       page.submitOrderButton.should('exist')
     })
 
-    it('should display all tasks as incomplete or unable to start for a new order', () => {
+    it('should display all tasks except Additional Documents as incomplete or unable to start for a new order', () => {
       const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
 
       page.aboutTheDeviceWearerTask.shouldHaveStatus('Incomplete')
@@ -43,12 +43,16 @@ context('Order Summary', () => {
       page.electronicMonitoringTask.shouldHaveStatus('Incomplete')
       page.electronicMonitoringTask.link.should('have.attr', 'href', `/order/${mockOrderId}/monitoring-conditions`)
 
-      page.additionalDocumentsTask.shouldHaveStatus('Incomplete')
-      page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
-
       cy.get('.govuk-task-list__item').should('not.contain', 'Variation details')
 
       page.submitOrderButton.should('be.disabled')
+    })
+
+    it('should display the Additional Documents task without a status tag for a new order', () => {
+      const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
+
+      page.additionalDocumentsTask.shouldNotHaveStatus()
+      page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
     })
 
     it('Should be accessible', () => {
@@ -73,7 +77,7 @@ context('Order Summary', () => {
       cy.signIn()
     })
 
-    it('should display all tasks as incomplete or unable to start for a new variation', () => {
+    it('should display all tasks except Additional Documents as incomplete or unable to start for a new variation', () => {
       const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
 
       page.aboutTheDeviceWearerTask.shouldHaveStatus('Incomplete')
@@ -92,13 +96,17 @@ context('Order Summary', () => {
       page.electronicMonitoringTask.shouldHaveStatus('Incomplete')
       page.electronicMonitoringTask.link.should('have.attr', 'href', `/order/${mockOrderId}/monitoring-conditions`)
 
-      page.additionalDocumentsTask.shouldHaveStatus('Incomplete')
-      page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
-
       page.variationDetailsTask.shouldHaveStatus('Incomplete')
       page.variationDetailsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/variation/details`)
 
       page.submitOrderButton.should('be.disabled')
+    })
+
+    it('should display the Additional Documents task without a status tag for a new variation', () => {
+      const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
+
+      page.additionalDocumentsTask.shouldNotHaveStatus()
+      page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
     })
 
     it('Should be accessible', () => {

--- a/integration_tests/e2e/order/summary.cy.ts
+++ b/integration_tests/e2e/order/summary.cy.ts
@@ -48,10 +48,10 @@ context('Order Summary', () => {
       page.submitOrderButton.should('be.disabled')
     })
 
-    it('should display the Additional Documents task without a status tag for a new order', () => {
+    it('should display the Additional Documents task as optional for a new order', () => {
       const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
 
-      page.additionalDocumentsTask.shouldNotHaveStatus()
+      page.additionalDocumentsTask.shouldHaveStatus('Optional')
       page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
     })
 
@@ -102,10 +102,10 @@ context('Order Summary', () => {
       page.submitOrderButton.should('be.disabled')
     })
 
-    it('should display the Additional Documents task without a status tag for a new variation', () => {
+    it('should display the Additional Documents task as optional for a new variation', () => {
       const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
 
-      page.additionalDocumentsTask.shouldNotHaveStatus()
+      page.additionalDocumentsTask.shouldHaveStatus('Optional')
       page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
     })
 

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -57,31 +57,39 @@
       {% set items = [] %}
       {% for section in sections %}
         {% set name = section.name | replace("_", " ") | capitalize %}
+        {% set hintArgs = {} %}
 
-        {% set statusArgs = { 
+        {% if not isOrderEditable %}
+          {% set statusArgs = {} %}
+        {% elif section.name == 'ADDITIONAL_DOCUMENTS' %}
+          {% set statusArgs = { 
+            tag: {
+              text: 'Optional',
+              classes: 'govuk-tag--green'
+            }
+          } %}
+          {% set hintArgs = {
+            text: "Add all documents required for the order."
+          } %}
+        {% elif section.completed %}
+          {% set statusArgs = { 
             text: 'Complete'
-        } if section.completed else {
-          tag: {
-            text: 'Incomplete'
-          }
-        } %}
-
-        {% set statusArgs = statusArgs if isOrderEditable else {} %}
-
-        {% if section.name == 'ADDITIONAL_DOCUMENTS' %}
-          {% set items = (items.push({
-            idPrefix: "order-section",
-            title: { text: name },
-            href: section.path
-          }), items) %}
+          } %}
         {% else %}
-          {% set items = (items.push({
-            idPrefix: "order-section",
-            title: { text: name },
-            href: section.path,
-            status: statusArgs
-          }), items) %}
+          {% set statusArgs = { 
+            tag: {
+              text: 'Incomplete'
+            }
+          } %}
         {% endif %}
+
+        {% set items = (items.push({
+          idPrefix: "order-section",
+          title: { text: name },
+          href: section.path,
+          status: statusArgs,
+          hint: hintArgs
+        }), items) %}
 
       {% endfor %}
 

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -68,12 +68,20 @@
 
         {% set statusArgs = statusArgs if isOrderEditable else {} %}
 
-        {% set items = (items.push({
-          idPrefix: "order-section",
-          title: { text: name },
-          href: section.path,
-          status: statusArgs
-        }), items) %}
+        {% if section.name == 'ADDITIONAL_DOCUMENTS' %}
+          {% set items = (items.push({
+            idPrefix: "order-section",
+            title: { text: name },
+            href: section.path
+          }), items) %}
+        {% else %}
+          {% set items = (items.push({
+            idPrefix: "order-section",
+            title: { text: name },
+            href: section.path,
+            status: statusArgs
+          }), items) %}
+        {% endif %}
 
       {% endfor %}
 

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -83,8 +83,7 @@
           idPrefix: "order-section",
           title: { text: name },
           href: section.path,
-          status: statusArgs,
-          hint: hintArgs
+          status: statusArgs
         }), items) %}
 
       {% endfor %}

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -57,7 +57,6 @@
       {% set items = [] %}
       {% for section in sections %}
         {% set name = section.name | replace("_", " ") | capitalize %}
-        {% set hintArgs = {} %}
 
         {% if not isOrderEditable %}
           {% set statusArgs = {} %}
@@ -67,9 +66,6 @@
               text: 'Optional',
               classes: 'govuk-tag--green'
             }
-          } %}
-          {% set hintArgs = {
-            text: "Add all documents required for the order."
           } %}
         {% elif section.completed %}
           {% set statusArgs = { 


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3680

- In the form summary page, in the task list, each section has a tag indicating its status (eg. complete, incomplete).
- There isn't a precise definition of complete/incomplete for the Additional Documents section. Different order requests may have different attachments.
- Currently the Additional Documents section's status tag is always "incomplete", which is misleading.

![image](https://github.com/user-attachments/assets/30345935-c381-4eb1-9b7a-b6e7b6496e77)

### Changes proposed in this pull request

- Change the Additional Documents status tag text to "Optional".
- Update integration tests.