### PR TITLE
Remove cya actions for errored orders

### DIFF
--- a/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.error.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.error.cy.ts
@@ -1,0 +1,88 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import CheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
+
+const mockOrderId = uuidv4()
+
+context('Device wearer - check your answers', () => {
+  context('Order that failed to submit to Serco', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'ERROR',
+        order: {
+          deviceWearer: {
+            nomisId: 'nomis',
+            pncId: 'pnc',
+            deliusId: 'delius',
+            prisonNumber: 'prison',
+            homeOfficeReferenceNumber: 'ho',
+            firstName: 'test',
+            lastName: 'tester',
+            alias: 'tes',
+            dateOfBirth: '2000-01-01T00:00:00Z',
+            adultAtTimeOfInstallation: true,
+            sex: 'MALE',
+            gender: 'MALE',
+            disabilities: 'MENTAL_HEALTH',
+            otherDisability: null,
+            noFixedAbode: null,
+            interpreterRequired: false,
+          },
+          fmsResultDate: new Date('2024 12 14'),
+          DeviceWearerResponsibleAdult: null,
+        },
+      })
+
+      cy.signIn()
+    })
+
+    it('should show answers without any actions', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId }, {}, 'View answers')
+
+      // Should show the correct answers
+      page.personDetailsSection.shouldExist()
+      page.personDetailsSection.shouldHaveItems([
+        { key: "What is the device wearer's first name?", value: 'test' },
+        { key: "What is the device wearer's last name?", value: 'tester' },
+        { key: "What is the device wearer's preferred name or names? (optional)", value: 'tes' },
+        { key: "What is the device wearer's date of birth?", value: '01/01/2000' },
+        { key: 'Is a responsible adult required?', value: 'No' },
+        { key: 'What is the sex of the device wearer?', value: 'Male' },
+        { key: "What is the device wearer's gender?", value: 'Male' },
+        {
+          key: 'Does the device wearer have any of the disabilities or health conditions listed? (optional)',
+          value: 'Mental health',
+        },
+        { key: 'What language does the interpreter need to use? (optional)', value: '' },
+        { key: 'Is an interpreter needed?', value: 'No' },
+      ])
+      page.personDetailsSection.shouldNotHaveItems([
+        "What is the device wearer's disability or health condition?",
+        "What is the device wearer's chosen identity?",
+      ])
+      page.identityNumbersSection.shouldExist()
+      page.identityNumbersSection.shouldHaveItems([
+        { key: 'National Offender Management Information System (NOMIS) ID (optional)', value: 'nomis' },
+        { key: 'Police National Computer (PNC) ID (optional)', value: 'pnc' },
+        { key: 'Delius ID (optional)', value: 'delius' },
+        { key: 'Prison number (optional)', value: 'prison' },
+        { key: 'Home Office Reference Number (optional)', value: 'ho' },
+      ])
+      page.responsibleAdultSection.shouldNotExist()
+
+      // Should not have any "change" links
+      page.changeLinks.should('not.exist')
+
+      // Should show the correct buttons
+      page.continueButton().should('exist')
+      page.continueButton().contains('Go to next section')
+      page.returnButton().should('exist')
+      page.returnButton().contains('Return to main form menu')
+    })
+  })
+})

