### PR TITLE
Allow reference data to be changed at runtime

### DIFF
--- a/server/i18n/en/index.ts
+++ b/server/i18n/en/index.ts
@@ -1,4 +1,5 @@
 import I18n from '../../types/i18n'
+import DataDictionaryVersion from '../../types/i18n/dataDictionaryVersion'
 import alcoholPageContent from './pages/alcohol'
 import attendancePageContent from './pages/attendance'
 import contactDetailsPageContent from './pages/contactDetails'
@@ -21,34 +22,36 @@ import trailMonitoringPageContent from './pages/trailMonitoring'
 import uploadLicencePageContent from './pages/uploadLicence'
 import uploadPhotoIdPageContent from './pages/uploadPhotoId'
 import variationDetailsPageContent from './pages/variationDetails'
-import reference from './reference'
+import getReferenceData from './reference'
 
-const en: I18n = {
-  pages: {
-    alcohol: alcoholPageContent,
-    attendance: attendancePageContent,
-    contactDetails: contactDetailsPageContent,
-    curfewConditions: curfewConditionsPageContent,
-    curfewReleaseDate: curfewReleaseDatePageContent,
-    curfewTimetable: curfewTimeTablePageContent,
-    deviceWearer: deviceWearerPageContent,
-    exclusionZone: exclusionZonePageContent,
-    identityNumbers: identityNumbersPageContent,
-    installationAddress: installationAddressPageContent,
-    installationAndRisk: installationAndRiskPageContent,
-    interestedParties: interestedPartiesPageContent,
-    monitoringConditions: monitoringConditionsPageContent,
-    noFixedAbode: noFixedAbodePageContent,
-    primaryAddress: primaryAddressPageContent,
-    responsibleAdult: responsibleAdultPageContent,
-    secondaryAddress: secondaryAddressPageContent,
-    tertiaryAddress: tertiaryAddressPageContent,
-    trailMonitoring: trailMonitoringPageContent,
-    uploadLicense: uploadLicencePageContent,
-    uploadPhotoId: uploadPhotoIdPageContent,
-    variationDetails: variationDetailsPageContent,
-  },
-  reference,
+const getEnglishContent = (ddVersion: DataDictionaryVersion): I18n => {
+  return {
+    pages: {
+      alcohol: alcoholPageContent,
+      attendance: attendancePageContent,
+      contactDetails: contactDetailsPageContent,
+      curfewConditions: curfewConditionsPageContent,
+      curfewReleaseDate: curfewReleaseDatePageContent,
+      curfewTimetable: curfewTimeTablePageContent,
+      deviceWearer: deviceWearerPageContent,
+      exclusionZone: exclusionZonePageContent,
+      identityNumbers: identityNumbersPageContent,
+      installationAddress: installationAddressPageContent,
+      installationAndRisk: installationAndRiskPageContent,
+      interestedParties: interestedPartiesPageContent,
+      monitoringConditions: monitoringConditionsPageContent,
+      noFixedAbode: noFixedAbodePageContent,
+      primaryAddress: primaryAddressPageContent,
+      responsibleAdult: responsibleAdultPageContent,
+      secondaryAddress: secondaryAddressPageContent,
+      tertiaryAddress: tertiaryAddressPageContent,
+      trailMonitoring: trailMonitoringPageContent,
+      uploadLicense: uploadLicencePageContent,
+      uploadPhotoId: uploadPhotoIdPageContent,
+      variationDetails: variationDetailsPageContent,
+    },
+    reference: getReferenceData(ddVersion),
+  }
 }
 
-export default en
+export default getEnglishContent

--- a/server/i18n/en/reference/ddv5/crownCourts.ts
+++ b/server/i18n/en/reference/ddv5/crownCourts.ts
@@ -1,6 +1,6 @@
 import { CrownCourtsDDv5 } from '../../../../types/i18n/reference/crownCourts'
 
-const crownCourts: CrownCourtsDDv5 = {
+const crownCourtsDDv5: CrownCourtsDDv5 = {
   AMERSHAM_CROWN_COURT: 'Amersham Crown Court',
   AYLESBURY_CROWN_COURT: 'Aylesbury Crown Court',
   BARBICAN_ALDERSGATE_HOUSE_CROWN_COURT: 'Barbican (Aldersgate House) Crown Court',
@@ -104,4 +104,4 @@ const crownCourts: CrownCourtsDDv5 = {
   YORK_CROWN_COURT: 'York Crown Court',
 }
 
-export default crownCourts
+export default crownCourtsDDv5

--- a/server/i18n/en/reference/ddv5/disabilities.ts
+++ b/server/i18n/en/reference/ddv5/disabilities.ts
@@ -1,6 +1,6 @@
 import { DisabilitiesDDv5 } from '../../../../types/i18n/reference/disabilities'
 
-const disabilities: DisabilitiesDDv5 = {
+const disabilitiesDDv5: DisabilitiesDDv5 = {
   VISION: 'Visual impairment or blindness not corrected by wearing glasses',
   HEARING: 'Deafness or serious hearing impairment',
   MOBILITY: 'Physical disability or mobility issue',
@@ -16,4 +16,4 @@ const disabilities: DisabilitiesDDv5 = {
   NONE_OF_THE_ABOVE: 'Not able to provide this information',
 }
 
-export default disabilities
+export default disabilitiesDDv5

--- a/server/i18n/en/reference/ddv5/magistratesCourts.ts
+++ b/server/i18n/en/reference/ddv5/magistratesCourts.ts
@@ -1,6 +1,6 @@
 import { MagistratesCourtsDDv5 } from '../../../../types/i18n/reference/magistratesCourts'
 
-const magistratesCourts: MagistratesCourtsDDv5 = {
+const magistratesCourtsDDv5: MagistratesCourtsDDv5 = {
   ABERDARE_MAGISTRATES_COURT: 'Aberdare Magistrates Court',
   ABERGAVENNY_MAGISTRATES_COURT: 'Abergavenny Magistrates Court',
   ABERTILLERY_MAGISTRATES_COURT: 'Abertillery Magistrates Court',
@@ -417,4 +417,4 @@ const magistratesCourts: MagistratesCourtsDDv5 = {
   YSTRADGYNLAIS_MAGISTRATES_COURT: 'Ystradgynlais Magistrates Court',
 }
 
-export default magistratesCourts
+export default magistratesCourtsDDv5

--- a/server/i18n/en/reference/ddv5/notifyingOrganisations.ts
+++ b/server/i18n/en/reference/ddv5/notifyingOrganisations.ts
@@ -1,6 +1,6 @@
 import { NotifyingOrganisationsDDv5 } from '../../../../types/i18n/reference/notifyingOrganisations'
 
-const notifyingOrganisations: NotifyingOrganisationsDDv5 = {
+const notifyingOrganisationsDDv5: NotifyingOrganisationsDDv5 = {
   CIVIL_AND_COUNTY_COURT: 'Civil & County Court',
   CROWN_COURT: 'Crown Court',
   FAMILY_COURT: 'Family Court',
@@ -14,4 +14,4 @@ const notifyingOrganisations: NotifyingOrganisationsDDv5 = {
   YOUTH_COURT: 'Youth Court',
 }
 
-export default notifyingOrganisations
+export default notifyingOrganisationsDDv5

--- a/server/i18n/en/reference/ddv5/prisons.ts
+++ b/server/i18n/en/reference/ddv5/prisons.ts
@@ -1,6 +1,6 @@
 import { PrisonsDDv5 } from '../../../../types/i18n/reference/prisons'
 
-const prisons: PrisonsDDv5 = {
+const prisonsDDv5: PrisonsDDv5 = {
   ALTCOURSE_PRISON: 'Altcourse Prison',
   ASHFIELD_PRISON: 'Ashfield Prison',
   ASKHAM_GRANGE_PRISON_AND_YOUNG_OFFENDER_INSTITUTION: 'Askham Grange Prison and Young Offender Institution',
@@ -125,4 +125,4 @@ const prisons: PrisonsDDv5 = {
   WYMOTT_PRISON: 'Wymott Prison',
 }
 
-export default prisons
+export default prisonsDDv5

--- a/server/i18n/en/reference/ddv5/riskCategories.ts
+++ b/server/i18n/en/reference/ddv5/riskCategories.ts
@@ -1,6 +1,6 @@
 import { RiskCategoriesDDv5 } from '../../../../types/i18n/reference/riskCategories'
 
-const riskCategories: RiskCategoriesDDv5 = {
+const riskCategoriesDDv5: RiskCategoriesDDv5 = {
   THREATS_OF_VIOLENCE: 'Violent behaviour or threats of violence',
   SEXUAL_OFFENCES: 'Sex offender',
   RISK_TO_GENDER: 'Offensive towards someone because of their sex or gender',
@@ -18,4 +18,4 @@ const riskCategories: RiskCategoriesDDv5 = {
   OTHER_RISKS: 'Other known risks',
 }
 
-export default riskCategories
+export default riskCategoriesDDv5

--- a/server/i18n/en/reference/ddv5/variationTypes.ts
+++ b/server/i18n/en/reference/ddv5/variationTypes.ts
@@ -1,6 +1,6 @@
 import { VariationTypesDDv5 } from '../../../../types/i18n/reference/variationTypes'
 
-const variationTypes: VariationTypesDDv5 = {
+const variationTypesDDv5: VariationTypesDDv5 = {
   CHANGE_TO_ADDRESS: 'Change to Address',
   CHANGE_TO_PERSONAL_DETAILS: 'Change to Personal Details',
   CHANGE_TO_ADD_AN_INCLUSION_OR_EXCLUSION_ZONES: 'Change to add an Inclusion or Exclusion Zone(s)',
@@ -13,4 +13,4 @@ const variationTypes: VariationTypesDDv5 = {
   OTHER: 'Other',
 }
 
-export default variationTypes
+export default variationTypesDDv5

--- a/server/i18n/en/reference/index.ts
+++ b/server/i18n/en/reference/index.ts
@@ -1,7 +1,20 @@
-import ReferenceCatalog from '../../../types/i18n/reference'
+import DataDictionaryVersion from '../../../types/i18n/dataDictionaryVersion'
+import ReferenceCatalog, { ReferenceCatalogDDv4, ReferenceCatalogDDv5 } from '../../../types/i18n/reference'
 import alcoholMonitoringTypes from './alcoholMonitoringTypes'
 import conditionTypes from './conditionTypes'
 import crownCourts from './crownCourts'
+import civilCountyCourts from './ddv5/civilCountyCourts'
+import crownCourtsDDv5 from './ddv5/crownCourts'
+import disabilitiesDDv5 from './ddv5/disabilities'
+import familyCourts from './ddv5/familyCourts'
+import magistratesCourtsDDv5 from './ddv5/magistratesCourts'
+import militaryCourts from './ddv5/militaryCourts'
+import notifyingOrganisationsDDv5 from './ddv5/notifyingOrganisations'
+import pilots from './ddv5/pilots'
+import prisonsDDv5 from './ddv5/prisons'
+import riskCategoriesDDv5 from './ddv5/riskCategories'
+import variationTypesDDv5 from './ddv5/variationTypes'
+import youthCourts from './ddv5/youthCourts'
 import disabilities from './disabilities'
 import gender from './gender'
 import magistratesCourts from './magistratesCourts'
@@ -22,7 +35,7 @@ import variationTypes from './variationTypes'
 import yesNoUnknown from './yesNoUnknown'
 import youthJusticeServiceRegions from './youthJusticeServiceRegions'
 
-const reference: ReferenceCatalog = {
+const referenceCatalogDDv4: ReferenceCatalogDDv4 = {
   alcoholMonitoringTypes,
   conditionTypes,
   crownCourts,
@@ -47,4 +60,42 @@ const reference: ReferenceCatalog = {
   youthJusticeServiceRegions,
 }
 
-export default reference
+const referenceCatalogDDv5: ReferenceCatalogDDv5 = {
+  alcoholMonitoringTypes,
+  civilCountyCourts,
+  conditionTypes,
+  crownCourts: crownCourtsDDv5,
+  disabilities: disabilitiesDDv5,
+  familyCourts,
+  gender,
+  magistratesCourts: magistratesCourtsDDv5,
+  mappaCaseType,
+  mappaLevel,
+  militaryCourts,
+  notifyingOrganisations: notifyingOrganisationsDDv5,
+  offences,
+  orderTypeDescriptions,
+  orderTypes,
+  pilots,
+  prisons: prisonsDDv5,
+  probationRegions,
+  relationship,
+  responsibleOrganisations,
+  riskCategories: riskCategoriesDDv5,
+  sentenceTypes,
+  sex,
+  variationTypes: variationTypesDDv5,
+  yesNoUnknown,
+  youthCourts,
+  youthJusticeServiceRegions,
+}
+
+const getReferenceData = (ddVersion: DataDictionaryVersion): ReferenceCatalog => {
+  if (ddVersion === 'DDv5') {
+    return referenceCatalogDDv5
+  }
+
+  return referenceCatalogDDv4
+}
+
+export default getReferenceData

--- a/server/i18n/en/reference/index.ts
+++ b/server/i18n/en/reference/index.ts
@@ -1,4 +1,4 @@
-import DataDictionaryVersion from '../../../types/i18n/dataDictionaryVersion'
+import DataDictionaryVersion, { DataDictionaryVersions } from '../../../types/i18n/dataDictionaryVersion'
 import ReferenceCatalog, { ReferenceCatalogDDv4, ReferenceCatalogDDv5 } from '../../../types/i18n/reference'
 import alcoholMonitoringTypes from './alcoholMonitoringTypes'
 import conditionTypes from './conditionTypes'
@@ -91,7 +91,7 @@ const referenceCatalogDDv5: ReferenceCatalogDDv5 = {
 }
 
 const getReferenceData = (ddVersion: DataDictionaryVersion): ReferenceCatalog => {
-  if (ddVersion === 'DDv5') {
+  if (ddVersion === DataDictionaryVersions.DDv5) {
     return referenceCatalogDDv5
   }
 

--- a/server/i18n/index.ts
+++ b/server/i18n/index.ts
@@ -1,7 +1,13 @@
-import en from './en'
+import I18n from '../types/i18n'
+import DataDictionaryVersion from '../types/i18n/dataDictionaryVersion'
+import Locale from '../types/i18n/locale'
+import getEnglishContent from './en'
 
-const i18n = {
-  en,
+const getContent = (locale: Locale, ddVersion: DataDictionaryVersion): I18n => {
+  if (locale === 'cy') {
+    throw new Error('Welsh language not implemented')
+  }
+  return getEnglishContent(ddVersion)
 }
 
-export default i18n
+export default getContent

--- a/server/i18n/index.ts
+++ b/server/i18n/index.ts
@@ -1,10 +1,10 @@
 import I18n from '../types/i18n'
 import DataDictionaryVersion from '../types/i18n/dataDictionaryVersion'
-import Locale from '../types/i18n/locale'
+import Locale, { Locales } from '../types/i18n/locale'
 import getEnglishContent from './en'
 
 const getContent = (locale: Locale, ddVersion: DataDictionaryVersion): I18n => {
-  if (locale === 'cy') {
+  if (locale === Locales.cy) {
     throw new Error('Welsh language not implemented')
   }
   return getEnglishContent(ddVersion)

--- a/server/middleware/populateContent.ts
+++ b/server/middleware/populateContent.ts
@@ -1,9 +1,11 @@
 import { NextFunction, Request, Response } from 'express'
 import getContent from '../i18n'
+import { DataDictionaryVersions } from '../types/i18n/dataDictionaryVersion'
+import { Locales } from '../types/i18n/locale'
 
 const populateContent = async (req: Request, res: Response, next: NextFunction) => {
   // TODO: replace dd version with feature flag
-  res.locals.content = getContent('en', 'DDv4')
+  res.locals.content = getContent(Locales.en, DataDictionaryVersions.DDv4)
   next()
 }
 

--- a/server/middleware/populateContent.ts
+++ b/server/middleware/populateContent.ts
@@ -1,8 +1,9 @@
 import { NextFunction, Request, Response } from 'express'
-import i18n from '../i18n'
+import getContent from '../i18n'
 
 const populateContent = async (req: Request, res: Response, next: NextFunction) => {
-  res.locals.content = i18n.en
+  // TODO: replace dd version with feature flag
+  res.locals.content = getContent('en', 'DDv4')
   next()
 }
 

--- a/server/types/i18n/dataDictionaryVersion.ts
+++ b/server/types/i18n/dataDictionaryVersion.ts
@@ -1,0 +1,6 @@
+type DDv4 = 'DDv4'
+type DDv5 = 'DDv5'
+
+type DataDictionaryVersion = DDv4 | DDv5
+
+export default DataDictionaryVersion

--- a/server/types/i18n/dataDictionaryVersion.ts
+++ b/server/types/i18n/dataDictionaryVersion.ts
@@ -1,6 +1,10 @@
-type DDv4 = 'DDv4'
-type DDv5 = 'DDv5'
+const DataDictionaryVersions = {
+  DDv4: 'DDv4',
+  DDv5: 'DDv5',
+} as const
 
-type DataDictionaryVersion = DDv4 | DDv5
+type DataDictionaryVersion = keyof typeof DataDictionaryVersions
 
 export default DataDictionaryVersion
+
+export { DataDictionaryVersions }

--- a/server/types/i18n/locale.ts
+++ b/server/types/i18n/locale.ts
@@ -1,3 +1,10 @@
-type Locale = 'en' | 'cy'
+const Locales = {
+  en: 'en',
+  cy: 'cy',
+} as const
+
+type Locale = keyof typeof Locales
 
 export default Locale
+
+export { Locales }

--- a/server/types/i18n/reference/index.ts
+++ b/server/types/i18n/reference/index.ts
@@ -1,27 +1,32 @@
 import AlcoholMonitoringTypes from './alcoholMonitoringTypes'
+import CivilCountyCourts from './civilCountyCourts'
 import ConditionTypes from './conditionTypes'
-import CrownCourts from './crownCourts'
-import Disabilities from './disabilities'
+import CrownCourts, { CrownCourtsDDv5 } from './crownCourts'
+import Disabilities, { DisabilitiesDDv5 } from './disabilities'
+import FamilyCourts from './familyCourts'
 import Gender from './gender'
-import MagistratesCourts from './magistratesCourts'
+import MagistratesCourts, { MagistratesCourtsDDv5 } from './magistratesCourts'
 import MappaCaseType from './mappaCaseType'
 import MappaLevel from './mappaLevel'
-import NotifyingOrganisations from './notifyingOrganisations'
+import MilitaryCourts from './militaryCourts'
+import NotifyingOrganisations, { NotifyingOrganisationsDDv5 } from './notifyingOrganisations'
 import Offences from './offences'
 import OrderTypeDescriptions from './orderTypeDescriptions'
 import OrderTypes from './orderTypes'
-import Prisons from './prisons'
+import Pilots from './pilots'
+import Prisons, { PrisonsDDv5 } from './prisons'
 import ProbationRegions from './probationRegions'
 import Relationship from './relationship'
 import ResponsibleOrganisations from './responsibleOrganisations'
-import RiskCategories from './riskCategories'
+import RiskCategories, { RiskCategoriesDDv5 } from './riskCategories'
 import SentenceTypes from './sentenceTypes'
 import Sex from './sex'
-import VariationTypes from './variationTypes'
+import VariationTypes, { VariationTypesDDv5 } from './variationTypes'
 import YesNoUnknown from './yesNoUnknown'
+import YouthCourts from './youthCourts'
 import YouthJusticeServiceRegions from './youthJusticeServiceRegions'
 
-type ReferenceCatalog = {
+type ReferenceCatalogDDv4 = {
   alcoholMonitoringTypes: AlcoholMonitoringTypes
   conditionTypes: ConditionTypes
   crownCourts: CrownCourts
@@ -46,4 +51,38 @@ type ReferenceCatalog = {
   youthJusticeServiceRegions: YouthJusticeServiceRegions
 }
 
+type ReferenceCatalogDDv5 = {
+  alcoholMonitoringTypes: AlcoholMonitoringTypes
+  civilCountyCourts: CivilCountyCourts
+  conditionTypes: ConditionTypes
+  crownCourts: CrownCourtsDDv5
+  disabilities: DisabilitiesDDv5
+  familyCourts: FamilyCourts
+  gender: Gender
+  magistratesCourts: MagistratesCourtsDDv5
+  mappaCaseType: MappaCaseType
+  mappaLevel: MappaLevel
+  militaryCourts: MilitaryCourts
+  notifyingOrganisations: NotifyingOrganisationsDDv5
+  offences: Offences
+  orderTypeDescriptions: OrderTypeDescriptions
+  orderTypes: OrderTypes
+  pilots: Pilots
+  prisons: PrisonsDDv5
+  probationRegions: ProbationRegions
+  relationship: Relationship
+  responsibleOrganisations: ResponsibleOrganisations
+  riskCategories: RiskCategoriesDDv5
+  sentenceTypes: SentenceTypes
+  sex: Sex
+  variationTypes: VariationTypesDDv5
+  yesNoUnknown: YesNoUnknown
+  youthCourts: YouthCourts
+  youthJusticeServiceRegions: YouthJusticeServiceRegions
+}
+
+type ReferenceCatalog = ReferenceCatalogDDv4 | ReferenceCatalogDDv5
+
 export default ReferenceCatalog
+
+export { ReferenceCatalogDDv4, ReferenceCatalogDDv5 }

--- a/test/mocks/mockExpress.ts
+++ b/test/mocks/mockExpress.ts
@@ -1,5 +1,7 @@
 import type { Request, Response } from 'express'
 import getContent from '../../server/i18n'
+import { DataDictionaryVersions } from '../../server/types/i18n/dataDictionaryVersion'
+import { Locales } from '../../server/types/i18n/locale'
 
 export const createMockRequest = (
   overrideProperties: Partial<Request> = { params: { orderId: '123456789' } },
@@ -22,7 +24,7 @@ export const createMockResponse = (): Response => {
   // @ts-expect-error stubbing res.render
   return {
     locals: {
-      content: getContent('en', 'DDv4'),
+      content: getContent(Locales.en, DataDictionaryVersions.DDv4),
       user: {
         username: 'fakeUserName',
         token: 'fakeUserToken',

--- a/test/mocks/mockExpress.ts
+++ b/test/mocks/mockExpress.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express'
-import i18n from '../../server/i18n'
+import getContent from '../../server/i18n'
 
 export const createMockRequest = (
   overrideProperties: Partial<Request> = { params: { orderId: '123456789' } },
@@ -22,7 +22,7 @@ export const createMockResponse = (): Response => {
   // @ts-expect-error stubbing res.render
   return {
     locals: {
-      content: i18n.en,
+      content: getContent('en', 'DDv4'),
       user: {
         username: 'fakeUserName',
         token: 'fakeUserToken',


### PR DESCRIPTION
- Changes to the `res.locals.content` ensures that any reference data changes will be propogated through to any views using the data as well as any CYA view models.
- Using the same property names e.g. `prisons` for both the `DDv4` data and the `DDv5` data prevents the need to add custom logic in the views to render the correct version of the data.
