### PR TITLE
ELM-3682: Check your answers (failed to submit tidy up)

### DIFF
--- a/integration_tests/e2e/index.cy.ts
+++ b/integration_tests/e2e/index.cy.ts
@@ -29,9 +29,10 @@ context('Index', () => {
       page.newVariationFormButton.should('exist')
 
       // Order list
-      page.orders.should('exist').should('have.length', 2)
+      page.orders.should('exist').should('have.length', 3)
       page.SubmittedOrderFor('New form').should('exist')
       page.DraftOrderFor('test tester').should('exist')
+      page.FailedOrderFor('Failed request').should('exist')
 
       // A11y
       page.checkIsAccessible()

--- a/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/check-your-answers.cy.ts
@@ -435,6 +435,108 @@ context('Device wearer - check your answers', () => {
     })
   })
 
+  context('Application failed to submit', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'ERROR',
+        order: {
+          deviceWearer: {
+            nomisId: 'nomis',
+            pncId: 'pnc',
+            deliusId: 'delius',
+            prisonNumber: 'prison',
+            homeOfficeReferenceNumber: 'ho',
+            firstName: 'test',
+            lastName: 'tester',
+            alias: 'tes',
+            dateOfBirth: '2000-01-01T00:00:00Z',
+            adultAtTimeOfInstallation: true,
+            sex: 'MALE',
+            gender: 'MALE',
+            disabilities: 'MENTAL_HEALTH',
+            otherDisability: null,
+            noFixedAbode: null,
+            interpreterRequired: false,
+          },
+          DeviceWearerResponsibleAdult: null,
+        },
+      })
+
+      cy.signIn()
+    })
+
+    const pageHeading = 'View answers'
+
+    it('shows correct banner', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.submittedBanner.contains(
+        'This form failed to submit. This was due to a technical problem. For more information ',
+      )
+      page.submittedBanner.contains('a', 'view the guidance (opens in a new tab)')
+    })
+
+    it('shows correct caption and heading', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.checkOnPage()
+    })
+
+    it('shows answers for checking', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.personDetailsSection.shouldExist()
+      page.personDetailsSection.shouldHaveItems([
+        { key: "What is the device wearer's first name?", value: 'test' },
+        { key: "What is the device wearer's last name?", value: 'tester' },
+        { key: "What is the device wearer's preferred name or names? (optional)", value: 'tes' },
+        { key: "What is the device wearer's date of birth?", value: '01/01/2000' },
+        { key: 'Is a responsible adult required?', value: 'No' },
+        { key: 'What is the sex of the device wearer?', value: 'Male' },
+        { key: "What is the device wearer's gender?", value: 'Male' },
+        {
+          key: 'Does the device wearer have any of the disabilities or health conditions listed? (optional)',
+          value: 'Mental health',
+        },
+        { key: 'What language does the interpreter need to use? (optional)', value: '' },
+        { key: 'Is an interpreter needed?', value: 'No' },
+      ])
+      page.personDetailsSection.shouldNotHaveItems([
+        "What is the device wearer's disability or health condition?",
+        "What is the device wearer's chosen identity?",
+      ])
+      page.identityNumbersSection.shouldExist()
+      page.identityNumbersSection.shouldHaveItems([
+        { key: 'National Offender Management Information System (NOMIS) ID (optional)', value: 'nomis' },
+        { key: 'Police National Computer (PNC) ID (optional)', value: 'pnc' },
+        { key: 'Delius ID (optional)', value: 'delius' },
+        { key: 'Prison number (optional)', value: 'prison' },
+        { key: 'Home Office Reference Number (optional)', value: 'ho' },
+      ])
+      page.responsibleAdultSection.shouldNotExist()
+    })
+
+    it('does not show "change" links', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.changeLinks.should('not.exist')
+    })
+
+    it('shows correct buttons', () => {
+      const page = Page.visit(CheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.continueButton().should('exist')
+      page.continueButton().contains('Go to next section')
+      page.returnButton().should('exist')
+      page.returnButton().contains('Return to main form menu')
+    })
+  })
+
   context('Unhealthy backend', () => {
     beforeEach(() => {
       cy.task('reset')

--- a/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.cy.ts
@@ -172,4 +172,76 @@ context('installation and risk - check your answers', () => {
       page.returnButton().contains('Return to main form menu')
     })
   })
+
+  context('risk information check answers page failed to submit', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'ERROR',
+        order: {
+          installationAndRisk: {
+            offence: 'SEXUAL_OFFENCES',
+            riskCategory: ['RISK_TO_GENDER'],
+            riskDetails: 'some risk details',
+            mappaLevel: 'MAPPA 1',
+            mappaCaseType: 'SOC (Serious Organised Crime)',
+          },
+          fmsResultDate: new Date('2024 12 14'),
+        },
+      })
+      cy.signIn()
+    })
+
+    const pageHeading = 'View answers'
+
+    it('shows correct banner', () => {
+      const page = Page.visit(InstallationAndRiskCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.submittedBanner.contains(
+        'This form failed to submit. This was due to a technical problem. For more information ',
+      )
+      page.submittedBanner.contains('a', 'view the guidance (opens in a new tab)')
+    })
+
+    it('shows correct caption and heading', () => {
+      const page = Page.visit(InstallationAndRiskCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.checkOnPage()
+    })
+
+    it('shows answers for checking', () => {
+      const page = Page.visit(InstallationAndRiskCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.installationRiskSection.shouldExist()
+      page.installationRiskSection.shouldHaveItems([
+        { key: 'What type of offence did the device wearer commit? (optional)', value: 'Sexual offences' },
+        {
+          key: 'At installation what are the possible risks? (optional)',
+          value: 'Offensive towards someone because of their sex or gender',
+        },
+        { key: 'Any other risks to be aware of? (optional)', value: 'some risk details' },
+        { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
+        { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
+      ])
+    })
+
+    it('does not show "change" links', () => {
+      const page = Page.visit(InstallationAndRiskCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.changeLinks.should('not.exist')
+    })
+
+    it('shows correct buttons', () => {
+      const page = Page.visit(InstallationAndRiskCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.continueButton().should('exist')
+      page.continueButton().contains('Go to next section')
+      page.returnButton().should('exist')
+      page.returnButton().contains('Return to main form menu')
+    })
+  })
 })

--- a/integration_tests/e2e/order/attachments/index.page.failed.cy.ts
+++ b/integration_tests/e2e/order/attachments/index.page.failed.cy.ts
@@ -1,0 +1,61 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import Page from '../../../pages/page'
+import AttachmentSummaryPage from '../../../pages/order/attachments/summary'
+
+const mockOrderId = uuidv4()
+
+context('Attachments', () => {
+  context('Summary', () => {
+    context('Viewing a submitted order', () => {
+      beforeEach(() => {
+        cy.task('reset')
+        cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+        cy.task('stubCemoListOrders')
+        cy.task('stubCemoGetOrderWithAttachments', {
+          httpStatus: 200,
+          id: mockOrderId,
+          status: 'ERROR',
+          attachments: [
+            { id: uuidv4(), orderId: mockOrderId, fileName: 'Licence.jpeg', fileType: 'LICENCE' },
+            { id: uuidv4(), orderId: mockOrderId, fileName: 'photo.jpeg', fileType: 'PHOTO_ID' },
+          ],
+        })
+        cy.signIn()
+      })
+
+      it('Should render summary page with no download links and no delete links', () => {
+        const page = Page.visit(AttachmentSummaryPage, { orderId: mockOrderId })
+
+        // Header
+        page.header.userName().should('contain.text', 'J. Smith')
+        page.header.phaseBanner().should('contain.text', 'dev')
+        page.submittedBanner.contains(
+          'This form failed to submit. This was due to a technical problem. For more information ',
+        )
+        page.submittedBanner.contains('a', 'view the guidance (opens in a new tab)')
+        // Licence Task
+        page.licenceTask.status.should('contain', 'Licence.jpeg')
+        page.licenceTask.addAction.should('not.exist')
+        page.licenceTask.changeAction.should('not.exist')
+        page.licenceTask.deleteAction.should('not.exist')
+        page.licenceTask.downloadAction
+          .should('exist')
+          .should('have.attr', 'href', `/order/${mockOrderId}/attachments/licence/Licence.jpeg`)
+
+        // Photo ID Task
+        page.photoIdTask.status.should('contain', 'photo.jpeg')
+        page.photoIdTask.addAction.should('not.exist')
+        page.photoIdTask.changeAction.should('not.exist')
+        page.photoIdTask.deleteAction.should('not.exist')
+        page.photoIdTask.downloadAction
+          .should('exist')
+          .should('have.attr', 'href', `/order/${mockOrderId}/attachments/photo_Id/photo.jpeg`)
+
+        // Buttons
+        page.saveAndReturnButton.should('not.exist')
+        page.backToSummaryButton.should('exist')
+      })
+    })
+  })
+})

--- a/integration_tests/e2e/order/contact-information/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/contact-information/check-your-answers.cy.ts
@@ -686,6 +686,118 @@ context('Contact Information - check your answers', () => {
     })
   })
 
+  context('Application failed to submit', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+      cy.signIn()
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'ERROR',
+        order: {
+          contactDetails: {
+            contactNumber: '01234567890',
+          },
+          deviceWearer: {
+            nomisId: null,
+            pncId: null,
+            deliusId: null,
+            prisonNumber: null,
+            homeOfficeReferenceNumber: null,
+            firstName: null,
+            lastName: null,
+            alias: null,
+            adultAtTimeOfInstallation: null,
+            sex: null,
+            gender: null,
+            dateOfBirth: null,
+            disabilities: null,
+            noFixedAbode: true,
+            interpreterRequired: null,
+          },
+          interestedParties: {
+            notifyingOrganisation: 'HOME_OFFICE',
+            notifyingOrganisationName: '',
+            notifyingOrganisationEmail: 'notifying@organisation',
+            responsibleOrganisation: 'POLICE',
+            responsibleOrganisationEmail: 'responsible@organisation',
+            responsibleOrganisationRegion: '',
+            responsibleOfficerName: 'name',
+            responsibleOfficerPhoneNumber: '01234567891',
+          },
+        },
+      })
+    })
+
+    const pageHeading = 'View answers'
+
+    it('shows correct banner', () => {
+      const page = Page.visit(ContactInformationCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.submittedBanner.contains(
+        'This form failed to submit. This was due to a technical problem. For more information ',
+      )
+      page.submittedBanner.contains('a', 'view the guidance (opens in a new tab)')
+    })
+
+    it('shows contact information caption', () => {
+      const page = Page.visit(ContactInformationCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.checkOnPage()
+    })
+
+    it('displays the correct answers for checking', () => {
+      const page = Page.visit(ContactInformationCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+      page.contactDetailsSection.shouldExist()
+      page.contactDetailsSection.shouldHaveItems([
+        { key: "What is the device wearer's telephone number? (optional)", value: '01234567890' },
+      ])
+
+      page.deviceWearerAddressesSection.shouldExist()
+      page.deviceWearerAddressesSection.shouldHaveItems([
+        { key: 'Does the device wearer have a fixed address?', value: 'No' },
+      ])
+
+      page.deviceWearerAddressesSection.shouldNotHaveItems([
+        "What is the device wearer's main address?",
+        "What is the device wearer's second address?",
+        "What is the device wearer's third address?",
+      ])
+      page.organisationDetailsSection.shouldExist()
+      page.organisationDetailsSection.shouldHaveItems([
+        { key: 'What organisation or related organisation are you part of?', value: 'Home Office' },
+        { key: "What is your team's contact email address?", value: 'notifying@organisation' },
+        { key: "What is the Responsible Officer's full name?", value: 'name' },
+        { key: "What is the Responsible Officer's telephone number?", value: '01234567891' },
+        { key: "What is the Responsible Officer's organisation?", value: 'Police' },
+        { key: "What is the Responsible Organisation's email address? (optional)", value: 'responsible@organisation' },
+      ])
+      page.deviceWearerAddressesSection.shouldNotHaveItems([
+        'Select the name of the Crown Court',
+        'Select the name of the Court',
+        'Select the name of the Prison',
+        'Select the Probation region',
+        'Select the Youth Justice Service region',
+      ])
+    })
+    it('does not show "change" links', () => {
+      const page = Page.visit(ContactInformationCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.changeLinks.should('not.exist')
+    })
+
+    it('shows correct buttons', () => {
+      const page = Page.visit(ContactInformationCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.continueButton().should('exist')
+      page.continueButton().contains('Go to next section')
+      page.returnButton().should('exist')
+      page.returnButton().contains('Return to main form menu')
+    })
+  })
+
   context('Unhealthy backend', () => {
     beforeEach(() => {
       cy.task('reset')

--- a/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
@@ -134,4 +134,81 @@ context('Check your answers', () => {
       page.returnButton().contains('Return to main form menu')
     })
   })
+
+  context('Application status is error', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+      cy.signIn()
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'ERROR',
+        order: {
+          monitoringConditions: {
+            startDate: '2025-01-01T00:00:00Z',
+            endDate: '2025-02-01T00:00:00Z',
+            orderType: 'CIVIL',
+            curfew: true,
+            exclusionZone: true,
+            trail: true,
+            mandatoryAttendance: true,
+            alcohol: true,
+            conditionType: 'BAIL_ORDER',
+            orderTypeDescription: 'DAPO',
+            sentenceType: 'IPP',
+            issp: 'YES',
+            hdc: 'NO',
+            prarr: 'UNKNOWN',
+          },
+          fmsResultDate: new Date('2024 12 14'),
+        },
+      })
+    })
+
+    const pageHeading = 'View answers'
+
+    it('shows correct banner', () => {
+      const page = Page.visit(CheckYourAnswers, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.submittedBanner.contains(
+        'This form failed to submit. This was due to a technical problem. For more information ',
+      )
+      page.submittedBanner.contains('a', 'view the guidance (opens in a new tab)')
+    })
+
+    it('shows correct caption and heading', () => {
+      const page = Page.visit(CheckYourAnswers, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.checkOnPage()
+    })
+
+    it('shows answers for checking', () => {
+      const page = Page.visit(CheckYourAnswers, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.monitoringConditionsSection().should('exist')
+      page.installationAddressSection().should('exist')
+      page.curfewOnDayOfReleaseSection().should('exist')
+      page.curfewSection().should('exist')
+      page.curfewTimetableSection().should('exist')
+      page.trailMonitoringConditionsSection().should('exist')
+      page.alcoholMonitoringConditionsSection().should('exist')
+    })
+
+    it('does not show "change" links', () => {
+      const page = Page.visit(CheckYourAnswers, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.changeLinks.should('not.exist')
+    })
+
+    it('shows correct buttons', () => {
+      const page = Page.visit(CheckYourAnswers, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.continueButton().should('exist')
+      page.continueButton().contains('Go to next section')
+      page.returnButton().should('exist')
+      page.returnButton().contains('Return to main form menu')
+    })
+  })
 })

--- a/integration_tests/mockApis/cemo.ts
+++ b/integration_tests/mockApis/cemo.ts
@@ -104,6 +104,27 @@ const defaultListOrdersOptions: ListOrdersStubOptions = {
         interpreterRequired: null,
       },
     },
+    {
+      ...mockApiOrder(),
+      deviceWearer: {
+        nomisId: null,
+        pncId: null,
+        deliusId: null,
+        prisonNumber: null,
+        homeOfficeReferenceNumber: null,
+        firstName: 'Failed',
+        lastName: 'request',
+        alias: null,
+        dateOfBirth: null,
+        adultAtTimeOfInstallation: null,
+        sex: null,
+        gender: null,
+        disabilities: null,
+        noFixedAbode: null,
+        interpreterRequired: null,
+      },
+      status: 'ERROR',
+    },
   ],
 }
 

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -44,4 +44,8 @@ export default class IndexPage extends AppPage {
   DraftOrderFor(name: string): PageElement {
     return this.ordersList.contains('li', `${name} Draft`)
   }
+
+  FailedOrderFor(name: string): PageElement {
+    return this.ordersList.contains('li', `${name} Failed to submit`)
+  }
 }