--- a/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.error.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.error.cy.ts
@@ -1,0 +1,57 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import InstallationAndRiskCheckYourAnswersPage from '../../../pages/order/installation-and-risk/check-your-answers'
+
+const mockOrderId = uuidv4()
+
+context('Installation and risk - check your answers', () => {
+  context('Order that failed to submit to Serco', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'ERROR',
+        order: {
+          installationAndRisk: {
+            offence: 'SEXUAL_OFFENCES',
+            riskCategory: ['RISK_TO_GENDER'],
+            riskDetails: 'some risk details',
+            mappaLevel: 'MAPPA 1',
+            mappaCaseType: 'SOC (Serious Organised Crime)',
+          },
+          fmsResultDate: new Date('2024 12 14'),
+        },
+      })
+      cy.signIn()
+    })
+
+    it('should show answers without any actions', () => {
+      const page = Page.visit(InstallationAndRiskCheckYourAnswersPage, { orderId: mockOrderId }, {}, 'View answers')
+
+      // Should show the correct answers
+      page.installationRiskSection.shouldExist()
+      page.installationRiskSection.shouldHaveItems([
+        { key: 'What type of offence did the device wearer commit? (optional)', value: 'Sexual offences' },
+        {
+          key: 'At installation what are the possible risks? (optional)',
+          value: 'Offensive towards someone because of their sex or gender',
+        },
+        { key: 'Any other risks to be aware of? (optional)', value: 'some risk details' },
+        { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
+        { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
+      ])
+
+      // Should not have any "change" links
+      page.changeLinks.should('not.exist')
+
+      // Should show the correct buttons
+      page.continueButton().should('exist')
+      page.continueButton().contains('Go to next section')
+      page.returnButton().should('exist')
+      page.returnButton().contains('Return to main form menu')
+    })
+  })
+})

--- a/integration_tests/e2e/order/contact-information/check-your-answers.error.cy.ts
+++ b/integration_tests/e2e/order/contact-information/check-your-answers.error.cy.ts
@@ -1,0 +1,100 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
+
+const mockOrderId = uuidv4()
+
+context('Contact Information - check your answers', () => {
+  context('Order that failed to submit to Serco', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+      cy.signIn()
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'ERROR',
+        order: {
+          contactDetails: {
+            contactNumber: '01234567890',
+          },
+          deviceWearer: {
+            nomisId: null,
+            pncId: null,
+            deliusId: null,
+            prisonNumber: null,
+            homeOfficeReferenceNumber: null,
+            firstName: null,
+            lastName: null,
+            alias: null,
+            adultAtTimeOfInstallation: null,
+            sex: null,
+            gender: null,
+            dateOfBirth: null,
+            disabilities: null,
+            noFixedAbode: true,
+            interpreterRequired: null,
+          },
+          interestedParties: {
+            notifyingOrganisation: 'HOME_OFFICE',
+            notifyingOrganisationName: '',
+            notifyingOrganisationEmail: 'notifying@organisation',
+            responsibleOrganisation: 'POLICE',
+            responsibleOrganisationEmail: 'responsible@organisation',
+            responsibleOrganisationRegion: '',
+            responsibleOfficerName: 'name',
+            responsibleOfficerPhoneNumber: '01234567891',
+          },
+          fmsResultDate: new Date('2024 12 14'),
+        },
+      })
+    })
+
+    it('should show answers without any actions', () => {
+      const page = Page.visit(ContactInformationCheckYourAnswersPage, { orderId: mockOrderId }, {}, 'View answers')
+
+      // Should show the correct answers
+      page.contactDetailsSection.shouldExist()
+      page.contactDetailsSection.shouldHaveItems([
+        { key: "What is the device wearer's telephone number? (optional)", value: '01234567890' },
+      ])
+
+      page.deviceWearerAddressesSection.shouldExist()
+      page.deviceWearerAddressesSection.shouldHaveItems([
+        { key: 'Does the device wearer have a fixed address?', value: 'No' },
+      ])
+
+      page.deviceWearerAddressesSection.shouldNotHaveItems([
+        "What is the device wearer's main address?",
+        "What is the device wearer's second address?",
+        "What is the device wearer's third address?",
+      ])
+      page.organisationDetailsSection.shouldExist()
+      page.organisationDetailsSection.shouldHaveItems([
+        { key: 'What organisation or related organisation are you part of?', value: 'Home Office' },
+        { key: "What is your team's contact email address?", value: 'notifying@organisation' },
+        { key: "What is the Responsible Officer's full name?", value: 'name' },
+        { key: "What is the Responsible Officer's telephone number?", value: '01234567891' },
+        { key: "What is the Responsible Officer's organisation?", value: 'Police' },
+        { key: "What is the Responsible Organisation's email address? (optional)", value: 'responsible@organisation' },
+      ])
+      page.deviceWearerAddressesSection.shouldNotHaveItems([
+        'Select the name of the Crown Court',
+        'Select the name of the Court',
+        'Select the name of the Prison',
+        'Select the Probation region',
+        'Select the Youth Justice Service region',
+      ])
+
+      // Should not have any "change" links
+      page.changeLinks.should('not.exist')
+
+      // Should show the correct buttons
+      page.continueButton().should('exist')
+      page.continueButton().contains('Go to next section')
+      page.returnButton().should('exist')
+      page.returnButton().contains('Return to main form menu')
+    })
+  })
+})

