### PR TITLE
Integration test improvements

### DIFF
--- a/integration_tests/e2e/order/about-the-device-wearer/device-wearer.page.draft.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/device-wearer.page.draft.cy.ts
@@ -16,29 +16,17 @@ context('About the device wearer', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(AboutDeviceWearerPage, { orderId: mockOrderId })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(AboutDeviceWearerPage, { orderId: mockOrderId })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the device wearer', () => {
-        const page = Page.visit(AboutDeviceWearerPage, { orderId: mockOrderId })
-
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
         page.form.shouldNotBeDisabled()
         page.errorSummary.shouldNotExist()
         page.backButton.should('exist')
-      })
-
-      it('Should be accessible', () => {
-        const page = Page.visit(AboutDeviceWearerPage, { orderId: mockOrderId })
         page.checkIsAccessible()
+        page.form.shouldHaveAllOptions()
       })
     })
 

--- a/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.page.draft.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.page.draft.cy.ts
@@ -16,28 +16,15 @@ context('About the device wearer', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the identity numbers', () => {
-        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
-
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
         page.form.shouldNotBeDisabled()
         page.backButton.should('exist')
         page.errorSummary.shouldNotExist()
-      })
-
-      it('Should be accessible', () => {
-        const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
         page.checkIsAccessible()
       })
     })

--- a/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
@@ -17,23 +17,15 @@ context('About the device wearer - Responsible Adult', () => {
       cy.signIn()
     })
 
-    it('Should display the user name visible in header', () => {
+    it('Should display contents', () => {
       const page = Page.visit(ResponsibleAdultPage, { orderId: mockOrderId })
       page.header.userName().should('contain.text', 'J. Smith')
-    })
-
-    it('Should display the phase banner in header', () => {
-      const page = Page.visit(ResponsibleAdultPage, { orderId: mockOrderId })
       page.header.phaseBanner().should('contain.text', 'dev')
-    })
-
-    it('Should render the save and continue/return buttons', () => {
-      const page = Page.visit(ResponsibleAdultPage, { orderId: mockOrderId })
-
       page.form.saveAndContinueButton.should('exist')
       page.form.saveAndReturnButton.should('exist')
       page.backButton.should('exist')
       page.errorSummary.shouldNotExist()
+      page.form.shouldHaveAllOptions()
     })
 
     // TODO: FAIL there are two form input related issues

--- a/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.page.draft.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.page.draft.cy.ts
@@ -16,29 +16,17 @@ context('Access needs and installation risk information', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(InstallationAndRiskPage, { orderId: mockOrderId })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(InstallationAndRiskPage, { orderId: mockOrderId })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the identity numbers', () => {
-        const page = Page.visit(InstallationAndRiskPage, { orderId: mockOrderId })
-
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
         page.form.shouldNotBeDisabled()
         page.errorSummary.shouldNotExist()
         page.backButton.should('exist')
-      })
-
-      it('Should be accessible', () => {
-        const page = Page.visit(InstallationAndRiskPage, { orderId: mockOrderId })
         page.checkIsAccessible()
+        page.form.shouldHaveAllOptions()
       })
 
       context('With MAPPA disabled', () => {

--- a/integration_tests/e2e/order/attachments/delete-licence.page.draft.cy.ts
+++ b/integration_tests/e2e/order/attachments/delete-licence.page.draft.cy.ts
@@ -28,10 +28,8 @@ context('Attachments', () => {
         page.form.deleteButton.should('exist')
         page.form.backButton.should('exist')
         page.backButton.should('exist')
-      })
 
-      it('Should be accessible', () => {
-        const page = Page.visit(DeleteLicencePage, { orderId: mockOrderId })
+        // Accessible
         page.checkIsAccessible()
       })
     })

--- a/integration_tests/e2e/order/attachments/delete-photo-id.page.draft.cy.ts
+++ b/integration_tests/e2e/order/attachments/delete-photo-id.page.draft.cy.ts
@@ -28,10 +28,7 @@ context('Attachments', () => {
         page.form.deleteButton.should('exist')
         page.form.backButton.should('exist')
         page.backButton.should('exist')
-      })
 
-      it('Should be accessible', () => {
-        const page = Page.visit(DeletePhotoIdPage, { orderId: mockOrderId })
         page.checkIsAccessible()
       })
     })

