### PR TITLE
ELM-3681: Remove seconds from times displayed in the UI

### DIFF
--- a/server/controllers/monitoringConditions/checkAnswersController.test.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.test.ts
@@ -473,7 +473,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'What is the start time on the first day of monitoring?',
             },
             value: {
-              text: '01:01:00',
+              text: '01:01',
             },
             actions: {
               items: [
@@ -507,7 +507,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'What is the end time on the last day of monitoring? (optional)',
             },
             value: {
-              text: '01:01:00',
+              text: '01:01',
             },
             actions: {
               items: [
@@ -809,7 +809,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'Line 1, Line 2, Postcode',
             },
             value: {
-              html: 'Monday - 11:11:00-11:11:00<br/>Tuesday - 11:11:00-11:11:00<br/>Wednesday - 11:11:00-11:11:00<br/>Thursday - 11:11:00-11:11:00<br/>Friday - 11:11:00-11:11:00<br/>Saturday - 11:11:00-11:11:00<br/>Sunday - 11:11:00-11:11:00',
+              html: 'Monday - 11:11-11:11<br/>Tuesday - 11:11-11:11<br/>Wednesday - 11:11-11:11<br/>Thursday - 11:11-11:11<br/>Friday - 11:11-11:11<br/>Saturday - 11:11-11:11<br/>Sunday - 11:11-11:11',
             },
             actions: {
               items: [
@@ -826,7 +826,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'Line 1, Line 2, Postcode',
             },
             value: {
-              html: 'Monday - 11:11:00-11:11:00',
+              html: 'Monday - 11:11-11:11',
             },
             actions: {
               items: [
@@ -1139,7 +1139,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                 text: 'What time does the appointment start?',
               },
               value: {
-                text: '01:11:00',
+                text: '01:11',
               },
               actions: {
                 items: [
@@ -1159,7 +1159,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                 text: 'What time does the appointment end?',
               },
               value: {
-                text: '11:11:00',
+                text: '11:11',
               },
               actions: {
                 items: [

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -6,6 +6,7 @@ import {
   formatDateTime,
   isNullOrUndefined,
   lookup,
+  trimSeconds,
 } from '../../utils/utils'
 import { AddressType, AddressTypeEnum } from '../Address'
 import { CurfewSchedule, CurfewTimetable } from '../CurfewTimetable'
@@ -80,7 +81,7 @@ const createInstallationAddressAnswers = (order: Order, content: I18n) => {
 }
 
 const createSchedulePreview = (schedule: CurfewSchedule) =>
-  `${convertToTitleCase(schedule.dayOfWeek)} - ${schedule.startTime}-${schedule.endTime}`
+  `${convertToTitleCase(schedule.dayOfWeek)} - ${trimSeconds(schedule.startTime)}-${trimSeconds(schedule.endTime)}`
 
 const groupTimetableByAddress = (timetable: CurfewTimetable) =>
   timetable.reduce(
@@ -244,8 +245,8 @@ const createAttendanceAnswers = (order: Order, content: I18n) => {
       createDateAnswer(questions.endDate.text, attendance.endDate, uri, answerOpts),
       createAnswer(questions.purpose.text, attendance.purpose, uri, answerOpts),
       createAnswer(questions.appointmentDay.text, attendance.appointmentDay, uri, answerOpts),
-      createAnswer(questions.startTime.text, attendance.startTime, uri, answerOpts),
-      createAnswer(questions.endTime.text, attendance.endTime, uri, answerOpts),
+      createAnswer(questions.startTime.text, trimSeconds(attendance.startTime), uri, answerOpts),
+      createAnswer(questions.endTime.text, trimSeconds(attendance.endTime), uri, answerOpts),
       createAddressAnswer(
         questions.address.text,
         {

--- a/server/utils/checkYourAnswers.ts
+++ b/server/utils/checkYourAnswers.ts
@@ -1,4 +1,4 @@
-import { isNullOrUndefined, convertBooleanToEnum, createAddressPreview } from './utils'
+import { isNullOrUndefined, convertBooleanToEnum, createAddressPreview, trimSeconds } from './utils'
 import { AddressWithoutType } from '../models/Address'
 
 type Optional<T> = T | null | undefined
@@ -61,7 +61,7 @@ const createDatePreview = (value: Optional<string>) =>
   isNullOrUndefined(value) ? '' : new Date(value).toLocaleDateString('en-GB')
 
 const createTimePreview = (value: Optional<string>) =>
-  isNullOrUndefined(value) ? '' : new Date(value).toLocaleTimeString('en-GB')
+  isNullOrUndefined(value) ? '' : trimSeconds(new Date(value).toLocaleTimeString('en-GB'))
 
 export const createDateAnswer = (key: string, value: Optional<string>, uri: string, opts: AnswerOptions = {}): Answer =>
   createAnswer(key, createDatePreview(value), uri, opts)

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -89,6 +89,13 @@ export const deserialiseTime = (timeString?: string | null): [hours: string, min
   return [timeMatch[1], timeMatch[2]]
 }
 
+export const trimSeconds = (timeString?: string | null): string => {
+  if (!timeString || isBlank(timeString)) {
+    return ''
+  }
+  return timeString.split(':').slice(0, 2).join(':')
+}
+
 export const getError = (validationErrors: ValidationResult, field: string): ErrorMessage | undefined => {
   const matchedError = validationErrors.find(e => e.field === field)
 


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3681

- Currently times are rendered in the UI as HH:mm:SS, eg. 14:30:00
- In the current design, seconds will never be relevant.
- To make times easier for users to interpret, they should instead be rendered in the format HH:mm, eg. 14:30.

### Changes proposed in this pull request

- Render times in the format HH:mm.