--- a/integration_tests/e2e/order/monitoring-conditions/check-your-answers.error.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/check-your-answers.error.cy.ts
@@ -1,0 +1,62 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import CheckYourAnswers from '../../../pages/order/monitoring-conditions/check-your-answers'
+
+const mockOrderId = uuidv4()
+
+context('Monitoring conditions - check your answers', () => {
+  context('Order that failed to submit to Serco', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+      cy.signIn()
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'ERROR',
+        order: {
+          monitoringConditions: {
+            startDate: '2025-01-01T00:00:00Z',
+            endDate: '2025-02-01T00:00:00Z',
+            orderType: 'CIVIL',
+            curfew: true,
+            exclusionZone: true,
+            trail: true,
+            mandatoryAttendance: true,
+            alcohol: true,
+            conditionType: 'BAIL_ORDER',
+            orderTypeDescription: 'DAPO',
+            sentenceType: 'IPP',
+            issp: 'YES',
+            hdc: 'NO',
+            prarr: 'UNKNOWN',
+          },
+          fmsResultDate: new Date('2024 12 14'),
+        },
+      })
+    })
+
+    it('should show answers without any actions', () => {
+      const page = Page.visit(CheckYourAnswers, { orderId: mockOrderId }, {}, 'View answers')
+
+      // Should show the correct answers
+      page.monitoringConditionsSection().should('exist')
+      page.installationAddressSection().should('exist')
+      page.curfewOnDayOfReleaseSection().should('exist')
+      page.curfewSection().should('exist')
+      page.curfewTimetableSection().should('exist')
+      page.trailMonitoringConditionsSection().should('exist')
+      page.alcoholMonitoringConditionsSection().should('exist')
+
+      // Should not have any "change" links
+      page.changeLinks.should('not.exist')
+
+      // Should show the correct buttons
+      page.continueButton().should('exist')
+      page.continueButton().contains('Go to next section')
+      page.returnButton().should('exist')
+      page.returnButton().contains('Return to main form menu')
+    })
+  })
+})

