### PR TITLE
Unit tests for FeatureFlags class.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --cache --max-warnings 0",
     "lint-fix": "eslint . --cache --max-warnings 0 --fix",
     "typecheck": "tsc && tsc -p integration_tests",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:ci": "jest --runInBand",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "cy:run": "cypress run --config video=false",
@@ -36,6 +36,9 @@
     "npm": "^10"
   },
   "jest": {
+    "setupFiles": [
+      "<rootDir>/test/jest/jest.setup.ts"
+    ],
     "transform": {
       "^.+\\.tsx?$": [
         "ts-jest",

--- a/server/utils/featureFlags.test.ts
+++ b/server/utils/featureFlags.test.ts
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/no-var-requires, global-require */
+
+// NB: Intead of importing FeatureFlags at top of file, it's is imorted with require() in each test so that the module is re-evaluated at the start of each test. This is required for tests checking the behaviour of the module on instantiation.
+
+import path from 'path'
+import fs from 'fs'
+
+const featureFlagFilePath = path.join(process.cwd(), 'data', 'feature-flags.json')
+const defaultFeatureFlagFilePath = path.join(process.cwd(), 'data', 'default-feature-flags.json')
+
+const mockFlags = {
+  DD_V5_1_ENABLED: false,
+  MAPPA_ENABLED: true,
+  MONITORING_CONDITION_TIMES_ENABLED: false,
+  VARIATIONS_ENABLED: true,
+}
+
+jest.mock('fs')
+const mockFs = fs as jest.Mocked<typeof fs>
+mockFs.writeFileSync.mockImplementation(() => {})
+mockFs.readFileSync.mockImplementation(() => JSON.stringify(mockFlags))
+
+describe('FeatureFlags', () => {
+  test('Should act as a singleton', () => {
+    const FeatureFlags = require('./featureFlags').default
+    const instance1 = FeatureFlags.getInstance()
+    const instance2 = FeatureFlags.getInstance()
+
+    expect(instance1).toBe(instance2)
+  })
+
+  test('Should load flags from process.env and write to JSON files', () => {
+    const FeatureFlags = require('./featureFlags').default
+    FeatureFlags.getInstance()
+
+    expect(mockFs.writeFileSync).toHaveBeenCalledWith(featureFlagFilePath, JSON.stringify(mockFlags, null, 2), 'utf-8')
+    expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+      defaultFeatureFlagFilePath,
+      JSON.stringify(mockFlags, null, 2),
+      'utf-8',
+    )
+  })
+
+  test('getAll should return all flags', () => {
+    const FeatureFlags = require('./featureFlags').default
+    const flags = FeatureFlags.getInstance().getAll()
+
+    expect(flags).toEqual(mockFlags)
+  })
+
+  test('get should return the specified flag', () => {
+    const FeatureFlags = require('./featureFlags').default
+
+    const dataDictionaryFlag = FeatureFlags.getInstance().get('DD_V5_1_ENABLED')
+    const mappaFlag = FeatureFlags.getInstance().get('MAPPA_ENABLED')
+
+    expect(dataDictionaryFlag).toBe(false)
+    expect(mappaFlag).toBe(true)
+  })
+
+  test('get should throw if flag is not defined', () => {
+    const FeatureFlags = require('./featureFlags').default
+    const flags = FeatureFlags.getInstance()
+
+    expect(() => flags.get('UNKNOWN_FLAG')).toThrow('Feature flag "UNKNOWN_FLAG" not defined.')
+  })
+})

--- a/test/jest/jest.setup.ts
+++ b/test/jest/jest.setup.ts
@@ -1,0 +1,5 @@
+process.env.FEATURE_FLAG_WRITE_DISABLED = 'true'
+process.env.DD_V5_1_ENABLED = 'false'
+process.env.MAPPA_ENABLED = 'true'
+process.env.MONITORING_CONDITION_TIMES_ENABLED = 'false'
+process.env.VARIATIONS_ENABLED = 'true'


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3753

- Previous work on this ticket is in the ticket comments before [this point](https://dsdmoj.atlassian.net/browse/ELM-3753?focusedCommentId=610983).
- The FeatureFlags class from that work requires unit tests.

### Changes proposed in this pull request

- Create unit tests for the FeatureFlag class.
- Configure Jest to use feature flag env variables defined in `jest.setup.ts`.
- Configure Jest to run tests in sequence locally, to avoid a race condition caused when FeatureFlag is instantiated multiple times. This only very slightly increases unit testing time. Unit testing in deployment is already run in sequence. This race condition should not occur in production, where the FeatureFlags class will only be instantiated once, when the service first starts.