### PR TITLE
ELM-3681: Remove seconds from times displayed in the UI

### DIFF
--- a/integration_tests/e2e/order/summary.cy.ts
+++ b/integration_tests/e2e/order/summary.cy.ts
@@ -24,7 +24,7 @@ context('Order Summary', () => {
       page.submitOrderButton.should('exist')
     })
 
-    it('should display all tasks as incomplete or unable to start for a new order', () => {
+    it('should display all tasks except Additional Documents as incomplete or unable to start for a new order', () => {
       const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
 
       page.aboutTheDeviceWearerTask.shouldHaveStatus('Incomplete')
@@ -43,12 +43,16 @@ context('Order Summary', () => {
       page.electronicMonitoringTask.shouldHaveStatus('Incomplete')
       page.electronicMonitoringTask.link.should('have.attr', 'href', `/order/${mockOrderId}/monitoring-conditions`)
 
-      page.additionalDocumentsTask.shouldHaveStatus('Incomplete')
-      page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
-
       cy.get('.govuk-task-list__item').should('not.contain', 'Variation details')
 
       page.submitOrderButton.should('be.disabled')
+    })
+
+    it('should display the Additional Documents task without a status tag for a new order', () => {
+      const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
+
+      page.additionalDocumentsTask.shouldNotHaveStatus()
+      page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
     })
 
     it('Should be accessible', () => {
@@ -73,7 +77,7 @@ context('Order Summary', () => {
       cy.signIn()
     })
 
-    it('should display all tasks as incomplete or unable to start for a new variation', () => {
+    it('should display all tasks except Additional Documents as incomplete or unable to start for a new variation', () => {
       const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
 
       page.aboutTheDeviceWearerTask.shouldHaveStatus('Incomplete')
@@ -92,13 +96,17 @@ context('Order Summary', () => {
       page.electronicMonitoringTask.shouldHaveStatus('Incomplete')
       page.electronicMonitoringTask.link.should('have.attr', 'href', `/order/${mockOrderId}/monitoring-conditions`)
 
-      page.additionalDocumentsTask.shouldHaveStatus('Incomplete')
-      page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
-
       page.variationDetailsTask.shouldHaveStatus('Incomplete')
       page.variationDetailsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/variation/details`)
 
       page.submitOrderButton.should('be.disabled')
+    })
+
+    it('should display the Additional Documents task without a status tag for a new variation', () => {
+      const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
+
+      page.additionalDocumentsTask.shouldNotHaveStatus()
+      page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
     })
 
     it('Should be accessible', () => {

--- a/integration_tests/e2e/order/summary.cy.ts
+++ b/integration_tests/e2e/order/summary.cy.ts
@@ -48,10 +48,10 @@ context('Order Summary', () => {
       page.submitOrderButton.should('be.disabled')
     })
 
-    it('should display the Additional Documents task without a status tag for a new order', () => {
+    it('should display the Additional Documents task as optional for a new order', () => {
       const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
 
-      page.additionalDocumentsTask.shouldNotHaveStatus()
+      page.additionalDocumentsTask.shouldHaveStatus('Optional')
       page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
     })
 
@@ -102,10 +102,10 @@ context('Order Summary', () => {
       page.submitOrderButton.should('be.disabled')
     })
 
-    it('should display the Additional Documents task without a status tag for a new variation', () => {
+    it('should display the Additional Documents task as optional for a new variation', () => {
       const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
 
-      page.additionalDocumentsTask.shouldNotHaveStatus()
+      page.additionalDocumentsTask.shouldHaveStatus('Optional')
       page.additionalDocumentsTask.link.should('have.attr', 'href', `/order/${mockOrderId}/attachments`)
     })
 

--- a/server/controllers/monitoringConditions/checkAnswersController.test.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.test.ts
@@ -473,7 +473,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'What is the start time on the first day of monitoring?',
             },
             value: {
-              text: '01:01:00',
+              text: '01:01',
             },
             actions: {
               items: [
@@ -507,7 +507,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'What is the end time on the last day of monitoring? (optional)',
             },
             value: {
-              text: '01:01:00',
+              text: '01:01',
             },
             actions: {
               items: [
@@ -809,7 +809,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'Line 1, Line 2, Postcode',
             },
             value: {
-              html: 'Monday - 11:11:00-11:11:00<br/>Tuesday - 11:11:00-11:11:00<br/>Wednesday - 11:11:00-11:11:00<br/>Thursday - 11:11:00-11:11:00<br/>Friday - 11:11:00-11:11:00<br/>Saturday - 11:11:00-11:11:00<br/>Sunday - 11:11:00-11:11:00',
+              html: 'Monday - 11:11-11:11<br/>Tuesday - 11:11-11:11<br/>Wednesday - 11:11-11:11<br/>Thursday - 11:11-11:11<br/>Friday - 11:11-11:11<br/>Saturday - 11:11-11:11<br/>Sunday - 11:11-11:11',
             },
             actions: {
               items: [
@@ -826,7 +826,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'Line 1, Line 2, Postcode',
             },
             value: {
-              html: 'Monday - 11:11:00-11:11:00',
+              html: 'Monday - 11:11-11:11',
             },
             actions: {
               items: [
@@ -1139,7 +1139,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                 text: 'What time does the appointment start?',
               },
               value: {
-                text: '01:11:00',
+                text: '01:11',
               },
               actions: {
                 items: [
@@ -1159,7 +1159,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                 text: 'What time does the appointment end?',
               },
               value: {
-                text: '11:11:00',
+                text: '11:11',
               },
               actions: {
                 items: [

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -6,6 +6,7 @@ import {
   formatDateTime,
   isNullOrUndefined,
   lookup,
+  trimSeconds,
 } from '../../utils/utils'
 import { AddressType, AddressTypeEnum } from '../Address'
 import { CurfewSchedule, CurfewTimetable } from '../CurfewTimetable'
@@ -80,7 +81,7 @@ const createInstallationAddressAnswers = (order: Order, content: I18n) => {
 }
 
 const createSchedulePreview = (schedule: CurfewSchedule) =>
-  `${convertToTitleCase(schedule.dayOfWeek)} - ${schedule.startTime}-${schedule.endTime}`
+  `${convertToTitleCase(schedule.dayOfWeek)} - ${trimSeconds(schedule.startTime)}-${trimSeconds(schedule.endTime)}`
 
 const groupTimetableByAddress = (timetable: CurfewTimetable) =>
   timetable.reduce(
@@ -244,8 +245,8 @@ const createAttendanceAnswers = (order: Order, content: I18n) => {
       createDateAnswer(questions.endDate.text, attendance.endDate, uri, answerOpts),
       createAnswer(questions.purpose.text, attendance.purpose, uri, answerOpts),
       createAnswer(questions.appointmentDay.text, attendance.appointmentDay, uri, answerOpts),
-      createAnswer(questions.startTime.text, attendance.startTime, uri, answerOpts),
-      createAnswer(questions.endTime.text, attendance.endTime, uri, answerOpts),
+      createAnswer(questions.startTime.text, trimSeconds(attendance.startTime), uri, answerOpts),
+      createAnswer(questions.endTime.text, trimSeconds(attendance.endTime), uri, answerOpts),
       createAddressAnswer(
         questions.address.text,
         {

--- a/server/utils/checkYourAnswers.ts
+++ b/server/utils/checkYourAnswers.ts
@@ -1,4 +1,4 @@
-import { isNullOrUndefined, convertBooleanToEnum, createAddressPreview } from './utils'
+import { isNullOrUndefined, convertBooleanToEnum, createAddressPreview, trimSeconds } from './utils'
 import { AddressWithoutType } from '../models/Address'
 
 type Optional<T> = T | null | undefined
@@ -61,7 +61,7 @@ const createDatePreview = (value: Optional<string>) =>
   isNullOrUndefined(value) ? '' : new Date(value).toLocaleDateString('en-GB')
 
 const createTimePreview = (value: Optional<string>) =>
-  isNullOrUndefined(value) ? '' : new Date(value).toLocaleTimeString('en-GB')
+  isNullOrUndefined(value) ? '' : trimSeconds(new Date(value).toLocaleTimeString('en-GB'))
 
 export const createDateAnswer = (key: string, value: Optional<string>, uri: string, opts: AnswerOptions = {}): Answer =>
   createAnswer(key, createDatePreview(value), uri, opts)

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -89,6 +89,13 @@ export const deserialiseTime = (timeString?: string | null): [hours: string, min
   return [timeMatch[1], timeMatch[2]]
 }
 
+export const trimSeconds = (timeString?: string | null): string => {
+  if (!timeString || isBlank(timeString)) {
+    return ''
+  }
+  return timeString.split(':').slice(0, 2).join(':')
+}
+
 export const getError = (validationErrors: ValidationResult, field: string): ErrorMessage | undefined => {
   const matchedError = validationErrors.find(e => e.field === field)
 

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -57,31 +57,39 @@
       {% set items = [] %}
       {% for section in sections %}
         {% set name = section.name | replace("_", " ") | capitalize %}
+        {% set hintArgs = {} %}
 
-        {% set statusArgs = { 
+        {% if not isOrderEditable %}
+          {% set statusArgs = {} %}
+        {% elif section.name == 'ADDITIONAL_DOCUMENTS' %}
+          {% set statusArgs = { 
+            tag: {
+              text: 'Optional',
+              classes: 'govuk-tag--green'
+            }
+          } %}
+          {% set hintArgs = {
+            text: "Add all documents required for the order."
+          } %}
+        {% elif section.completed %}
+          {% set statusArgs = { 
             text: 'Complete'
-        } if section.completed else {
-          tag: {
-            text: 'Incomplete'
-          }
-        } %}
-
-        {% set statusArgs = statusArgs if isOrderEditable else {} %}
-
-        {% if section.name == 'ADDITIONAL_DOCUMENTS' %}
-          {% set items = (items.push({
-            idPrefix: "order-section",
-            title: { text: name },
-            href: section.path
-          }), items) %}
+          } %}
         {% else %}
-          {% set items = (items.push({
-            idPrefix: "order-section",
-            title: { text: name },
-            href: section.path,
-            status: statusArgs
-          }), items) %}
+          {% set statusArgs = { 
+            tag: {
+              text: 'Incomplete'
+            }
+          } %}
         {% endif %}
+
+        {% set items = (items.push({
+          idPrefix: "order-section",
+          title: { text: name },
+          href: section.path,
+          status: statusArgs,
+          hint: hintArgs
+        }), items) %}
 
       {% endfor %}
 

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -68,12 +68,20 @@
 
         {% set statusArgs = statusArgs if isOrderEditable else {} %}
 
-        {% set items = (items.push({
-          idPrefix: "order-section",
-          title: { text: name },
-          href: section.path,
-          status: statusArgs
-        }), items) %}
+        {% if section.name == 'ADDITIONAL_DOCUMENTS' %}
+          {% set items = (items.push({
+            idPrefix: "order-section",
+            title: { text: name },
+            href: section.path
+          }), items) %}
+        {% else %}
+          {% set items = (items.push({
+            idPrefix: "order-section",
+            title: { text: name },
+            href: section.path,
+            status: statusArgs
+          }), items) %}
+        {% endif %}
 
       {% endfor %}
 

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -83,8 +83,7 @@
           idPrefix: "order-section",
           title: { text: name },
           href: section.path,
-          status: statusArgs,
-          hint: hintArgs
+          status: statusArgs
         }), items) %}
 
       {% endfor %}

--- a/server/views/pages/order/summary.njk
+++ b/server/views/pages/order/summary.njk
@@ -57,7 +57,6 @@
       {% set items = [] %}
       {% for section in sections %}
         {% set name = section.name | replace("_", " ") | capitalize %}
-        {% set hintArgs = {} %}
 
         {% if not isOrderEditable %}
           {% set statusArgs = {} %}
@@ -67,9 +66,6 @@
               text: 'Optional',
               classes: 'govuk-tag--green'
             }
-          } %}
-          {% set hintArgs = {
-            text: "Add all documents required for the order."
           } %}
         {% elif section.completed %}
           {% set statusArgs = { 


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3681

- Currently times are rendered in the UI as HH:mm:SS, eg. 14:30:00
- In the current design, seconds will never be relevant.
- To make times easier for users to interpret, they should instead be rendered in the format HH:mm, eg. 14:30.

### Changes proposed in this pull request
- Where times are rendered in the UI, use the format HH:mm.