--- a/server/models/view-models/additionalDocumentsCheckAnswers.ts
+++ b/server/models/view-models/additionalDocumentsCheckAnswers.ts
@@ -6,7 +6,7 @@ import AttachmentType from '../AttachmentType'
 const createViewModel = (order: Order) => {
   const licence = order.additionalDocuments.find(x => x.fileType === AttachmentType.LICENCE)
   const photo = order.additionalDocuments.find(x => x.fileType === AttachmentType.PHOTO_ID)
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   const answers = [
     createAnswer('Licence', licence?.fileName ?? 'No licence document uploaded', '', answerOpts),
     createAnswer('Photo identification (optional)', photo?.fileName ?? 'No photo ID document uploaded', '', answerOpts),

--- a/server/models/view-models/contactInformationCheckAnswers.ts
+++ b/server/models/view-models/contactInformationCheckAnswers.ts
@@ -15,7 +15,7 @@ const createContactDetailsAnswers = (order: Order, content: I18n) => {
   const uri = paths.CONTACT_INFORMATION.CONTACT_DETAILS.replace(':orderId', order.id)
   return [
     createAnswer(content.pages.contactDetails.questions.contactNumber.text, order.contactDetails?.contactNumber, uri, {
-      ignoreActions: order.status === 'SUBMITTED',
+      ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR',
     }),
   ]
 }
@@ -31,7 +31,7 @@ const createAddressAnswers = (order: Order, content: I18n) => {
   const secondaryAddress = order.addresses.find(({ addressType }) => addressType === 'SECONDARY')
   const tertiaryAddress = order.addresses.find(({ addressType }) => addressType === 'TERTIARY')
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   const answers = [
     createBooleanAnswer(
       content.pages.noFixedAbode.questions.noFixedAbode.text,
@@ -65,7 +65,7 @@ const createAddressAnswers = (order: Order, content: I18n) => {
 const getNotifyingOrganisationNameAnswer = (order: Order, content: I18n, uri: string) => {
   const notifyingOrganisation = order.interestedParties?.notifyingOrganisation
   const { questions } = content.pages.interestedParties
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   if (notifyingOrganisation === 'PRISON') {
     return [
       createAnswer(
@@ -106,7 +106,7 @@ const getResponsibleOrganisationRegionAnswer = (order: Order, content: I18n, uri
   const responsibleOrganisation = order.interestedParties?.responsibleOrganisation
   const { questions } = content.pages.interestedParties
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   if (responsibleOrganisation === 'PROBATION') {
     return [
       createAnswer(
@@ -137,7 +137,7 @@ const createInterestedPartiesAnswers = (order: Order, content: I18n) => {
 
   const { questions } = content.pages.interestedParties
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   return [
     createAnswer(
       questions.notifyingOrganisation.text,

--- a/server/models/view-models/deviceWearerCheckAnswers.ts
+++ b/server/models/view-models/deviceWearerCheckAnswers.ts
@@ -13,7 +13,7 @@ const createOtherDisabilityAnswer = (order: Order, content: I18n, uri: string) =
   if (order.deviceWearer.disabilities.includes('OTHER')) {
     return [
       createAnswer(content.pages.deviceWearer.questions.otherDisability.text, order.deviceWearer.otherDisability, uri, {
-        ignoreActions: order.status === 'SUBMITTED',
+        ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR',
       }),
     ]
   }
@@ -27,7 +27,7 @@ const createDeviceWearerAnswers = (order: Order, content: I18n) => {
     lookup(content.reference.disabilities, disability),
   )
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   return [
     createAnswer(content.pages.deviceWearer.questions.firstName.text, order.deviceWearer.firstName, uri, answerOpts),
     createAnswer(content.pages.deviceWearer.questions.lastName.text, order.deviceWearer.lastName, uri, answerOpts),
@@ -71,7 +71,7 @@ const createDeviceWearerAnswers = (order: Order, content: I18n) => {
 const createPersonIdentifierAnswers = (order: Order, content: I18n) => {
   const uri = paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id)
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   return [
     createAnswer(content.pages.identityNumbers.questions.nomisId.text, order.deviceWearer.nomisId, uri, answerOpts),
     createAnswer(content.pages.identityNumbers.questions.pncId.text, order.deviceWearer.pncId, uri, answerOpts),
@@ -98,7 +98,7 @@ const createOtherRelationshipAnswer = (order: Order, content: I18n, uri: string)
         content.pages.responsibleAdult.questions.otherRelationship.text,
         order.deviceWearerResponsibleAdult?.otherRelationshipDetails,
         uri,
-        { ignoreActions: order.status === 'SUBMITTED' },
+        { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' },
       ),
     ]
   }
@@ -117,7 +117,7 @@ const createResponsibeAdultAnswers = (order: Order, content: I18n) => {
     return []
   }
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   return [
     createAnswer(
       content.pages.responsibleAdult.questions.relationship.text,

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -46,7 +46,7 @@ const createMonitoringConditionsAnswers = (order: Order, content: I18n) => {
   const prarr = lookup(yesNoUnknown, order.monitoringConditions.prarr)
   const { questions } = content.pages.monitoringConditions
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   return [
     createDateAnswer(questions.startDate.text, order.monitoringConditions.startDate, uri, answerOpts),
     createTimeAnswer(questions.startTime.text, order.monitoringConditions.startDate, uri, answerOpts),
@@ -74,7 +74,7 @@ const createInstallationAddressAnswers = (order: Order, content: I18n) => {
 
   return [
     createAddressAnswer(content.pages.installationAddress.legend, installationAddress, uri, {
-      ignoreActions: order.status === 'SUBMITTED',
+      ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR',
     }),
   ]
 }
@@ -127,7 +127,7 @@ const createCurfewTimetableAnswers = (order: Order) => {
         : createAddressPreview(address)
 
       return createMultipleChoiceAnswer(preview, groups[group].map(createSchedulePreview), uri, {
-        ignoreActions: order.status === 'SUBMITTED',
+        ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR',
       })
     })
 }
@@ -140,7 +140,7 @@ const createCurfewReleaseDateAnswers = (order: Order, content: I18n) => {
     return []
   }
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   return [
     createDateAnswer(
       questions.releaseDate.text,
@@ -172,7 +172,7 @@ const createCurfewAnswers = (order: Order, content: I18n) => {
     return []
   }
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   return [
     createDateAnswer(questions.startDate.text, order.curfewConditions?.startDate, conditionsUri, answerOpts),
     createDateAnswer(questions.endDate.text, order.curfewConditions?.endDate, conditionsUri, answerOpts),
@@ -200,7 +200,7 @@ const createExclusionZoneAnswers = (order: Order, content: I18n) => {
       const zoneId = enforcementZone.zoneId || 0
       const zoneUri = uri ? uri.replace(':zoneId', zoneId.toString()) : ''
 
-      const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+      const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
       return [
         createDateAnswer(questions.startDate.text, enforcementZone.startDate, zoneUri, answerOpts),
         createDateAnswer(questions.endDate.text, enforcementZone.endDate, zoneUri, answerOpts),
@@ -219,7 +219,7 @@ const createTrailAnswers = (order: Order, content: I18n) => {
     return []
   }
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   return [
     createDateAnswer(questions.startDate.text, order.monitoringConditionsTrail?.startDate, uri, answerOpts),
     createDateAnswer(questions.endDate.text, order.monitoringConditionsTrail?.endDate, uri, answerOpts),
@@ -238,7 +238,7 @@ const createAttendanceAnswers = (order: Order, content: I18n) => {
     )
     const { questions } = content.pages.attendance
 
-    const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+    const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
     return [
       createDateAnswer(questions.startDate.text, attendance.startDate, uri, answerOpts),
       createDateAnswer(questions.endDate.text, attendance.endDate, uri, answerOpts),
@@ -274,7 +274,7 @@ const createAlcoholAnswers = (order: Order, content: I18n) => {
     return []
   }
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   return [
     createAnswer(questions.monitoringType.text, monitoringType, uri, answerOpts),
     createDateAnswer(questions.startDate.text, order.monitoringConditionsAlcohol?.startDate, uri, answerOpts),

--- a/server/models/view-models/riskInformationCheckAnswers.ts
+++ b/server/models/view-models/riskInformationCheckAnswers.ts
@@ -8,7 +8,7 @@ import config from '../../config'
 const createViewModel = (order: Order, content: I18n, uri: string = '') => {
   const { questions } = content.pages.installationAndRisk
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   const answers = [
     createAnswer(
       questions.offence.text,


### PR DESCRIPTION
Orders that submit to Serco are immutable, however when viewing an order that failed to submit to Serco, the check your answers pages display the "change" links.

This functionality is very similar to how the successfully submitted orders are handled so the logic used for those views can be updated for these views too.

To ensure that this is working correctly, additional integration tests are added.