### PR TITLE
License upload: Set permitted file formats and max size

### DIFF
--- a/server/i18n/en/pages/uploadLicence.ts
+++ b/server/i18n/en/pages/uploadLicence.ts
@@ -6,7 +6,7 @@ const uploadLicencePageContent: UploadDocumentPageContent = {
   questions: {
     file: {
       text: 'Upload a copy of the licence',
-      hint: 'Upload a scanned copy or photo of the original licence document. The file must be a PDF, PNG, JPEG or JPG and under 10MB in size.',
+      hint: 'Upload a scanned copy or photo of the original licence document. The file must be a PDF or Word document and under 25MB in size.',
     },
   },
   section: 'Additional documents',


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3952

For uploading a license in the Additional Documents section:
- Max file size is changed to 25MB
- Permitted file formats are changed to PDF, DOC & DOCX

### Changes proposed in this pull request

The only frontend change at this time is updating the hint text for the license upload field.
Validation is implemented in the backend.