### PR TITLE
Mandatory monitoring end dates

### DIFF
--- a/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.validation.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/monitoring-conditions.validation.cy.ts
@@ -14,6 +14,7 @@ const errorMessages = {
   startDateMustIncludeMonth: 'Start date for monitoring must include a month',
   startDateMustIncludeYear: 'Start date for monitoring must include a year',
   startDateRequired: 'Enter start date for monitoring',
+  endDateRequired: 'Enter end date for monitoring',
   yearMustIncludeFourNumbers: 'Year must include 4 numbers',
 }
 
@@ -60,6 +61,7 @@ context('Monitoring conditions', () => {
         page.errorSummary.shouldHaveError(errorMessages.conditionTypeRequired)
         page.errorSummary.shouldHaveError(errorMessages.monitoringTypeRequired)
         page.errorSummary.shouldHaveError(errorMessages.startDateRequired)
+        page.errorSummary.shouldHaveError(errorMessages.endDateRequired)
       })
 
       it('should show errors from API response if frontend validation passes', () => {

--- a/integration_tests/pages/components/forms/monitoring-conditions/attendanceMonitoringFormComponent.ts
+++ b/integration_tests/pages/components/forms/monitoring-conditions/attendanceMonitoringFormComponent.ts
@@ -24,7 +24,7 @@ export default class AttendanceMonitoringFormComponent extends FormComponent {
   }
 
   get endDateField(): FormDateComponent {
-    return new FormDateComponent(this.form, 'What date does mandatory attendance monitoring end? (optional)')
+    return new FormDateComponent(this.form, 'What date does mandatory attendance monitoring end?')
   }
 
   get purposeField(): FormInputComponent {

--- a/integration_tests/scenarios/mandatory-field-only.cy.ts
+++ b/integration_tests/scenarios/mandatory-field-only.cy.ts
@@ -94,6 +94,7 @@ context('Mandatory fields only', () => {
     const probationDeliveryUnit = { unit: 'Blackburn' }
     const monitoringConditions = {
       startDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 10), // 10 days
+      endDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 11), // 11 days
       orderType: 'Post Release',
       orderTypeDescription: 'DAPOL HDC',
       conditionType: 'Bail Order',
@@ -369,6 +370,7 @@ context('Mandatory fields only', () => {
     const probationDeliveryUnit = { unit: 'Blackburn' }
     const monitoringConditions = {
       startDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 10), // 10 days
+      endDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 11), // 11 days
       orderType: 'Post Release',
       orderTypeDescription: 'DAPOL HDC',
       conditionType: 'Bail Order',

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -148,7 +148,7 @@ const validationErrors: ValidationErrors = {
     monitoringTypeRequired: 'Select monitoring required',
     orderTypeRequired: 'Select order type',
     startDateTime: getMonitoringConditionStartDateTimeErrorMessages('monitoring'),
-    endDateTime: getMonitoringConditionEndDateTimeErrorMessages('monitoring'),
+    endDateTime: getMonitoringConditionEndDateTimeErrorMessages('monitoring', true),
   },
   monitoringConditionsAlcohol: {
     startDateTime: getMonitoringConditionStartDateTimeErrorMessages('alcohol monitoring'),

--- a/server/controllers/monitoringConditions/checkAnswersController.test.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.test.ts
@@ -87,7 +87,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
           },
           {
             key: {
-              text: 'What is the date when all monitoring ends? (optional)',
+              text: 'What is the date when all monitoring ends?',
             },
             value: {
               text: '',
@@ -97,7 +97,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                 {
                   href: paths.MONITORING_CONDITIONS.BASE_URL.replace(':orderId', order.id),
                   text: 'Change',
-                  visuallyHiddenText: 'what is the date when all monitoring ends? (optional)',
+                  visuallyHiddenText: 'what is the date when all monitoring ends?',
                 },
               ],
             },
@@ -491,7 +491,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
           },
           {
             key: {
-              text: 'What is the date when all monitoring ends? (optional)',
+              text: 'What is the date when all monitoring ends?',
             },
             value: {
               text: '11/11/2024',
@@ -501,7 +501,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                 {
                   href: paths.MONITORING_CONDITIONS.BASE_URL.replace(':orderId', order.id),
                   text: 'Change',
-                  visuallyHiddenText: 'what is the date when all monitoring ends? (optional)',
+                  visuallyHiddenText: 'what is the date when all monitoring ends?',
                 },
               ],
             },
@@ -1079,7 +1079,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
             },
             {
               key: {
-                text: 'What date does mandatory attendance monitoring end? (optional)',
+                text: 'What date does mandatory attendance monitoring end?',
               },
               value: {
                 text: '11/01/2025',
@@ -1092,7 +1092,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                       conditionId,
                     ),
                     text: 'Change',
-                    visuallyHiddenText: 'what date does mandatory attendance monitoring end? (optional)',
+                    visuallyHiddenText: 'what date does mandatory attendance monitoring end?',
                   },
                 ],
               },
@@ -1457,7 +1457,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
           },
           {
             key: {
-              text: 'What is the date when all monitoring ends? (optional)',
+              text: 'What is the date when all monitoring ends?',
             },
             value: {
               text: '11/11/2024',
@@ -1467,7 +1467,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                 {
                   href: paths.MONITORING_CONDITIONS.BASE_URL.replace(':orderId', order.id),
                   text: 'Change',
-                  visuallyHiddenText: 'what is the date when all monitoring ends? (optional)',
+                  visuallyHiddenText: 'what is the date when all monitoring ends?',
                 },
               ],
             },
@@ -2028,7 +2028,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
             },
             {
               key: {
-                text: 'What date does mandatory attendance monitoring end? (optional)',
+                text: 'What date does mandatory attendance monitoring end?',
               },
               value: {
                 text: '11/01/2025',
@@ -2041,7 +2041,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
                       conditionId,
                     ),
                     text: 'Change',
-                    visuallyHiddenText: 'what date does mandatory attendance monitoring end? (optional)',
+                    visuallyHiddenText: 'what date does mandatory attendance monitoring end?',
                   },
                 ],
               },

--- a/server/i18n/en/pages/attendance.ts
+++ b/server/i18n/en/pages/attendance.ts
@@ -15,7 +15,7 @@ const attendancePageContent: AttendancePageContent = {
       hint: 'For example, fortnightly on Mondays. Only include one day and frequency, if the same type of appointment occurs on another day on the same week enter this as a separate appointment.',
     },
     endDate: {
-      text: 'What date does mandatory attendance monitoring end? (optional)',
+      text: 'What date does mandatory attendance monitoring end?',
       hint: 'For example, 21 05 2025',
     },
     endTime: {

--- a/server/i18n/en/pages/monitoringConditions.ts
+++ b/server/i18n/en/pages/monitoringConditions.ts
@@ -8,7 +8,7 @@ const monitoringConditionsPageContent: MonitoringConditionsPageContent = {
       text: 'What are the order type conditions?',
     },
     endDate: {
-      text: 'What is the date when all monitoring ends? (optional)',
+      text: 'What is the date when all monitoring ends?',
       hint: 'For example, 21 5 2029. If more than one type of monitoring is required, provide the date when all monitoring finishes.',
     },
     endTime: {


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3801

FMS mandates that monitoring end dates are provided.
These changes makes one such field mandatory and changes messaging in the UI.
  
### Changes proposed in this pull request

- The End Date field of the Monitoring Conditions page is now mandatory, with input validation.
- Specific End Date field labels are updated; the text '(optional)' is removed.