--- a/integration_tests/e2e/order/contact-information/contact-details.page.cy.ts
+++ b/integration_tests/e2e/order/contact-information/contact-details.page.cy.ts
@@ -17,21 +17,14 @@ context('Contact details - Contact information', () => {
       cy.signIn()
     })
 
-    it('Should display the user name visible in header', () => {
+    it('Should display contents', () => {
       const page = Page.visit(ContactDetailsPage, { orderId: mockOrderId })
       page.header.userName().should('contain.text', 'J. Smith')
-    })
-
-    it('Should display the phase banner in header', () => {
-      const page = Page.visit(ContactDetailsPage, { orderId: mockOrderId })
       page.header.phaseBanner().should('contain.text', 'dev')
-    })
-
-    it('Should render the save and continue/return buttons', () => {
-      const page = Page.visit(ContactDetailsPage, { orderId: mockOrderId })
 
       page.form.saveAndContinueButton.should('exist')
       page.form.saveAndReturnButton.should('exist')
+
       page.backButton.should('exist')
       page.errorSummary.shouldNotExist()
     })

--- a/integration_tests/e2e/order/contact-information/interested-parties.page.draft.cy.ts
+++ b/integration_tests/e2e/order/contact-information/interested-parties.page.draft.cy.ts
@@ -16,28 +16,18 @@ context('Contact information', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(InterestedPartiesPage, { orderId: mockOrderId })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(InterestedPartiesPage, { orderId: mockOrderId })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the interested parites details', () => {
-        const page = Page.visit(InterestedPartiesPage, { orderId: mockOrderId })
 
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
         page.form.shouldNotBeDisabled()
         page.errorSummary.shouldNotExist()
         page.backButton.should('exist')
-      })
+        page.form.shouldHaveAllOptions()
 
-      it('Should be accessible', () => {
-        const page = Page.visit(InterestedPartiesPage, { orderId: mockOrderId })
         page.checkIsAccessible()
       })
     })

--- a/integration_tests/e2e/order/contact-information/no-fixed-abode.page.draft.cy.ts
+++ b/integration_tests/e2e/order/contact-information/no-fixed-abode.page.draft.cy.ts
@@ -16,24 +16,17 @@ context('Contact information', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(NoFixedAbodePage, { orderId: mockOrderId })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(NoFixedAbodePage, { orderId: mockOrderId })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the no fixed abode details', () => {
-        const page = Page.visit(NoFixedAbodePage, { orderId: mockOrderId })
 
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
         page.form.shouldNotBeDisabled()
         page.errorSummary.shouldNotExist()
         page.backButton.should('exist')
+        page.form.shouldHaveAllOptions()
       })
 
       // TODO: FAIL issue determining if autocomplete is valid