--- a/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.ts
@@ -26,7 +26,7 @@ export default class DeviceWearerCheckAnswersController {
     const { action } = CheckYourAnswersFormModel.parse(req.body)
 
     if (action === 'continue') {
-      if (order.status === 'SUBMITTED') {
+      if (order.status === 'SUBMITTED' || order.status === 'ERROR') {
         res.redirect(this.taskListService.getNextCheckYourAnswersPage('CHECK_ANSWERS_DEVICE_WEARER', order))
       } else {
         res.redirect(this.taskListService.getNextPage('CHECK_ANSWERS_DEVICE_WEARER', order))

--- a/server/controllers/contact-information/checkAnswersController.ts
+++ b/server/controllers/contact-information/checkAnswersController.ts
@@ -25,7 +25,7 @@ export default class CheckAnswersController {
     const { action } = CheckYourAnswersFormModel.parse(req.body)
 
     if (action === 'continue') {
-      if (order.status === 'SUBMITTED') {
+      if (order.status === 'SUBMITTED' || order.status === 'ERROR') {
         res.redirect(this.taskListService.getNextCheckYourAnswersPage('CHECK_ANSWERS_CONTACT_INFORMATION', order))
       } else {
         res.redirect(this.taskListService.getNextPage('CHECK_ANSWERS_CONTACT_INFORMATION', order))

--- a/server/controllers/installationAndRisk/installationAndRiskCheckAnswersController.ts
+++ b/server/controllers/installationAndRisk/installationAndRiskCheckAnswersController.ts
@@ -27,7 +27,7 @@ export default class CheckAnswersController {
     const { action } = CheckYourAnswersFormModel.parse(req.body)
 
     if (action === 'continue') {
-      if (order.status === 'SUBMITTED') {
+      if (order.status === 'SUBMITTED' || order.status === 'ERROR') {
         res.redirect(this.taskListService.getNextCheckYourAnswersPage('CHECK_ANSWERS_INSTALLATION_AND_RISK', order))
       } else {
         res.redirect(this.taskListService.getNextPage('CHECK_ANSWERS_INSTALLATION_AND_RISK', order))

--- a/server/controllers/monitoringConditions/checkAnswersController.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.ts
@@ -26,7 +26,7 @@ export default class CheckAnswersController {
     const { action } = CheckYourAnswersFormModel.parse(req.body)
 
     if (action === 'continue') {
-      if (order.status === 'SUBMITTED') {
+      if (order.status === 'SUBMITTED' || order.status === 'ERROR') {
         res.redirect(this.taskListService.getNextCheckYourAnswersPage('CHECK_ANSWERS_MONITORING_CONDITIONS', order))
       } else {
         res.redirect(this.taskListService.getNextPage('CHECK_ANSWERS_MONITORING_CONDITIONS', order))

--- a/server/middleware/populateCurrentOrder.ts
+++ b/server/middleware/populateCurrentOrder.ts
@@ -13,6 +13,7 @@ const populateOrder =
 
       req.order = order
       res.locals.orderId = order.id
+      res.locals.orderStatus = order.status
       res.locals.isOrderEditable = order.status === OrderStatusEnum.Enum.IN_PROGRESS
       res.locals.orderSummaryUri = paths.ORDER.SUMMARY.replace(':orderId', order.id)
 

--- a/server/models/view-models/additionalDocumentsCheckAnswers.ts
+++ b/server/models/view-models/additionalDocumentsCheckAnswers.ts
@@ -6,7 +6,7 @@ import AttachmentType from '../AttachmentType'
 const createViewModel = (order: Order) => {
   const licence = order.additionalDocuments.find(x => x.fileType === AttachmentType.LICENCE)
   const photo = order.additionalDocuments.find(x => x.fileType === AttachmentType.PHOTO_ID)
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   const answers = [
     createAnswer('Licence', licence?.fileName ?? 'No licence document uploaded', '', answerOpts),
     createAnswer('Photo identification (optional)', photo?.fileName ?? 'No photo ID document uploaded', '', answerOpts),

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -17,6 +17,7 @@ import {
   createMultipleAddressAnswer,
   createMultipleChoiceAnswer,
   createAnswer,
+  AnswerOptions,
 } from '../../utils/checkYourAnswers'
 import sentenceTypes from '../../reference/sentence-types'
 import yesNoUnknown from '../../reference/yes-no-unknown'
@@ -32,7 +33,7 @@ const getSelectedMonitoringTypes = (order: Order) => {
   ].filter(val => val !== '')
 }
 
-const createMonitoringConditionsAnswers = (order: Order, content: I18n) => {
+const createMonitoringConditionsAnswers = (order: Order, content: I18n, answerOpts: AnswerOptions) => {
   const uri = paths.MONITORING_CONDITIONS.BASE_URL.replace(':orderId', order.id)
   const conditionType = lookup(content.reference.conditionTypes, order.monitoringConditions.conditionType)
   const orderType = lookup(content.reference.orderTypes, order.monitoringConditions.orderType)
@@ -46,7 +47,6 @@ const createMonitoringConditionsAnswers = (order: Order, content: I18n) => {
   const prarr = lookup(yesNoUnknown, order.monitoringConditions.prarr)
   const { questions } = content.pages.monitoringConditions
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
   return [
     createDateAnswer(questions.startDate.text, order.monitoringConditions.startDate, uri, answerOpts),
     createTimeAnswer(questions.startTime.text, order.monitoringConditions.startDate, uri, answerOpts),
@@ -63,7 +63,7 @@ const createMonitoringConditionsAnswers = (order: Order, content: I18n) => {
   ]
 }
 
-const createInstallationAddressAnswers = (order: Order, content: I18n) => {
+const createInstallationAddressAnswers = (order: Order, content: I18n, answerOpts: AnswerOptions) => {
   const uri = paths.MONITORING_CONDITIONS.INSTALLATION_ADDRESS.replace(':orderId', order.id).replace(
     ':addressType(installation)',
     'installation',
@@ -72,11 +72,7 @@ const createInstallationAddressAnswers = (order: Order, content: I18n) => {
     ({ addressType }) => addressType === AddressTypeEnum.Enum.INSTALLATION,
   )
 
-  return [
-    createAddressAnswer(content.pages.installationAddress.legend, installationAddress, uri, {
-      ignoreActions: order.status === 'SUBMITTED',
-    }),
-  ]
+  return [createAddressAnswer(content.pages.installationAddress.legend, installationAddress, uri, answerOpts)]
 }
 
 const createSchedulePreview = (schedule: CurfewSchedule) =>
@@ -103,7 +99,7 @@ const groupTimetableByAddress = (timetable: CurfewTimetable) =>
     } as Record<Partial<AddressType>, Array<CurfewSchedule>>,
   )
 
-const createCurfewTimetableAnswers = (order: Order) => {
+const createCurfewTimetableAnswers = (order: Order, answerOpts: AnswerOptions) => {
   const timetable = order.curfewTimeTable
   const uri = paths.MONITORING_CONDITIONS.CURFEW_TIMETABLE.replace(':orderId', order.id)
 
@@ -126,13 +122,11 @@ const createCurfewTimetableAnswers = (order: Order) => {
         ? `${convertToTitleCase(group)} address`
         : createAddressPreview(address)
 
-      return createMultipleChoiceAnswer(preview, groups[group].map(createSchedulePreview), uri, {
-        ignoreActions: order.status === 'SUBMITTED',
-      })
+      return createMultipleChoiceAnswer(preview, groups[group].map(createSchedulePreview), uri, answerOpts)
     })
 }
 
-const createCurfewReleaseDateAnswers = (order: Order, content: I18n) => {
+const createCurfewReleaseDateAnswers = (order: Order, content: I18n, answerOpts: AnswerOptions) => {
   const releaseDateUri = paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE.replace(':orderId', order.id)
   const { questions } = content.pages.curfewReleaseDate
 
@@ -140,7 +134,6 @@ const createCurfewReleaseDateAnswers = (order: Order, content: I18n) => {
     return []
   }
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
   return [
     createDateAnswer(
       questions.releaseDate.text,
@@ -164,7 +157,7 @@ const createCurfewReleaseDateAnswers = (order: Order, content: I18n) => {
   ]
 }
 
-const createCurfewAnswers = (order: Order, content: I18n) => {
+const createCurfewAnswers = (order: Order, content: I18n, answerOpts: AnswerOptions) => {
   const conditionsUri = paths.MONITORING_CONDITIONS.CURFEW_CONDITIONS.replace(':orderId', order.id)
   const { questions } = content.pages.curfewConditions
 
@@ -172,7 +165,6 @@ const createCurfewAnswers = (order: Order, content: I18n) => {
     return []
   }
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
   return [
     createDateAnswer(questions.startDate.text, order.curfewConditions?.startDate, conditionsUri, answerOpts),
     createDateAnswer(questions.endDate.text, order.curfewConditions?.endDate, conditionsUri, answerOpts),
@@ -185,7 +177,7 @@ const createCurfewAnswers = (order: Order, content: I18n) => {
   ]
 }
 
-const createExclusionZoneAnswers = (order: Order, content: I18n) => {
+const createExclusionZoneAnswers = (order: Order, content: I18n, answerOpts: AnswerOptions) => {
   const uri = paths.MONITORING_CONDITIONS.ZONE.replace(':orderId', order.id)
   const { questions } = content.pages.exclusionZone
 
@@ -199,8 +191,6 @@ const createExclusionZoneAnswers = (order: Order, content: I18n) => {
       const fileName = enforcementZone.fileName || 'No file selected'
       const zoneId = enforcementZone.zoneId || 0
       const zoneUri = uri ? uri.replace(':zoneId', zoneId.toString()) : ''
-
-      const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
       return [
         createDateAnswer(questions.startDate.text, enforcementZone.startDate, zoneUri, answerOpts),
         createDateAnswer(questions.endDate.text, enforcementZone.endDate, zoneUri, answerOpts),
@@ -211,7 +201,7 @@ const createExclusionZoneAnswers = (order: Order, content: I18n) => {
     })
 }
 
-const createTrailAnswers = (order: Order, content: I18n) => {
+const createTrailAnswers = (order: Order, content: I18n, answerOpts: AnswerOptions) => {
   const uri = paths.MONITORING_CONDITIONS.TRAIL.replace(':orderId', order.id)
   const { questions } = content.pages.trailMonitoring
 
@@ -219,14 +209,13 @@ const createTrailAnswers = (order: Order, content: I18n) => {
     return []
   }
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
   return [
     createDateAnswer(questions.startDate.text, order.monitoringConditionsTrail?.startDate, uri, answerOpts),
     createDateAnswer(questions.endDate.text, order.monitoringConditionsTrail?.endDate, uri, answerOpts),
   ]
 }
 
-const createAttendanceAnswers = (order: Order, content: I18n) => {
+const createAttendanceAnswers = (order: Order, content: I18n, answerOpts: AnswerOptions) => {
   if (!order.mandatoryAttendanceConditions) {
     return []
   }
@@ -238,7 +227,6 @@ const createAttendanceAnswers = (order: Order, content: I18n) => {
     )
     const { questions } = content.pages.attendance
 
-    const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
     return [
       createDateAnswer(questions.startDate.text, attendance.startDate, uri, answerOpts),
       createDateAnswer(questions.endDate.text, attendance.endDate, uri, answerOpts),
@@ -262,7 +250,7 @@ const createAttendanceAnswers = (order: Order, content: I18n) => {
   })
 }
 
-const createAlcoholAnswers = (order: Order, content: I18n) => {
+const createAlcoholAnswers = (order: Order, content: I18n, answerOpts: AnswerOptions) => {
   const uri = paths.MONITORING_CONDITIONS.ALCOHOL.replace(':orderId', order.id)
   const monitoringType = lookup(
     content.reference.alcoholMonitoringTypes,
@@ -273,8 +261,6 @@ const createAlcoholAnswers = (order: Order, content: I18n) => {
   if (!order.monitoringConditions.alcohol) {
     return []
   }
-
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
   return [
     createAnswer(questions.monitoringType.text, monitoringType, uri, answerOpts),
     createDateAnswer(questions.startDate.text, order.monitoringConditionsAlcohol?.startDate, uri, answerOpts),
@@ -300,16 +286,19 @@ const createAlcoholAnswers = (order: Order, content: I18n) => {
 }
 
 const createViewModel = (order: Order, content: I18n) => {
+  const ignoreActions = {
+    ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR',
+  }
   return {
-    monitoringConditions: createMonitoringConditionsAnswers(order, content),
-    installationAddress: createInstallationAddressAnswers(order, content),
-    curfew: createCurfewAnswers(order, content),
-    curfewReleaseDate: createCurfewReleaseDateAnswers(order, content),
-    curfewTimetable: createCurfewTimetableAnswers(order),
-    exclusionZone: createExclusionZoneAnswers(order, content),
-    trail: createTrailAnswers(order, content),
-    attendance: createAttendanceAnswers(order, content),
-    alcohol: createAlcoholAnswers(order, content),
+    monitoringConditions: createMonitoringConditionsAnswers(order, content, ignoreActions),
+    installationAddress: createInstallationAddressAnswers(order, content, ignoreActions),
+    curfew: createCurfewAnswers(order, content, ignoreActions),
+    curfewReleaseDate: createCurfewReleaseDateAnswers(order, content, ignoreActions),
+    curfewTimetable: createCurfewTimetableAnswers(order, ignoreActions),
+    exclusionZone: createExclusionZoneAnswers(order, content, ignoreActions),
+    trail: createTrailAnswers(order, content, ignoreActions),
+    attendance: createAttendanceAnswers(order, content, ignoreActions),
+    alcohol: createAlcoholAnswers(order, content, ignoreActions),
     submittedDate: order.fmsResultDate ? formatDateTime(order.fmsResultDate) : undefined,
   }
 }

--- a/server/models/view-models/riskInformationCheckAnswers.ts
+++ b/server/models/view-models/riskInformationCheckAnswers.ts
@@ -8,7 +8,7 @@ import config from '../../config'
 const createViewModel = (order: Order, content: I18n, uri: string = '') => {
   const { questions } = content.pages.installationAndRisk
 
-  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' }
+  const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   const answers = [
     createAnswer(
       questions.offence.text,

--- a/server/utils/checkYourAnswers.ts
+++ b/server/utils/checkYourAnswers.ts
@@ -24,7 +24,7 @@ type Answer = {
 
 export default Answer
 
-interface AnswerOptions {
+export interface AnswerOptions {
   ignoreActions?: boolean
   valueType?: 'html' | 'text'
 }

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -125,6 +125,10 @@
               <strong class="govuk-tag govuk-tag--green">
                 Submitted
               </strong>
+            {% elif order.status == 'ERROR' %}
+              <strong class="govuk-tag govuk-tag--red">
+                Failed to submit
+              </strong>            
             {% else %}
               <strong class="govuk-tag govuk-tag--grey">
                 Draft

--- a/server/views/pages/order/attachments/view.njk
+++ b/server/views/pages/order/attachments/view.njk
@@ -14,10 +14,22 @@
     href: "/order/" + order.id + "/summary"
   }) }}
 
-  {% if order.status == "SUBMITTED" %}
+  {% if order.status === "SUBMITTED" %}
     {% set html %}
       <p class="govuk-notification-banner__heading">
         You are viewing a submitted order.
+      </p>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+      html: html
+    }) }}
+  {% endif %}
+
+   {% if order.status === "ERROR" %}
+    {% set html %}
+      <p class="govuk-notification-banner__heading">
+         This form failed to submit. This was due to a technical problem. For more information <a href="https://ministryofjustice.github.io/hmpps-electronic-monitoring-create-an-order-docs/index.html">view the guidance (opens in a new tab)</a> .
       </p>
     {% endset %}
 

--- a/server/views/partials/check-your-answers-layout.njk
+++ b/server/views/partials/check-your-answers-layout.njk
@@ -22,7 +22,11 @@
 	{% set submittedDate = submittedDate %}
         {% set html %}
           <p class="govuk-notification-banner__heading">
-            You are viewing a submitted form. This form was submitted on the {{ submittedDate }}.
+            {% if orderStatus === 'ERROR' %}
+              This form failed to submit. This was due to a technical problem. For more information <a href="https://ministryofjustice.github.io/hmpps-electronic-monitoring-create-an-order-docs/index.html">view the guidance (opens in a new tab)</a> .
+            {% else %}
+              You are viewing a submitted form. This form was submitted on the {{ submittedDate }}.
+            {% endif %}           
           </p>
         {% endset %}
 

--- a/server/views/partials/form-layout.njk
+++ b/server/views/partials/form-layout.njk
@@ -24,7 +24,11 @@
       {% if not isOrderEditable %}
         {% set html %}
           <p class="govuk-notification-banner__heading">
-            You are viewing a submitted order.
+            {% if orderStatus === 'ERROR' %}
+              This form failed to submit. This was due to a technical problem. For more information <a href="https://ministryofjustice.github.io/hmpps-electronic-monitoring-create-an-order-docs/index.html">view the guidance (opens in a new tab)</a> .
+            {% else %}
+              You are viewing a submitted order.
+            {% endif %}
           </p>
         {% endset %}
 


### PR DESCRIPTION
Context
Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/1659?selectedIssue=ELM-3682

- Failed to submit orders has status of Draft in index page

- Check your answers pages and section page show order submitted banner for orders failed to submit

- Check your answers pages show change link for failed to submit orders,

Changes proposed in this pull request
Added Failed to submit status in index page to indicate a request failed to submit
![image](https://github.com/user-attachments/assets/1c39a755-1136-4353-b062-eda6c3915c7d)

Added form failed to submit banner in check your answers pages if order failed to submit
![image](https://github.com/user-attachments/assets/03a42b62-d2ab-4c57-8eee-83d880fe85b8)

Removed change link in check your answers pages if order failed to submit
![image](https://github.com/user-attachments/assets/462ca050-acfe-4e2b-a85e-5fac2820bce9)

Added form failed to submit banner in section page
![image](https://github.com/user-attachments/assets/a858178b-0ee9-4ea4-b7cd-a4daec09bfe0)


