### PR TITLE
Parallelise integration tests in circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
 
   integration_test:
     executor: intgration-testing
+    parallelism: 4
     environment:
       TZ: Europe/London
     steps:
@@ -145,7 +146,7 @@ jobs:
           command: sleep 5
       - run:
           name: integration tests
-          command: npm run int-test
+          command: npm run int-test:parallel
       - store_test_results:
           path: test_results
       - store_artifacts:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cy:run": "cypress run --config video=false",
     "cy:open": "cypress open --e2e --browser chrome",
     "int-test": "npm run cy:run -- --spec 'integration_tests/e2e/**/*'",
-    "int-test:parallel": "cypress-parallel -s cy:run -t 4 -d 'integration_tests/e2e/**/*' -a '\"--spec 'integration_tests/e2e/**/*'\"'",
+    "int-test:parallel": "npm run cy:run -- --spec 'integration_tests/e2e/**/*' --env split=true,spec=integration_tests/e2e/**/*",
     "int-test-scenarios": "npm run cy:run -- --spec 'integration_tests/scenarios/**/*'",
     "int-test-scenarios:parallel": "npm run cy:run -- --spec 'integration_tests/scenarios/**/*' --env split=true,spec=integration_tests/scenarios/**/*",
     "int-test-ui": "npm run cy:open",


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3886

### Changes proposed in this pull request

- Parallelise integration tests to accelerate ci/cd.
- The new parallel integration test command `int-test:parallel`  replaces an existing command in package.json of the same name, which I believe was unused.
