### PR TITLE
Hide field for additional risk categories

### DIFF
--- a/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.cy.ts
@@ -81,10 +81,11 @@ context('installation and risk - check your answers', () => {
           key: 'Any other information to be aware of about the offence committed? (optional)',
           value: 'some offence details',
         },
-        {
-          key: 'At installation what are the possible risks? (optional)',
-          value: 'Offensive towards someone because of their sex or gender',
-        },
+        // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+        // {
+        //   key: 'At installation what are the possible risks? (optional)',
+        //   value: 'Offensive towards someone because of their sex or gender',
+        // },
         { key: 'Any other risks to be aware of? (optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
@@ -157,10 +158,11 @@ context('installation and risk - check your answers', () => {
           key: 'Any other information to be aware of about the offence committed? (optional)',
           value: 'some offence details',
         },
-        {
-          key: 'At installation what are the possible risks? (optional)',
-          value: 'Offensive towards someone because of their sex or gender',
-        },
+        // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+        // {
+        //   key: 'At installation what are the possible risks? (optional)',
+        //   value: 'Offensive towards someone because of their sex or gender',
+        // },
         { key: 'Any other risks to be aware of? (optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
@@ -234,14 +236,22 @@ context('installation and risk - check your answers', () => {
           key: 'Any other information to be aware of about the offence committed? (optional)',
           value: 'some offence details',
         },
-        {
-          key: 'At installation what are the possible risks? (optional)',
-          value: 'Offensive towards someone because of their sex or gender',
-        },
+        // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+        // {
+        //   key: 'At installation what are the possible risks? (optional)',
+        //   value: 'Offensive towards someone because of their sex or gender',
+        // },
         { key: 'Any other risks to be aware of? (optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
       ])
+    })
+
+    // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+    it('does not show the possible risks question', () => {
+      const page = Page.visit(InstallationAndRiskCheckYourAnswersPage, { orderId: mockOrderId }, {}, pageHeading)
+
+      page.installationRiskSection.shouldNotHaveItem('At installation what are the possible risks? (optional)')
     })
 
     it('does not show "change" links', () => {
@@ -296,10 +306,11 @@ context('installation and risk - check your answers', () => {
       page.installationRiskSection.shouldExist()
       page.installationRiskSection.shouldHaveItems([
         { key: 'What type of offence did the device wearer commit? (optional)', value: 'Sexual offences' },
-        {
-          key: 'At installation what are the possible risks? (optional)',
-          value: 'Offensive towards someone because of their sex or gender',
-        },
+        // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+        // {
+        //   key: 'At installation what are the possible risks? (optional)',
+        //   value: 'Offensive towards someone because of their sex or gender',
+        // },
         { key: 'Any other risks to be aware of? (optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },

--- a/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.submission.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.submission.cy.ts
@@ -38,7 +38,8 @@ context('Access needs and installation risk information', () => {
         const validFormData = {
           offence: 'Robbery',
           offenceAdditionalDetails: '',
-          riskCategory: 'Sex offender',
+          // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+          // riskCategory: 'Sex offender',
           riskDetails: '',
           mappaLevel: 'MAPPA 1',
           mappaCaseType: 'Serious Organised Crime',
@@ -52,7 +53,9 @@ context('Access needs and installation risk information', () => {
           body: {
             offence: 'ROBBERY',
             offenceAdditionalDetails: '',
-            riskCategory: ['SEXUAL_OFFENCES'],
+            // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+            // riskCategory: ['SEXUAL_OFFENCES'],
+            riskCategory: null,
             riskDetails: '',
             mappaLevel: 'MAPPA 1',
             mappaCaseType: 'SOC (Serious Organised Crime)',
@@ -65,7 +68,8 @@ context('Access needs and installation risk information', () => {
 
         const validFormData = {
           offence: 'Robbery',
-          riskCategory: 'Sex offender',
+          // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+          // riskCategory: 'Sex offender',
           riskDetails: '',
           mappaLevel: 'MAPPA 1',
           mappaCaseType: 'Serious Organised Crime',
@@ -82,7 +86,8 @@ context('Access needs and installation risk information', () => {
 
         const validFormData = {
           offence: 'Robbery',
-          riskCategory: 'Sex offender',
+          // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+          // riskCategory: 'Sex offender',
           riskDetails: '',
           mappaLevel: 'MAPPA 1',
           mappaCaseType: 'Serious Organised Crime',

--- a/integration_tests/e2e/order/receipt.cy.ts
+++ b/integration_tests/e2e/order/receipt.cy.ts
@@ -121,10 +121,11 @@ context('Receipt', () => {
     page.riskInformationSection.shouldExist()
     page.riskInformationSection.shouldHaveItems([
       { key: 'What type of offence did the device wearer commit? (optional)', value: 'Sexual offences' },
-      {
-        key: 'At installation what are the possible risks? (optional)',
-        value: 'Offensive towards someone because of their sex or gender',
-      },
+      // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+      // {
+      //   key: 'At installation what are the possible risks? (optional)',
+      //   value: 'Offensive towards someone because of their sex or gender',
+      // },
       { key: 'Any other risks to be aware of? (optional)', value: 'Information about potential risks' },
       { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
       { key: 'What is the MAPPA case type? (optional)', value: 'Terrorism Act, Counter Terrorism' },
@@ -251,10 +252,11 @@ context('Receipt when app is submitted', () => {
     page.riskInformationSection.shouldExist()
     page.riskInformationSection.shouldHaveItems([
       { key: 'What type of offence did the device wearer commit? (optional)', value: 'Sexual offences' },
-      {
-        key: 'At installation what are the possible risks? (optional)',
-        value: 'Offensive towards someone because of their sex or gender',
-      },
+      // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+      // {
+      //   key: 'At installation what are the possible risks? (optional)',
+      //   value: 'Offensive towards someone because of their sex or gender',
+      // },
       { key: 'Any other risks to be aware of? (optional)', value: 'Information about potential risks' },
       { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
       { key: 'What is the MAPPA case type? (optional)', value: 'Terrorism Act, Counter Terrorism' },

--- a/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO001 - pre-trial bail - curfew 7pm-10am 7 nights - single photo attachment.cy.ts
+++ b/integration_tests/scenarios/SR01 Adult Device Wearer/Curfew/CEMO001 - pre-trial bail - curfew 7pm-10am 7 nights - single photo attachment.cy.ts
@@ -88,7 +88,9 @@ context('Scenarios', () => {
 
     const installationAndRisk = {
       offence: 'Robbery',
-      riskCategory: 'Sex offender',
+      // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+      // riskCategory: 'Sex offender',
+      riskDetails: '',
       mappaLevel: 'MAPPA 1',
       mappaCaseType: 'Serious Organised Crime',
     }
@@ -181,11 +183,13 @@ context('Scenarios', () => {
           risk_details: '',
           mappa: 'MAPPA 1',
           mappa_case_type: 'SOC (Serious Organised Crime)',
-          risk_categories: [
-            {
-              category: 'Sexual Offences',
-            },
-          ],
+          // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+          // risk_categories: [
+          //   {
+          //     category: 'Sexual Offences',
+          //   },
+          // ],
+          risk_categories: [],
           responsible_adult_required: 'false',
           parent: '',
           guardian: '',

--- a/server/controllers/installationAndRisk/installationAndRiskCheckAnswersController.test.ts
+++ b/server/controllers/installationAndRisk/installationAndRiskCheckAnswersController.test.ts
@@ -62,23 +62,24 @@ describe('InstallationAndRiskCheckAnswersController', () => {
             ],
           },
         },
-        {
-          key: {
-            text: questions.riskCategory.text,
-          },
-          value: {
-            html: '',
-          },
-          actions: {
-            items: [
-              {
-                href: paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK.replace(':orderId', order.id),
-                text: 'Change',
-                visuallyHiddenText: questions.riskCategory.text.toLowerCase(),
-              },
-            ],
-          },
-        },
+        // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+        // {
+        //   key: {
+        //     text: questions.riskCategory.text,
+        //   },
+        //   value: {
+        //     html: '',
+        //   },
+        //   actions: {
+        //     items: [
+        //       {
+        //         href: paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK.replace(':orderId', order.id),
+        //         text: 'Change',
+        //         visuallyHiddenText: questions.riskCategory.text.toLowerCase(),
+        //       },
+        //     ],
+        //   },
+        // },
         {
           key: {
             text: questions.riskDetails.text,
@@ -173,23 +174,24 @@ describe('InstallationAndRiskCheckAnswersController', () => {
             ],
           },
         },
-        {
-          key: {
-            text: questions.riskCategory.text,
-          },
-          value: {
-            html: 'Offensive towards someone because of their sex or gender',
-          },
-          actions: {
-            items: [
-              {
-                href: paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK.replace(':orderId', order.id),
-                text: 'Change',
-                visuallyHiddenText: questions.riskCategory.text.toLowerCase(),
-              },
-            ],
-          },
-        },
+        // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+        // {
+        //   key: {
+        //     text: questions.riskCategory.text,
+        //   },
+        //   value: {
+        //     html: '',
+        //   },
+        //   actions: {
+        //     items: [
+        //       {
+        //         href: paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK.replace(':orderId', order.id),
+        //         text: 'Change',
+        //         visuallyHiddenText: questions.riskCategory.text.toLowerCase(),
+        //       },
+        //     ],
+        //   },
+        // },
         {
           key: {
             text: questions.riskDetails.text,
@@ -284,23 +286,24 @@ describe('InstallationAndRiskCheckAnswersController', () => {
             ],
           },
         },
-        {
-          key: {
-            text: questions.riskCategory.text,
-          },
-          value: {
-            html: 'Offensive towards someone because of their sex or gender',
-          },
-          actions: {
-            items: [
-              {
-                href: paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK.replace(':orderId', order.id),
-                text: 'Change',
-                visuallyHiddenText: questions.riskCategory.text.toLowerCase(),
-              },
-            ],
-          },
-        },
+        // Temporary change until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+        // {
+        //   key: {
+        //     text: questions.riskCategory.text,
+        //   },
+        //   value: {
+        //     html: '',
+        //   },
+        //   actions: {
+        //     items: [
+        //       {
+        //         href: paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK.replace(':orderId', order.id),
+        //         text: 'Change',
+        //         visuallyHiddenText: questions.riskCategory.text.toLowerCase(),
+        //       },
+        //     ],
+        //   },
+        // },
         {
           key: {
             text: questions.riskDetails.text,

--- a/server/models/view-models/riskInformationCheckAnswers.ts
+++ b/server/models/view-models/riskInformationCheckAnswers.ts
@@ -1,4 +1,4 @@
-import { createAnswer, createMultipleChoiceAnswer } from '../../utils/checkYourAnswers'
+import { createAnswer } from '../../utils/checkYourAnswers'
 
 import { Order } from '../Order'
 import I18n from '../../types/i18n'
@@ -29,15 +29,17 @@ const createViewModel = (order: Order, content: I18n, uri: string = '') => {
       ),
     )
   }
-  answers.push(
-    createMultipleChoiceAnswer(
-      questions.riskCategory.text,
-      order.installationAndRisk?.riskCategory?.map(category => lookup(content.reference.riskCategories, category)) ??
-        [],
-      uri,
-      answerOpts,
-    ),
-  )
+  // Temporarily disabled until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
+  // answers.push(
+  //   createMultipleChoiceAnswer(
+  //     questions.riskCategory.text,
+  //     order.installationAndRisk?.riskCategory?.map(category => lookup(content.reference.riskCategories, category)) ??
+  //       [],
+  //     uri,
+  //     answerOpts,
+  //   ),
+  // )
+
   answers.push(createAnswer(questions.riskDetails.text, order.installationAndRisk?.riskDetails, uri, answerOpts))
 
   if (config.mappa.enabled) {

--- a/server/views/pages/order/installation-and-risk/index.njk
+++ b/server/views/pages/order/installation-and-risk/index.njk
@@ -50,22 +50,24 @@
       }) }}
   {% endif %}
  
-  {{ govukCheckboxes({
-    idPrefix: "riskCategory",
-    name: "riskCategory[]",
-    fieldset: {
-      legend: {
-        text: content.pages.installationAndRisk.questions.riskCategory.text,
-        classes: "govuk-fieldset__legend--s"
-      }
-    },
-    hint: {
-      text: content.pages.installationAndRisk.questions.riskCategory.hint
-    },
-    items: content.reference.riskCategories | toOptions(not isOrderEditable),
-    errorMessage: riskCategory.error,
-    values: riskCategory.values
-  }) }}
+  <div class="govuk-form-hidden-items">
+    {{ govukCheckboxes({
+      idPrefix: "riskCategory",
+      name: "riskCategory[]",
+      fieldset: {
+        legend: {
+          text: content.pages.installationAndRisk.questions.riskCategory.text,
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      hint: {
+        text: content.pages.installationAndRisk.questions.riskCategory.hint
+      },
+      items: content.reference.riskCategories | toOptions(not isOrderEditable),
+      errorMessage: riskCategory.error,
+      values: riskCategory.values
+    }) }}
+  </div>
 
   {{ govukTextarea({
     name: "riskDetails",

--- a/server/views/pages/order/installation-and-risk/index.njk
+++ b/server/views/pages/order/installation-and-risk/index.njk
@@ -50,6 +50,7 @@
       }) }}
   {% endif %}
  
+  ## Temporarily disabled until Serco fix their issue: https://dsdmoj.atlassian.net/browse/ELM-3765
   <div class="govuk-form-hidden-items">
     {{ govukCheckboxes({
       idPrefix: "riskCategory",


### PR DESCRIPTION
### Context

The additional risk categories field needs to be temporarily hidden on the CEMO UI to avoid form failures and to allow users to focus on completing risk info in the additional risk details free text field (until Serco fix the additional risk categories issue on the API) 

[https://dsdmoj.atlassian.net/browse/ELM-3765](https://dsdmoj.atlassian.net/browse/ELM-3765)

### Changes proposed in this pull request

Hiding risk categories until a bug is fixed on the serco side