--- a/integration_tests/e2e/order/contact-information/primary-address.page.draft.cy.ts
+++ b/integration_tests/e2e/order/contact-information/primary-address.page.draft.cy.ts
@@ -16,27 +16,13 @@ context('Contact information', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(PrimaryAddressPage, {
           orderId: mockOrderId,
           'addressType(primary|secondary|tertiary)': 'primary',
         })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(PrimaryAddressPage, {
-          orderId: mockOrderId,
-          'addressType(primary|secondary|tertiary)': 'primary',
-        })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the primary address details', () => {
-        const page = Page.visit(PrimaryAddressPage, {
-          orderId: mockOrderId,
-          'addressType(primary|secondary|tertiary)': 'primary',
-        })
 
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
@@ -50,6 +36,7 @@ context('Contact information', () => {
         page.form.postcodeField.shouldHaveValue('')
         page.errorSummary.shouldNotExist()
         page.backToSummaryButton.should('not.exist')
+        page.form.shouldHaveAllOptions()
       })
 
       // TODO: FAIL issue determining if autocomplete is valid

--- a/integration_tests/e2e/order/contact-information/secondary-address.page.draft.cy.ts
+++ b/integration_tests/e2e/order/contact-information/secondary-address.page.draft.cy.ts
@@ -16,27 +16,13 @@ context('Contact information', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(SecondaryAddressPage, {
           orderId: mockOrderId,
           'addressType(primary|secondary|tertiary)': 'secondary',
         })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(SecondaryAddressPage, {
-          orderId: mockOrderId,
-          'addressType(primary|secondary|tertiary)': 'secondary',
-        })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the secondary address details', () => {
-        const page = Page.visit(SecondaryAddressPage, {
-          orderId: mockOrderId,
-          'addressType(primary|secondary|tertiary)': 'secondary',
-        })
 
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
@@ -50,6 +36,7 @@ context('Contact information', () => {
         page.form.postcodeField.shouldHaveValue('')
         page.backToSummaryButton.should('not.exist')
         page.errorSummary.shouldNotExist()
+        page.form.shouldHaveAllOptions()
       })
 
       // TODO: FAIL issue determining if autocomplete is valid

--- a/integration_tests/e2e/order/contact-information/tertiary-address.page.draft.cy.ts
+++ b/integration_tests/e2e/order/contact-information/tertiary-address.page.draft.cy.ts
@@ -16,27 +16,13 @@ context('Contact information', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(TertiaryAddressPage, {
           orderId: mockOrderId,
           'addressType(primary|secondary|tertiary)': 'tertiary',
         })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(TertiaryAddressPage, {
-          orderId: mockOrderId,
-          'addressType(primary|secondary|tertiary)': 'tertiary',
-        })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the tertiary address details', () => {
-        const page = Page.visit(TertiaryAddressPage, {
-          orderId: mockOrderId,
-          'addressType(primary|secondary|tertiary)': 'tertiary',
-        })
 
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
@@ -55,6 +41,7 @@ context('Contact information', () => {
         page.form.postcodeField.shouldHaveValue('')
         page.backToSummaryButton.should('not.exist')
         page.errorSummary.shouldNotExist()
+        page.form.shouldHaveAllOptions()
       })
 
       // TODO: FAIL issue determining if autocomplete is valid

--- a/integration_tests/e2e/order/contact-information/tertiary-address.page.draft.cy.ts
+++ b/integration_tests/e2e/order/contact-information/tertiary-address.page.draft.cy.ts
@@ -40,7 +40,7 @@ context('Contact information', () => {
         page.form.addressLine4Field.shouldHaveValue('')
         page.form.postcodeField.shouldHaveValue('')
         page.backToSummaryButton.should('not.exist')
-        page.errorSummary.shouldNotExist()       
+        page.errorSummary.shouldNotExist()
       })
 
       // TODO: FAIL issue determining if autocomplete is valid

--- a/integration_tests/e2e/order/contact-information/tertiary-address.page.draft.cy.ts
+++ b/integration_tests/e2e/order/contact-information/tertiary-address.page.draft.cy.ts
@@ -40,8 +40,7 @@ context('Contact information', () => {
         page.form.addressLine4Field.shouldHaveValue('')
         page.form.postcodeField.shouldHaveValue('')
         page.backToSummaryButton.should('not.exist')
-        page.errorSummary.shouldNotExist()
-        page.form.shouldHaveAllOptions()
+        page.errorSummary.shouldNotExist()       
       })
 
       // TODO: FAIL issue determining if autocomplete is valid

--- a/integration_tests/e2e/order/monitoring-conditions/alcoholMonitoring.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/alcoholMonitoring.cy.ts
@@ -50,6 +50,7 @@ context('Alcohol monitoring', () => {
       const page = Page.verifyOnPage(AlcoholMonitoringPage)
       page.header.userName().should('contain.text', 'J. Smith')
       page.errorSummary.shouldNotExist()
+      page.form.shouldHaveAllOptions()
     })
   })
 

--- a/integration_tests/e2e/order/monitoring-conditions/attendanceMonitoring.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/attendanceMonitoring.cy.ts
@@ -107,6 +107,7 @@ context('Attendance monitoring', () => {
       const page = Page.verifyOnPage(AttendanceMonitoringPage)
       page.header.userName().should('contain.text', 'J. Smith')
       page.errorSummary.shouldNotExist()
+      page.form.shouldHaveAllOptions()
     })
   })
 

--- a/integration_tests/e2e/order/monitoring-conditions/curfew-timetable/page.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/curfew-timetable/page.cy.ts
@@ -18,41 +18,19 @@ context('Monitoring conditions - Curfew timetable', () => {
       cy.signIn()
     })
 
