### PR TITLE
Question text amendments in Curfew Release Date & Fixed Address pages.

### DIFF
--- a/integration_tests/pages/components/forms/monitoring-conditions/curfewReleaseDateFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoring-conditions/curfewReleaseDateFormComponent.ts
@@ -22,7 +22,7 @@ export default class CurfewReleaseDateFormComponent extends FormComponent {
   }
 
   get endTimeField(): FormTimeComponent {
-    return new FormTimeComponent(this.form, 'On the day of release, what time does the curfew end?')
+    return new FormTimeComponent(this.form, 'On the day after release, what time does the curfew end?')
   }
 
   get addressField(): FormRadiosComponent {

--- a/server/controllers/monitoringConditions/checkAnswersController.test.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.test.ts
@@ -720,7 +720,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
           },
           {
             key: {
-              text: 'On the day of release, what time does the curfew end?',
+              text: 'On the day after release, what time does the curfew end?',
             },
             value: {
               text: 'Invalid Date',
@@ -730,7 +730,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                 {
                   href: paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE.replace(':orderId', order.id),
                   text: 'Change',
-                  visuallyHiddenText: 'on the day of release, what time does the curfew end?',
+                  visuallyHiddenText: 'on the day after release, what time does the curfew end?',
                 },
               ],
             },
@@ -1668,7 +1668,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
           },
           {
             key: {
-              text: 'On the day of release, what time does the curfew end?',
+              text: 'On the day after release, what time does the curfew end?',
             },
             value: {
               text: 'Invalid Date',
@@ -1678,7 +1678,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                 {
                   href: paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE.replace(':orderId', order.id),
                   text: 'Change',
-                  visuallyHiddenText: 'on the day of release, what time does the curfew end?',
+                  visuallyHiddenText: 'on the day after release, what time does the curfew end?',
                 },
               ],
             },

--- a/server/i18n/en/pages/curfewReleaseDate.ts
+++ b/server/i18n/en/pages/curfewReleaseDate.ts
@@ -9,7 +9,7 @@ const curfewReleaseDatePageContent: CurfewReleaseDatePageContent = {
       hint: "Select one address. Addresses listed are those entered earlier in the form. Go to the 'Contact information' section to edit address information.",
     },
     endTime: {
-      text: 'On the day of release, what time does the curfew end?',
+      text: 'On the day after release, what time does the curfew end?',
       hint: 'Enter time using a 24 hour clock. For example 19:00 instead of 7:00pm.',
     },
     releaseDate: {

--- a/server/i18n/en/pages/noFixedAbode.ts
+++ b/server/i18n/en/pages/noFixedAbode.ts
@@ -6,7 +6,7 @@ const noFixedAbodePageContent: NoFixedAbodePageContent = {
   questions: {
     noFixedAbode: {
       text: 'Does the device wearer have a fixed address?',
-      hint: "An address the device wearer has registered as their home address. It can be temporary accommodation, a fixed tenancy or a permanent address. If they are registered as homeless, select 'No'.",
+      hint: "An address the device wearer has registered as their home address. It can be temporary accommodation, an Approved Premises (AP), a fixed tenancy or a permanent address. If they are registered as homeless, select 'No'.",
     },
   },
   section: 'Contact information',


### PR DESCRIPTION
### Context

Tickets:

https://dsdmoj.atlassian.net/browse/ELM-3708
- In the Curfew Release Date page, the phrasing of a question is inaccurate and is confusing to users. This text should be amended.

https://dsdmoj.atlassian.net/browse/ELM-3709
- In the Fixed Address page, the help text of a question is confusing to users. This text should be amended.

### Changes proposed in this pull request

**ELM-3708:**
In the Curfew Release Date page, update the text of a question
from "On the day of release, what time does the curfew end?"
to "On the day after release, what time does the curfew end?"

![image](https://github.com/user-attachments/assets/ce508f9f-3646-4ac3-9b04-0083c66c177a)


**ELM-3709:**
In the Fixed Address page, update the help text of a question to explicitly mention that an Approved Premises (AP)
can be used as the device wearer's  home address

![image](https://github.com/user-attachments/assets/36d91d02-b065-4a35-a141-da69c281756f)


