### PR TITLE
ELM-3922:Refactor to use character count instead of text area for risk details

### DIFF
--- a/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.page.validation.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.page.validation.cy.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid'
+import { fakerEN_GB as faker } from '@faker-js/faker'
 import Page from '../../../pages/page'
 import InstallationAndRiskPage from '../../../pages/order/installationAndRisk'
 
@@ -80,6 +81,32 @@ context('Access needs and installation risk information', () => {
         Page.verifyOnPage(InstallationAndRiskPage)
         page.form.riskDetailsField.shouldHaveValidationMessage('Enter any other risks to be aware of')
         page.errorSummary.shouldHaveError('Enter any other risks to be aware of')
+      })
+
+      it('should display error message when risk details is longer than 200 charactger', () => {
+        const page = Page.visit(InstallationAndRiskPage, { orderId: mockOrderId })
+
+        const validFormData = {
+          offence: 'Robbery',
+          riskCategory: 'History of substance abuse',
+          riskDetails: faker.string.fromCharacters(
+            'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
+            201,
+          ),
+          mappaLevel: 'MAPPA 1',
+          mappaCaseType: 'Serious Organised Crime',
+          possibleRisk: 'Sex offender',
+        }
+
+        page.form.fillInWith(validFormData)
+        page.form.riskDetailsField.shouldHaveValidationMessage('You have 1 character too many')
+        page.form.saveAndContinueButton.click()
+
+        Page.verifyOnPage(InstallationAndRiskPage)
+        page.form.riskDetailsField.shouldHaveValidationMessage(
+          'Any other risks to be aware of must be 350 characters or less',
+        )
+        page.errorSummary.shouldHaveError('Any other risks to be aware of must be 350 characters or less')
       })
     })
   })

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -71,6 +71,7 @@ interface ValidationErrors {
   installationAndRisk: {
     possibleRiskRequired: string
     riskDetailsRequired: string
+    riskDetailsTooLong: string
   }
 }
 
@@ -238,6 +239,7 @@ const validationErrors: ValidationErrors = {
   installationAndRisk: {
     possibleRiskRequired: "Select all the possible risks from the device wearer's behaviour",
     riskDetailsRequired: 'Enter any other risks to be aware of',
+    riskDetailsTooLong: 'Any other risks to be aware of must be 200 characters or less',
   },
 }
 

--- a/server/models/form-data/installationAndRisk.ts
+++ b/server/models/form-data/installationAndRisk.ts
@@ -22,7 +22,10 @@ const InstallationAndRiskFormDataValidator = z
     offence: z.string().nullable(),
     offenceAdditionalDetails: z.string(),
     riskCategory: z.array(z.string()),
-    riskDetails: z.string().min(1, validationErrors.installationAndRisk.riskDetailsRequired),
+    riskDetails: z
+      .string()
+      .min(1, validationErrors.installationAndRisk.riskDetailsRequired)
+      .max(200, validationErrors.installationAndRisk.riskDetailsTooLong),
     mappaLevel: z.string().nullable(),
     mappaCaseType: z.string().nullable(),
   })

--- a/server/views/pages/order/installation-and-risk/index.njk
+++ b/server/views/pages/order/installation-and-risk/index.njk
@@ -7,6 +7,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% set section = content.pages.installationAndRisk.section %}
@@ -85,19 +86,23 @@
       values: riskCategory.values
     }) }}
 </div>
-  {{ govukTextarea({
+ 
+{% set isDisabled = {} if isOrderEditable else { disabled: true } %}
+  {{ govukCharacterCount({
     name: "riskDetails",
     id: "riskDetails",
-    value: riskDetails.value,
-    errorMessage: riskDetails.error,
-    disabled: not isOrderEditable,
+    maxlength: 200,
     label: {
       text: content.pages.installationAndRisk.questions.riskDetails.text,
-      classes: "govuk-label--s"
+      classes: "govuk-label--s",
+      isPageHeading: false
     },
     hint: {
       text: content.pages.installationAndRisk.questions.riskDetails.hint
-    }
+    },
+    value: riskDetails.value,
+    errorMessage: riskDetails.error,
+    attributes: isDisabled
   }) }}
 
   {% if mappaEnabled %}


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/4473?selectedIssue=ELM-3922

Refactor to use govukCharacterCount for risk details input, and set limit of 200 characters