### PR TITLE
fix: ensure gotenberg shares same network as other services in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
   gotenberg:
     image: gotenberg/gotenberg:8
     networks:
-      - hmpps_int
+      - hmpps
     container_name: gotenberg
     ports:
       - "3001:3000"


### PR DESCRIPTION
align network between services in docker-compose