### PR TITLE
ELM-3820: Add phase 2 prison agency ids to ACTIVE_AGENCIES list

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-create-an-order/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-create-an-order/values.yaml
@@ -36,7 +36,7 @@ generic-service:
     AUDIT_SERVICE_NAME: 'HMPPS529' # Your audit service name
     VARIATIONS_ENABLED: 'true'
     MAPPA_ENABLED: 'false'
-    ACTIVE_AGENCIES: 'DNI,WEI'
+    ACTIVE_AGENCIES: 'DNI,WEI,HDI,HLI,HMI,LEI,LHI,MDI'
     GOTENBERG_API_URL: http://hmpps-electronic-monitoring-create-an-order-gotenberg
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/4473?selectedIssue=ELM-3820


[What has been changed?]

Add phase 2 prison agency ids to ACTIVE_AGENCIES list

List of phase 2 prisons:
Hatfield
Hull
Humber
Leeds
Lindholme
Moorland