-    it('Should display the user name visible in header', () => {
+    it('Should display contents', () => {
       const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
 
       page.header.userName().should('contain.text', 'J. Smith')
-    })
-
-    it('Should display the phase banner in header', () => {
-      const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
-
       page.header.phaseBanner().should('contain.text', 'dev')
-    })
-
-    it('Should not indicate to the user that this is a submitted order', () => {
-      const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
-
       page.submittedBanner.should('not.exist')
-    })
-
-    it('Should allow the user to update the curfew timetable details', () => {
-      const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
 
       page.form.saveAndContinueButton.should('exist')
       page.form.saveAndReturnButton.should('exist')
       page.backButton.should('exist').should('have.attr', 'href', '#')
-    })
-
-    it('Should display the timetable form', () => {
-      const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
 
       page.form.shouldBeDisplayed()
       page.form.shouldBeEmpty()
-    })
-
-    it('Should be accessible', () => {
-      const page = Page.visit(CurfewTimetablePage, { orderId: mockOrderId })
 
       page.checkIsAccessible()
     })

--- a/integration_tests/e2e/order/monitoring-conditions/curfewConditions.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/curfewConditions.cy.ts
@@ -114,6 +114,7 @@ context('Curfew conditions', () => {
       cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/curfew/conditions`)
       const page = Page.verifyOnPage(CurfewConditionsPage)
       page.header.userName().should('contain.text', 'J. Smith')
+      page.form.shouldHaveAllOptions()
       page.errorSummary.shouldNotExist()
     })
   })

--- a/integration_tests/e2e/order/monitoring-conditions/curfewReleaseDate.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/curfewReleaseDate.cy.ts
@@ -138,6 +138,7 @@ context('Curfew monitoring - release date', () => {
       cy.signIn().visit(`/order/${mockOrderId}/monitoring-conditions/curfew/release-date`)
       const page = Page.verifyOnPage(CurfewReleaseDatePage)
       page.header.userName().should('contain.text', 'J. Smith')
+      page.form.shouldHaveAllOptions()
       page.errorSummary.shouldNotExist()
     })
   })

--- a/integration_tests/e2e/order/monitoring-conditions/enforcement-zone.page.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/enforcement-zone.page.cy.ts
@@ -17,28 +17,17 @@ context('Monitoring conditions - Enforcement Zone', () => {
       cy.signIn()
     })
 
-    it('Should display the user name visible in header', () => {
+    it('Should display contents', () => {
       const page = Page.visit(EnforcementZonePage, { orderId: mockOrderId })
       page.header.userName().should('contain.text', 'J. Smith')
-    })
-
-    it('Should display the phase banner in header', () => {
-      const page = Page.visit(EnforcementZonePage, { orderId: mockOrderId })
       page.header.phaseBanner().should('contain.text', 'dev')
-    })
-
-    it('Should render the save and continue/return buttons', () => {
-      const page = Page.visit(EnforcementZonePage, { orderId: mockOrderId })
 
       page.form.saveAndContinueButton.should('exist')
       page.form.saveAndReturnButton.should('exist')
       page.backButton.should('exist')
       page.errorSummary.shouldNotExist()
-    })
+      page.form.shouldHaveAllOptions()
 
-    // TODO: FAIL there is one form input related issues
-    it('Should be accessible', () => {
-      const page = Page.visit(EnforcementZonePage, { orderId: mockOrderId })
       page.checkIsAccessible()
     })
   })

--- a/integration_tests/e2e/order/monitoring-conditions/installation-address.page.draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/installation-address.page.draft.cy.ts
@@ -16,28 +16,13 @@ context('Monitoring conditions', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(InstallationAddressPage, {
           orderId: mockOrderId,
           'addressType(installation)': 'installation',
         })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(InstallationAddressPage, {
-          orderId: mockOrderId,
-          'addressType(installation)': 'installation',
-        })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the installation address details', () => {
-        const page = Page.visit(InstallationAddressPage, {
-          orderId: mockOrderId,
-          'addressType(installation)': 'installation',
-        })
-
         page.form.saveAndContinueButton.should('exist')
         page.form.saveAndReturnButton.should('exist')
         page.form.shouldNotBeDisabled()
@@ -53,6 +38,8 @@ context('Monitoring conditions', () => {
         page.form.addressLine3Field.shouldHaveValue('')
         page.form.addressLine4Field.shouldHaveValue('')
         page.form.postcodeField.shouldHaveValue('')
+        page.form.shouldHaveAllOptions()
+
         page.errorSummary.shouldNotExist()
         page.backToSummaryButton.should('not.exist')
       })

--- a/integration_tests/e2e/order/monitoring-conditions/installation-address.page.draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/installation-address.page.draft.cy.ts
@@ -38,7 +38,6 @@ context('Monitoring conditions', () => {
         page.form.addressLine3Field.shouldHaveValue('')
         page.form.addressLine4Field.shouldHaveValue('')
         page.form.postcodeField.shouldHaveValue('')
-        page.form.shouldHaveAllOptions()
 
         page.errorSummary.shouldNotExist()
         page.backToSummaryButton.should('not.exist')

--- a/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.page.draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.page.draft.cy.ts
@@ -16,24 +16,12 @@ context('Monitoring conditions', () => {
         cy.signIn()
       })
 
-      it('Should display the user name visible in header', () => {
+      it('Should display contents', () => {
         const page = Page.visit(MonitoringConditionsPage, {
           orderId: mockOrderId,
         })
         page.header.userName().should('contain.text', 'J. Smith')
-      })
-
-      it('Should display the phase banner in header', () => {
-        const page = Page.visit(MonitoringConditionsPage, {
-          orderId: mockOrderId,
-        })
         page.header.phaseBanner().should('contain.text', 'dev')
-      })
-
-      it('Should allow the user to update the monitoring conditions', () => {
-        const page = Page.visit(MonitoringConditionsPage, {
-          orderId: mockOrderId,
-        })
 
         page.form.shouldNotBeDisabled()
         page.backButton.should('exist')
@@ -51,14 +39,10 @@ context('Monitoring conditions', () => {
         page.form.hdcField.shouldNotHaveValue()
         page.form.prarrField.shouldNotHaveValue()
         page.form.monitoringRequiredField.shouldNotHaveValue()
-      })
-
-      it('The Alcohol Monitoring checkbox in Condition Type should be disabled', () => {
-        const page = Page.visit(MonitoringConditionsPage, {
-          orderId: mockOrderId,
-        })
 
         page.form.monitoringRequiredField.element.find('input[type=checkbox][value="alcohol"]').should('be.disabled')
+
+        page.form.shouldHaveAllOptions()
       })
 
       // Test disabled because the hint text of the disabled Alcohol Monitoring order type checkbox is too low contrast to meet WCAG 2 AA accessibility standards. This is a known issue in the GOV.UK design system. This test should be enabled again when this design system issue is resolved or the Alcohol Monitoring checkbox is enabled.

--- a/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
@@ -29,7 +29,7 @@ context('Variation', () => {
         page.form.shouldNotBeDisabled()
         page.errorSummary.shouldNotExist()
         page.backButton.should('exist')
-
+        page.form.shouldHaveAllOptions()
         // A11y
         page.checkIsAccessible()
       })

--- a/integration_tests/pages/components/formCheckboxesComponent.ts
+++ b/integration_tests/pages/components/formCheckboxesComponent.ts
@@ -11,8 +11,6 @@ export default class FormCheckboxesComponent {
     private readonly options: string[] | RegExp[],
   ) {
     this.parent.getByLegend(this.label, { log: false }).as(`${this.elementCacheId}-element`)
-
-    this.options.forEach(option => this.shouldHaveOption(option))
   }
 
   get element(): PageElement {
@@ -72,5 +70,9 @@ export default class FormCheckboxesComponent {
 
   shouldNotHaveValidationMessage(): void {
     this.validationMessage.should('not.exist')
+  }
+
+  shouldHaveAllOptions(): void {
+    this.options.forEach(option => this.shouldHaveOption(option))
   }
 }

--- a/integration_tests/pages/components/formRadiosComponent.ts
+++ b/integration_tests/pages/components/formRadiosComponent.ts
@@ -11,8 +11,6 @@ export default class FormRadiosComponent {
     private readonly options: (string | RegExp)[],
   ) {
     this.parent.getByLegend(this.label, { log: false }).as(`${this.elementCacheId}-element`)
-
-    this.options.forEach(option => this.shouldHaveOption(option))
   }
 
   get element(): PageElement {
@@ -61,5 +59,9 @@ export default class FormRadiosComponent {
 
   shouldNotHaveValidationMessage(): void {
     this.validationMessage.should('not.exist')
+  }
+
+  shouldHaveAllOptions(): void {
+    this.options.forEach(option => this.shouldHaveOption(option))
   }
 }

--- a/integration_tests/pages/components/formSelectComponent.ts
+++ b/integration_tests/pages/components/formSelectComponent.ts
@@ -12,8 +12,6 @@ export default class FormSelectComponent {
   ) {
     this.parent.getByLabel(this.label, { log: false }).as(`${this.elementCacheId}-element`)
     this.element.should('exist')
-
-    this.options.forEach(option => this.shouldHaveOption(option))
   }
 
   get element(): PageElement {
@@ -50,5 +48,9 @@ export default class FormSelectComponent {
 
   shouldNotHaveValidationMessage(): void {
     this.validationMessage.should('not.exist')
+  }
+
+  shouldHaveAllOptions(): void {
+    this.options.forEach(option => this.shouldHaveOption(option))
   }
 }

--- a/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerForm.ts
+++ b/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerForm.ts
@@ -305,4 +305,13 @@ export default class AboutDeviceWearerFormComponent extends FormComponent {
     this.interpreterRequiredField.shouldNotBeDisabled()
     this.languageField.shouldNotBeDisabled()
   }
+
+  shouldHaveAllOptions(): void {
+    this.responsibleAdultRequiredField.shouldHaveAllOptions()
+    this.sexField.shouldHaveAllOptions()
+    this.genderIdentityField.shouldHaveAllOptions()
+    this.disabilityField.shouldHaveAllOptions()
+    this.interpreterRequiredField.shouldHaveAllOptions()
+    this.languageField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/about-the-device-wearer/responsibleAdultForm.ts
+++ b/integration_tests/pages/components/forms/about-the-device-wearer/responsibleAdultForm.ts
@@ -53,4 +53,8 @@ export default class ResponsibleAdultFormComponent extends FormComponent {
       this.relationshipDetailsField.set(profile.otherRelationshipDetails)
     }
   }
+
+  shouldHaveAllOptions(): void {
+    this.relationshipField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/access-needs-installation-risk/installationAndRiskForm.ts
+++ b/integration_tests/pages/components/forms/access-needs-installation-risk/installationAndRiskForm.ts
@@ -122,4 +122,11 @@ export default class InstallationAndRiskFormComponent extends FormComponent {
     this.mappaLevelField.shouldNotBeDisabled()
     this.mappaCaseTypeField.shouldNotBeDisabled()
   }
+
+  shouldHaveAllOptions(): void {
+    this.offenceField.shouldHaveAllOptions()
+    this.riskCategoryField.shouldHaveAllOptions()
+    this.mappaLevelField.shouldHaveAllOptions()
+    this.mappaCaseTypeField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/addressForm.ts
+++ b/integration_tests/pages/components/forms/addressForm.ts
@@ -107,4 +107,8 @@ export default class AddressFormComponent extends FormComponent {
       this.hasAnotherAddressField.shouldNotBeDisabled()
     }
   }
+
+  shouldHaveAllOptions(): void {
+    this.hasAnotherAddressField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/contact-information/interestedPartiesForm.ts
+++ b/integration_tests/pages/components/forms/contact-information/interestedPartiesForm.ts
@@ -197,4 +197,11 @@ export default class InterestedPartiesFormComponent extends FormComponent {
     this.responsibleOfficerNameField.shouldNotBeDisabled()
     this.responsibleOfficerContactNumberField.shouldNotBeDisabled()
   }
+
+  shouldHaveAllOptions(): void {
+    this.notifyingOrganisationField.shouldHaveAllOptions()
+    this.responsibleOrganisationField.shouldHaveAllOptions()
+    this.probationRegionField.shouldHaveAllOptions()
+    this.yjsRegionField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/contact-information/noFixedAbodeForm.ts
+++ b/integration_tests/pages/components/forms/contact-information/noFixedAbodeForm.ts
@@ -32,4 +32,8 @@ export default class NoFixedAbodeFormComponent extends FormComponent {
   shouldNotBeDisabled(): void {
     this.hasFixedAddressField.shouldNotBeDisabled()
   }
+
+  shouldHaveAllOptions(): void {
+    this.hasFixedAddressField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/monitoring-conditions/alcoholMonitoringFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoring-conditions/alcoholMonitoringFormComponent.ts
@@ -96,4 +96,9 @@ export default class AlcoholMonitoringFormComponent extends FormComponent {
     this.endDateField.shouldNotBeDisabled()
     this.installLocationField.shouldNotBeDisabled()
   }
+
+  shouldHaveAllOptions(): void {
+    this.monitoringTypeField.shouldHaveAllOptions()
+    this.installLocationField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/monitoring-conditions/attendanceMonitoringFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoring-conditions/attendanceMonitoringFormComponent.ts
@@ -118,4 +118,8 @@ export default class AttendanceMonitoringFormComponent extends FormComponent {
     this.endTimeField.shouldNotBeDisabled()
     this.addressField.shouldNotBeDisabled()
   }
+
+  shouldHaveAllOptions(): void {
+    this.addAnotherField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/monitoring-conditions/curfewConditionsFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoring-conditions/curfewConditionsFormComponent.ts
@@ -54,4 +54,8 @@ export default class CurfewConditionsFormComponent extends FormComponent {
     this.endDateField.shouldBeDisabled()
     this.addressesField.shouldBeDisabled()
   }
+
+  shouldHaveAllOptions(): void {
+    this.addressesField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/monitoring-conditions/curfewReleaseDateFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoring-conditions/curfewReleaseDateFormComponent.ts
@@ -66,4 +66,8 @@ export default class CurfewReleaseDateFormComponent extends FormComponent {
     this.endTimeField.shouldBeDisabled()
     this.addressField.shouldNotHaveValidationMessage()
   }
+
+  shouldHaveAllOptions(): void {
+    this.addressField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/monitoring-conditions/enforcementZoneFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoring-conditions/enforcementZoneFormComponent.ts
@@ -91,4 +91,8 @@ export default class EnforcementZoneFormComponent extends FormComponent {
     // this.anotherZoneField.shouldBeDisabled()
     cy.contains('legend', 'Add another exclusion or inclusion zone?', { log: false }).should('not.exist')
   }
+
+  shouldHaveAllOptions(): void {
+    this.anotherZoneField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/monitoringConditionsFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoringConditionsFormComponent.ts
@@ -186,4 +186,15 @@ export default class MonitoringConditionsFormComponent extends FormComponent {
     this.hdcField.shouldNotBeDisabled()
     this.prarrField.shouldNotBeDisabled()
   }
+
+  shouldHaveAllOptions(): void {
+    this.orderTypeField.shouldHaveAllOptions()
+    this.orderTypeDescriptionField.shouldHaveAllOptions()
+    this.conditionTypeField.shouldHaveAllOptions()
+    this.monitoringRequiredField.shouldHaveAllOptions()
+    this.sentenceTypeField.shouldHaveAllOptions()
+    this.isspField.shouldHaveAllOptions()
+    this.hdcField.shouldHaveAllOptions()
+    this.prarrField.shouldHaveAllOptions()
+  }
 }

--- a/integration_tests/pages/components/forms/variation/variationDetails.ts
+++ b/integration_tests/pages/components/forms/variation/variationDetails.ts
@@ -52,4 +52,8 @@ export default class VariationDetailsFormComponent extends FormComponent {
     this.variationDateField.shouldNotBeDisabled()
     this.variationTypeField.shouldNotBeDisabled()
   }
+
+  shouldHaveAllOptions(): void {
+    this.variationTypeField.shouldHaveAllOptions()
+  }
 }


### PR DESCRIPTION
### Context

The value options are checked every time `formCheckboxesComponent`, `formRadiosComponent`, or `formSelectComponents `is constructed. This is a repetitive check that only needs to happen once.
Most `page.draft` tests load the page multiple times to check that different sections of content are rendered. This causes duplication of page loading and adds processing time for integration tests.
### Changes proposed in this pull request

Refactor `formCheckboxesComponenet`, `formRadiosComponent `and `formSelectComponenets `to have `shouldHaveAllOptions` method to check all options existing on demand.

Refactor all tests to only has single test to check all content is rendered, include check for all options exists by calling page formComponent's shouldHaveAllOptions() method. 
 