### PR TITLE
ELM-3720: Curfew release day times shown as invalid date in CYA page

### DIFF
--- a/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
@@ -31,6 +31,12 @@ context('Check your answers', () => {
             hdc: 'NO',
             prarr: 'UNKNOWN',
           },
+          curfewReleaseDateConditions: {
+            curfewAddress: '',
+            releaseDate: '2025-05-11',
+            startTime: '19:00:00',
+            endTime: '07:00:00',
+          },
         },
       })
 
@@ -44,7 +50,12 @@ context('Check your answers', () => {
 
       page.monitoringConditionsSection().should('exist')
       page.installationAddressSection().should('exist')
-      page.curfewOnDayOfReleaseSection().should('exist')
+      page.curfewOnDayOfReleaseSection.shouldExist()
+      page.curfewOnDayOfReleaseSection.shouldHaveItems([
+        { key: 'What date is the device wearer released from custody?', value: '11/05/2025' },
+        { key: 'On the day of release, what time does the curfew start?', value: '19:00' },
+        { key: 'On the day of release, what time does the curfew end?', value: '07:00' },
+      ])
       page.curfewSection().should('exist')
       page.curfewTimetableSection().should('exist')
       page.trailMonitoringConditionsSection().should('exist')
@@ -112,7 +123,7 @@ context('Check your answers', () => {
 
       page.monitoringConditionsSection().should('exist')
       page.installationAddressSection().should('exist')
-      page.curfewOnDayOfReleaseSection().should('exist')
+      page.curfewOnDayOfReleaseSection.shouldExist()
       page.curfewSection().should('exist')
       page.curfewTimetableSection().should('exist')
       page.trailMonitoringConditionsSection().should('exist')
@@ -189,7 +200,7 @@ context('Check your answers', () => {
 
       page.monitoringConditionsSection().should('exist')
       page.installationAddressSection().should('exist')
-      page.curfewOnDayOfReleaseSection().should('exist')
+      page.curfewOnDayOfReleaseSection.shouldExist()
       page.curfewSection().should('exist')
       page.curfewTimetableSection().should('exist')
       page.trailMonitoringConditionsSection().should('exist')

--- a/integration_tests/pages/order/monitoring-conditions/check-your-answers.ts
+++ b/integration_tests/pages/order/monitoring-conditions/check-your-answers.ts
@@ -1,6 +1,7 @@
 import paths from '../../../../server/constants/paths'
 import { PageElement } from '../../page'
 import CheckYourAnswersPage from '../../checkYourAnswersPage'
+import SummaryListComponent from '../../components/summaryListComponent'
 
 export default class MonitoringConditionsCheckYourAnswersPage extends CheckYourAnswersPage {
   constructor(heading: string) {
@@ -11,7 +12,10 @@ export default class MonitoringConditionsCheckYourAnswersPage extends CheckYourA
 
   installationAddressSection = (): PageElement => cy.contains('Installation address')
 
-  curfewOnDayOfReleaseSection = (): PageElement => cy.contains('Curfew on day of release')
+  get curfewOnDayOfReleaseSection(): SummaryListComponent {
+    const label = 'Curfew on day of release'
+    return new SummaryListComponent(label)
+  }
 
   curfewSection = (): PageElement => cy.contains('Curfew')
 

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO003 - AAMR Post Release.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO003 - AAMR Post Release.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 // Scenario skipped as alcohol monitoring is currently disabled.
 context.skip('Scenarios', () => {
@@ -97,7 +97,7 @@ context.skip('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'adult',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -220,7 +220,7 @@ context.skip('Scenarios', () => {
             conditional_release_date: '',
             reason_for_order_ending_early: '',
             business_unit: '',
-            service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+            service_end_date: formatAsFmsDate(monitoringConditions.endDate),
             curfew_description: '',
             curfew_start: '',
             curfew_end: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO004 - AAMR Post Release - multiple attachments.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 // Scenario skipped as alcohol monitoring is currently disabled.
 context.skip('Scenarios', () => {
@@ -170,7 +170,7 @@ context.skip('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -294,7 +294,7 @@ context.skip('Scenarios', () => {
                 conditional_release_date: '',
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: '',
                 curfew_end: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO013 - AML Post Release.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Alcohol Monitoring/CEMO013 - AML Post Release.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 // Scenario skipped as alcohol monitoring is currently disabled.
 context.skip('Scenarios', () => {
@@ -97,7 +97,7 @@ context.skip('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'adult',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -221,7 +221,7 @@ context.skip('Scenarios', () => {
               conditional_release_date: '',
               reason_for_order_ending_early: '',
               business_unit: '',
-              service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+              service_end_date: formatAsFmsDate(monitoringConditions.endDate),
               curfew_description: '',
               curfew_start: '',
               curfew_end: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO001 - pre-trial bail - curfew 7pm-10am 7 nights - single photo attachment.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO001 - pre-trial bail - curfew 7pm-10am 7 nights - single photo attachment.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -153,7 +153,7 @@ context('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'adult',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -275,10 +275,10 @@ context('Scenarios', () => {
               technical_bail: '',
               trial_date: '',
               trial_outcome: '',
-              conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+              conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
               reason_for_order_ending_early: '',
               business_unit: '',
-              service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+              service_end_date: formatAsFmsDate(monitoringConditions.endDate),
               curfew_description: '',
               curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
               curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO002 - pre-trial technical bail - curfew 7pm-10am 7 nights - single document attachment.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO002 - pre-trial technical bail - curfew 7pm-10am 7 nights - single document attachment.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -149,7 +149,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -271,10 +271,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO005 - post release supervision - curfew 7pm-7am weekend only.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO005 - post release supervision - curfew 7pm-7am weekend only.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -113,7 +113,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -235,10 +235,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO017 - post release DAPOL parole - curfew 7pm-7am week nights only.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO017 - post release DAPOL parole - curfew 7pm-7am week nights only.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -113,7 +113,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -234,10 +234,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO018 - pre-trial bail - curfew 7pm-10am 7 nights - variation of curfew address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO018 - pre-trial bail - curfew 7pm-10am 7 nights - variation of curfew address.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -154,7 +154,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -275,10 +275,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO020 - pre-trial bail - curfew 7pm-3am 7 nights - variation of additional address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO020 - pre-trial bail - curfew 7pm-3am 7 nights - variation of additional address.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -168,7 +168,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -291,10 +291,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(variationCurfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO023 - community suspended sentence - curfew 7pm-7am 7 nights - variation of curfew 7pm-7am week nights only.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO023 - community suspended sentence - curfew 7pm-7am 7 nights - variation of curfew 7pm-7am week nights only.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -164,7 +164,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -285,10 +285,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(variationCurfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO024 - post release supervision - curfew 7pm-7am weekend only - variation of curfew 7pm-7am week days only.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO024 - post release supervision - curfew 7pm-7am weekend only - variation of curfew 7pm-7am week days only.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -170,7 +170,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -291,10 +291,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(variationCurfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO034 - pre-trial bail - curfew 7pm-10am 7 nights - two addresses.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO034 - pre-trial bail - curfew 7pm-10am 7 nights - two addresses.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createFakeAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -108,7 +108,7 @@ context('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'adult',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -229,10 +229,10 @@ context('Scenarios', () => {
               technical_bail: '',
               trial_date: '',
               trial_outcome: '',
-              conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+              conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
               reason_for_order_ending_early: '',
               business_unit: '',
-              service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+              service_end_date: formatAsFmsDate(monitoringConditions.endDate),
               curfew_description: '',
               curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
               curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO019 - post release - single inclusion zone - variation of home address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Exclusion zone/CEMO019 - post release - single inclusion zone - variation of home address.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -175,7 +175,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -299,7 +299,7 @@ context('Scenarios', () => {
                 conditional_release_date: '',
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: '',
                 curfew_end: '',
@@ -309,8 +309,8 @@ context('Scenarios', () => {
                   {
                     description: enforcementZoneDetails.description,
                     duration: enforcementZoneDetails.duration,
-                    start: enforcementZoneDetails.startDate.toISOString().split('T')[0],
-                    end: enforcementZoneDetails.endDate.toISOString().split('T')[0],
+                    start: formatAsFmsDate(enforcementZoneDetails.startDate),
+                    end: formatAsFmsDate(enforcementZoneDetails.endDate),
                   },
                 ],
                 inclusion_zones: [],

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Multiple Conditions/CEMO036 - post release DAPOL parole - curfew 7pm-7am week nights only - GPS tag location fitted.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Multiple Conditions/CEMO036 - post release DAPOL parole - curfew 7pm-7am week nights only - GPS tag location fitted.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, kelvinCloseAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -120,7 +120,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -246,10 +246,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO009 -  Immigration - GPS tag location fitted.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO009 -  Immigration - GPS tag location fitted.cy.ts
@@ -15,7 +15,7 @@ import InstallationAddressPage from '../../../pages/order/monitoring-conditions/
 import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import TrailMonitoringPage from '../../../pages/order/monitoring-conditions/trail-monitoring'
 import AttachmentSummaryPage from '../../../pages/order/attachments/summary'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
@@ -162,7 +162,7 @@ context('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'adult',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -287,7 +287,7 @@ context('Scenarios', () => {
               conditional_release_date: '',
               reason_for_order_ending_early: '',
               business_unit: '',
-              service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+              service_end_date: formatAsFmsDate(monitoringConditions.endDate),
               curfew_description: '',
               curfew_start: '',
               curfew_end: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO010 -  Immigration - location non-fitted.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO010 -  Immigration - location non-fitted.cy.ts
@@ -15,7 +15,7 @@ import InstallationAddressPage from '../../../pages/order/monitoring-conditions/
 import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import TrailMonitoringPage from '../../../pages/order/monitoring-conditions/trail-monitoring'
 import AttachmentSummaryPage from '../../../pages/order/attachments/summary'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
@@ -162,7 +162,7 @@ context.skip('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'adult',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -287,7 +287,7 @@ context.skip('Scenarios', () => {
               conditional_release_date: '',
               reason_for_order_ending_early: '',
               business_unit: '',
-              service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+              service_end_date: formatAsFmsDate(monitoringConditions.endDate),
               curfew_description: '',
               curfew_start: '',
               curfew_end: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO012 - Community - GPS tag location fitted.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO012 - Community - GPS tag location fitted.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { kelvinCloseAddress, createFakeAdultDeviceWearer, createFakeInterestedParties } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -93,7 +93,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'adult',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -217,7 +217,7 @@ context('Scenarios', () => {
                 conditional_release_date: '',
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: '',
                 curfew_end: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO016 - post release parole - location fitted.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO016 - post release parole - location fitted.cy.ts
@@ -5,7 +5,7 @@ import IndexPage from '../../../pages/index'
 import OrderSummaryPage from '../../../pages/order/summary'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties, createKnownAddress } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -132,7 +132,7 @@ context('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'adult',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -256,7 +256,7 @@ context('Scenarios', () => {
               conditional_release_date: '',
               reason_for_order_ending_early: '',
               business_unit: '',
-              service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+              service_end_date: formatAsFmsDate(monitoringConditions.endDate),
               curfew_description: '',
               curfew_start: '',
               curfew_end: '',

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO021 -  Immigration - GPS tag location fitted - variation of additional address.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Trail monitoring/CEMO021 -  Immigration - GPS tag location fitted - variation of additional address.cy.ts
@@ -16,7 +16,7 @@ import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import InstallationAndRiskCheckYourAnswersPage from '../../../pages/order/installation-and-risk/check-your-answers'
 import TrailMonitoringPage from '../../../pages/order/monitoring-conditions/trail-monitoring'
 import AttachmentSummaryPage from '../../../pages/order/attachments/summary'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
@@ -167,7 +167,7 @@ context.skip('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'adult',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -291,7 +291,7 @@ context.skip('Scenarios', () => {
               conditional_release_date: '',
               reason_for_order_ending_early: '',
               business_unit: '',
-              service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+              service_end_date: formatAsFmsDate(monitoringConditions.endDate),
               curfew_description: '',
               curfew_start: '',
               curfew_end: '',

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Attendance monitoring/CEMO035 - Community - Youth Rehabilitation Order with GPS Tag.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Attendance monitoring/CEMO035 - Community - Youth Rehabilitation Order with GPS Tag.cy.ts
@@ -198,7 +198,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'child',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -323,7 +323,7 @@ context('Scenarios', () => {
                 conditional_release_date: '',
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: '',
                 curfew_end: '',

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO007 - post release training order - curfew 7pm-7am 7 nights.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO007 - post release training order - curfew 7pm-7am 7 nights.cy.ts
@@ -10,7 +10,7 @@ import {
   createKnownAddress,
 } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -121,7 +121,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'child',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -243,10 +243,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO008 - community suspended sentence - curfew 7pm-7am weekend only.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO008 - community suspended sentence - curfew 7pm-7am weekend only.cy.ts
@@ -10,7 +10,7 @@ import {
   createKnownAddress,
 } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -114,7 +114,7 @@ context('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'child',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -236,10 +236,10 @@ context('Scenarios', () => {
               technical_bail: '',
               trial_date: '',
               trial_outcome: '',
-              conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+              conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
               reason_for_order_ending_early: '',
               business_unit: '',
-              service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+              service_end_date: formatAsFmsDate(monitoringConditions.endDate),
               curfew_description: '',
               curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
               curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO015 - pre-trial- curfew 7pm-7am daily - 2 addresses.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Curfew/CEMO015 - pre-trial- curfew 7pm-7am daily - 2 addresses.cy.ts
@@ -10,7 +10,7 @@ import {
   createKnownAddress,
 } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -116,7 +116,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'child',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -237,10 +237,10 @@ context('Scenarios', () => {
                 technical_bail: '',
                 trial_date: '',
                 trial_outcome: '',
-                conditional_release_date: curfewReleaseDetails.releaseDate.toISOString().split('T')[0],
+                conditional_release_date: formatAsFmsDate(curfewReleaseDetails.releaseDate),
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: formatAsFmsDateTime(curfewConditionDetails.startDate),
                 curfew_end: formatAsFmsDateTime(curfewConditionDetails.endDate),

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - post release - multiple exclusion zones - single document attachment.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO014 - post release - multiple exclusion zones - single document attachment.cy.ts
@@ -21,7 +21,7 @@ import EnforcementZonePage from '../../../pages/order/monitoring-conditions/enfo
 import SubmitSuccessPage from '../../../pages/order/submit-success'
 import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import AttachmentSummaryPage from '../../../pages/order/attachments/summary'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
@@ -225,7 +225,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'child',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -349,7 +349,7 @@ context('Scenarios', () => {
                 conditional_release_date: '',
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: '',
                 curfew_end: '',
@@ -359,8 +359,8 @@ context('Scenarios', () => {
                   {
                     description: enforcementZoneDetails.description,
                     duration: enforcementZoneDetails.duration,
-                    start: enforcementZoneDetails.startDate.toISOString().split('T')[0],
-                    end: enforcementZoneDetails.endDate.toISOString().split('T')[0],
+                    start: formatAsFmsDate(enforcementZoneDetails.startDate),
+                    end: formatAsFmsDate(enforcementZoneDetails.endDate),
                   },
                 ],
                 inclusion_zones: [],

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO022 - post release - single inclusion zone - variation of additional address.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Exclusion zone/CEMO022 - post release - single inclusion zone - variation of additional address.cy.ts
@@ -10,7 +10,7 @@ import {
   createFakeResponsibleAdult,
 } from '../../../mockApis/faker'
 import SubmitSuccessPage from '../../../pages/order/submit-success'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 
 context('Scenarios', () => {
   const fmsCaseId: string = uuidv4()
@@ -186,7 +186,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'child',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -312,7 +312,7 @@ context('Scenarios', () => {
                 conditional_release_date: '',
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: '',
                 curfew_end: '',
@@ -322,8 +322,8 @@ context('Scenarios', () => {
                   {
                     description: enforcementZoneDetails.description,
                     duration: enforcementZoneDetails.duration,
-                    start: enforcementZoneDetails.startDate.toISOString().split('T')[0],
-                    end: enforcementZoneDetails.endDate.toISOString().split('T')[0],
+                    start: formatAsFmsDate(enforcementZoneDetails.startDate),
+                    end: formatAsFmsDate(enforcementZoneDetails.endDate),
                   },
                 ],
                 inclusion_zones: [],

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Trail monitoring/CEMO006 - Youth Rehabilitation Order with Intensive Supervision and Surveillance - GPS tag location fitted.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Trail monitoring/CEMO006 - Youth Rehabilitation Order with Intensive Supervision and Surveillance - GPS tag location fitted.cy.ts
@@ -22,7 +22,7 @@ import InstallationAndRiskCheckYourAnswersPage from '../../../pages/order/instal
 import TrailMonitoringPage from '../../../pages/order/monitoring-conditions/trail-monitoring'
 import ResponsibleAdultPage from '../../../pages/order/about-the-device-wearer/responsible-adult-details'
 import AttachmentSummaryPage from '../../../pages/order/attachments/summary'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
@@ -186,7 +186,7 @@ context('Scenarios', () => {
             middle_name: '',
             last_name: deviceWearerDetails.lastName,
             alias: deviceWearerDetails.alias,
-            date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+            date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
             adult_child: 'child',
             sex: deviceWearerDetails.sex
               .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -311,7 +311,7 @@ context('Scenarios', () => {
                 conditional_release_date: '',
                 reason_for_order_ending_early: '',
                 business_unit: '',
-                service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+                service_end_date: formatAsFmsDate(monitoringConditions.endDate),
                 curfew_description: '',
                 curfew_start: '',
                 curfew_end: '',

--- a/integration_tests/scenarios/SR02 Child Device Wearer/Trail monitoring/CEMO011 -  Post release - location fitted.cy.ts
+++ b/integration_tests/scenarios/SR02 Child Device Wearer/Trail monitoring/CEMO011 -  Post release - location fitted.cy.ts
@@ -20,7 +20,7 @@ import InstallationAddressPage from '../../../pages/order/monitoring-conditions/
 import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 import TrailMonitoringPage from '../../../pages/order/monitoring-conditions/trail-monitoring'
 import AttachmentSummaryPage from '../../../pages/order/attachments/summary'
-import { formatAsFmsDateTime, formatAsFmsPhoneNumber } from '../../utils'
+import { formatAsFmsDateTime, formatAsFmsDate, formatAsFmsPhoneNumber } from '../../utils'
 import DeviceWearerCheckYourAnswersPage from '../../../pages/order/about-the-device-wearer/check-your-answers'
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import ContactInformationCheckYourAnswersPage from '../../../pages/order/contact-information/check-your-answers'
@@ -174,7 +174,7 @@ context('Scenarios', () => {
           middle_name: '',
           last_name: deviceWearerDetails.lastName,
           alias: deviceWearerDetails.alias,
-          date_of_birth: deviceWearerDetails.dob.toISOString().split('T')[0],
+          date_of_birth: formatAsFmsDate(deviceWearerDetails.dob),
           adult_child: 'child',
           sex: deviceWearerDetails.sex
             .replace('Not able to provide this information', 'Prefer Not to Say')
@@ -299,7 +299,7 @@ context('Scenarios', () => {
               conditional_release_date: '',
               reason_for_order_ending_early: '',
               business_unit: '',
-              service_end_date: monitoringConditions.endDate.toISOString().split('T')[0],
+              service_end_date: formatAsFmsDate(monitoringConditions.endDate),
               curfew_description: '',
               curfew_start: '',
               curfew_end: '',

--- a/server/controllers/monitoringConditions/checkAnswersController.test.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.test.ts
@@ -1653,7 +1653,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
             key: {
               text: 'On the day of release, what time does the curfew start?',
             },
-            value: { 
+            value: {
               text: '11:11',
             },
             actions: {

--- a/server/controllers/monitoringConditions/checkAnswersController.test.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.test.ts
@@ -706,7 +706,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'On the day of release, what time does the curfew start?',
             },
             value: {
-              text: 'Invalid Date',
+              text: '11:11',
             },
             actions: {
               items: [
@@ -723,7 +723,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'On the day of release, what time does the curfew end?',
             },
             value: {
-              text: 'Invalid Date',
+              text: '11:11',
             },
             actions: {
               items: [
@@ -1653,8 +1653,8 @@ describe('MonitoringConditionsCheckAnswersController', () => {
             key: {
               text: 'On the day of release, what time does the curfew start?',
             },
-            value: {
-              text: 'Invalid Date',
+            value: { 
+              text: '11:11',
             },
             actions: {
               items: [
@@ -1671,7 +1671,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
               text: 'On the day of release, what time does the curfew end?',
             },
             value: {
-              text: 'Invalid Date',
+              text: '11:11',
             },
             actions: {
               items: [

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -149,13 +149,18 @@ const createCurfewReleaseDateAnswers = (order: Order, content: I18n, answerOpts:
       releaseDateUri,
       answerOpts,
     ),
-    createTimeAnswer(
+    createAnswer(
       questions.startTime.text,
-      order.curfewReleaseDateConditions?.startTime,
+      trimSeconds(order.curfewReleaseDateConditions?.startTime),
       releaseDateUri,
       answerOpts,
     ),
-    createTimeAnswer(questions.endTime.text, order.curfewReleaseDateConditions?.endTime, releaseDateUri, answerOpts),
+    createAnswer(
+      questions.endTime.text,
+      trimSeconds(order.curfewReleaseDateConditions?.endTime),
+      releaseDateUri,
+      answerOpts,
+    ),
     createAddressAnswer(
       questions.address.text,
       order.addresses.find(({ addressType }) => addressType === order.curfewReleaseDateConditions?.curfewAddress),


### PR DESCRIPTION


### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3720

When user enters start and end time on curfew release day, the CYA page show both times as invalid date

### Changes proposed in this pull request

Refactor to use createAnswer instead of createTimeAnswer to create CYA answer view for start time and end time, as they are string value of time instead of date and time.

Added integration test to check valid time value are shown in CYA page
