### PR TITLE
New FeatureFlags class: Resolve a deployment error.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ dist
 .vscode-test
 
 # Stores feature flags used at runtime. Created on instantiation of FeatureFlags class.
-data/
+data/*.json
 
 # yarn v2
 .yarn/cache

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Stores feature flags used at runtime. Created on instantiation of FeatureFlags class.
+data/
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,6 @@ COPY --from=build --chown=appuser:appgroup \
 
 # Create writable data directory for feature flags
 RUN mkdir /app/data && chown appuser:appgroup /app/data
-RUN echo '{}' > /app/data/feature-flags.json
-RUN echo '{}' > /app/data/default-feature-flags.json
 
 EXPOSE 3000
 ENV NODE_ENV='production'

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ COPY --from=build --chown=appuser:appgroup \
 
 # Create writable data directory for feature flags
 RUN mkdir /app/data && chown appuser:appgroup /app/data
+RUN echo '{}' > /app/data/feature-flags.json
+RUN echo '{}' > /app/data/default-feature-flags.json
 
 EXPOSE 3000
 ENV NODE_ENV='production'

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,9 @@ COPY --from=build --chown=appuser:appgroup \
 COPY --from=build --chown=appuser:appgroup \
         /app/node_modules ./node_modules
 
+# Create writable data directory for feature flags
+RUN mkdir /app/data && chown appuser:appgroup /app/data
+
 EXPOSE 3000
 ENV NODE_ENV='production'
 USER 2000

--- a/data/default-feature-flags.json
+++ b/data/default-feature-flags.json
@@ -1,6 +1,0 @@
-{
-  "DD_V5_1_ENABLED": true,
-  "MAPPA_ENABLED": true,
-  "MONITORING_CONDITION_TIMES_ENABLED": true,
-  "VARIATIONS_ENABLED": true
-}

--- a/data/feature-flags.json
+++ b/data/feature-flags.json
@@ -1,6 +1,0 @@
-{
-  "DD_V5_1_ENABLED": true,
-  "MAPPA_ENABLED": true,
-  "MONITORING_CONDITION_TIMES_ENABLED": true,
-  "VARIATIONS_ENABLED": true
-}

--- a/server/utils/featureFlags.ts
+++ b/server/utils/featureFlags.ts
@@ -3,20 +3,8 @@ import path from 'path'
 
 type FeatureFlagMap = Record<string, boolean>
 
-const featureFlagDir = path.join(process.cwd(), 'data')
-const featureFlagFilePath = path.join(featureFlagDir, 'feature-flags.json')
-const defaultFeatureFlagFilePath = path.join(featureFlagDir, 'default-feature-flags.json')
-
-// Create data dirctory and feature flag files (if they don't already exist) before the class is instantiated.
-if (!fs.existsSync(featureFlagDir)) {
-  fs.mkdirSync(featureFlagDir)
-}
-if (!fs.existsSync(featureFlagFilePath)) {
-  fs.writeFileSync(featureFlagFilePath, '{}', 'utf-8')
-}
-if (!fs.existsSync(defaultFeatureFlagFilePath)) {
-  fs.writeFileSync(defaultFeatureFlagFilePath, '{}', 'utf-8')
-}
+const featureFlagFilePath = path.join(process.cwd(), 'data', 'feature-flags.json')
+const defaultFeatureFlagFilePath = path.join(process.cwd(), 'data', 'default-feature-flags.json')
 
 export default class FeatureFlags {
   private static instance: FeatureFlags

--- a/server/utils/featureFlags.ts
+++ b/server/utils/featureFlags.ts
@@ -7,7 +7,10 @@ const featureFlagDir = path.join(process.cwd(), 'data')
 const featureFlagFilePath = path.join(featureFlagDir, 'feature-flags.json')
 const defaultFeatureFlagFilePath = path.join(featureFlagDir, 'default-feature-flags.json')
 
-// Create feature flag files (if they don't already exist) before the class is instantiated.
+// Create data dirctory and feature flag files (if they don't already exist) before the class is instantiated.
+if (!fs.existsSync(featureFlagDir)) {
+  fs.mkdirSync(featureFlagDir)
+}
 if (!fs.existsSync(featureFlagFilePath)) {
   fs.writeFileSync(featureFlagFilePath, '{}', 'utf-8')
 }

--- a/server/utils/featureFlags.ts
+++ b/server/utils/featureFlags.ts
@@ -3,8 +3,17 @@ import path from 'path'
 
 type FeatureFlagMap = Record<string, boolean>
 
-const featureFlagFilePath = path.join(process.cwd(), 'data', 'feature-flags.json')
-const defaultFeatureFlagFilePath = path.join(process.cwd(), 'data', 'default-feature-flags.json')
+const featureFlagDir = path.join(process.cwd(), 'data')
+const featureFlagFilePath = path.join(featureFlagDir, 'feature-flags.json')
+const defaultFeatureFlagFilePath = path.join(featureFlagDir, 'default-feature-flags.json')
+
+// Create feature flag files (if they don't already exist) before the class is instantiated.
+if (!fs.existsSync(featureFlagFilePath)) {
+  fs.writeFileSync(featureFlagFilePath, '{}', 'utf-8')
+}
+if (!fs.existsSync(defaultFeatureFlagFilePath)) {
+  fs.writeFileSync(defaultFeatureFlagFilePath, '{}', 'utf-8')
+}
 
 export default class FeatureFlags {
   private static instance: FeatureFlags

--- a/server/utils/featureFlags.ts
+++ b/server/utils/featureFlags.ts
@@ -3,8 +3,20 @@ import path from 'path'
 
 type FeatureFlagMap = Record<string, boolean>
 
-const featureFlagFilePath = path.join(process.cwd(), 'data', 'feature-flags.json')
-const defaultFeatureFlagFilePath = path.join(process.cwd(), 'data', 'default-feature-flags.json')
+const featureFlagDir = path.join(process.cwd(), 'data')
+const featureFlagFilePath = path.join(featureFlagDir, 'feature-flags.json')
+const defaultFeatureFlagFilePath = path.join(featureFlagDir, 'default-feature-flags.json')
+
+// Create data dirctory and feature flag files (if they don't already exist) before the class is instantiated.
+if (!fs.existsSync(featureFlagDir)) {
+  fs.mkdirSync(featureFlagDir)
+}
+if (!fs.existsSync(featureFlagFilePath)) {
+  fs.writeFileSync(featureFlagFilePath, '{}', 'utf-8')
+}
+if (!fs.existsSync(defaultFeatureFlagFilePath)) {
+  fs.writeFileSync(defaultFeatureFlagFilePath, '{}', 'utf-8')
+}
 
 export default class FeatureFlags {
   private static instance: FeatureFlags


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3753

Prior work on this ticket is described in [this PR.](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order/pull/346)

The service failed to depoy to the development environment, with error:
`ENOENT: no such file or directory, open '/app/data/feature-flags.json`

### Changes proposed in this pull request

The required feature flag JSON files are created when the FeatureFlags module is first loaded.