### PR TITLE
Elm-3968: risk page issues

### DIFF
--- a/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.cy.ts
@@ -92,7 +92,7 @@ context('installation and risk - check your answers', () => {
           key: "At installation what are the possible risks from the device wearer's behaviour?",
           value: 'Offensive towards someone because of their sex or gender',
         },
-        { key: 'Any other risks to be aware of?(optional)', value: 'some risk details' },
+        { key: 'Any other risks to be aware of? (optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
       ])
@@ -177,7 +177,7 @@ context('installation and risk - check your answers', () => {
           key: 'At installation what are the possible risks at the installation address? (optional)',
           value: 'History of substance abuse',
         },
-        { key: 'Any other risks to be aware of?(optional)', value: 'some risk details' },
+        { key: 'Any other risks to be aware of? (optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
       ])
@@ -255,7 +255,7 @@ context('installation and risk - check your answers', () => {
           key: "At installation what are the possible risks from the device wearer's behaviour?",
           value: 'Offensive towards someone because of their sex or gender',
         },
-        { key: 'Any other risks to be aware of?(optional)', value: 'some risk details' },
+        { key: 'Any other risks to be aware of? (optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
       ])

--- a/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/check-your-answers.cy.ts
@@ -92,7 +92,7 @@ context('installation and risk - check your answers', () => {
           key: "At installation what are the possible risks from the device wearer's behaviour?",
           value: 'Offensive towards someone because of their sex or gender',
         },
-        { key: 'Any other risks to be aware of?', value: 'some risk details' },
+        { key: 'Any other risks to be aware of?(optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
       ])
@@ -177,7 +177,7 @@ context('installation and risk - check your answers', () => {
           key: 'At installation what are the possible risks at the installation address? (optional)',
           value: 'History of substance abuse',
         },
-        { key: 'Any other risks to be aware of?', value: 'some risk details' },
+        { key: 'Any other risks to be aware of?(optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
       ])
@@ -255,7 +255,7 @@ context('installation and risk - check your answers', () => {
           key: "At installation what are the possible risks from the device wearer's behaviour?",
           value: 'Offensive towards someone because of their sex or gender',
         },
-        { key: 'Any other risks to be aware of?', value: 'some risk details' },
+        { key: 'Any other risks to be aware of?(optional)', value: 'some risk details' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Serious Organised Crime' },
       ])

--- a/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.page.draft.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.page.draft.cy.ts
@@ -29,6 +29,27 @@ context('Access needs and installation risk information', () => {
         page.form.shouldHaveAllOptions()
       })
 
+      it('Should uncheck other options when no risk options is selected for possible risk ', () => {
+        const page = Page.visit(InstallationAndRiskPage, { orderId: mockOrderId })
+
+        page.form.fillInWith({
+          possibleRisk: 'Sex offender',
+        })
+        page.form.possibleRiskField.shouldHaveValue('Sex offender')
+        page.form.fillInWith({
+          possibleRisk: 'Violent behaviour or threats of violence',
+        })
+        page.form.possibleRiskField.shouldHaveValue('Sex offender')
+        page.form.possibleRiskField.shouldHaveValue('Violent behaviour or threats of violence')
+
+        page.form.fillInWith({
+          possibleRisk: 'There are no risks that the installer should be aware of',
+        })
+        page.form.possibleRiskField.shouldHaveValue('There are no risks that the installer should be aware of')
+        page.form.possibleRiskField.shouldNotHaveValueChekced('Sex offender')
+        page.form.possibleRiskField.shouldNotHaveValueChekced('Violent behaviour or threats of violence')
+      })
+
       context('With MAPPA disabled', () => {
         const testFlags = { MAPPA_ENABLED: false }
         beforeEach(() => {

--- a/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.page.validation.cy.ts
+++ b/integration_tests/e2e/order/access-needs-installation-risk/installation-and-risk.page.validation.cy.ts
@@ -44,25 +44,6 @@ context('Access needs and installation risk information', () => {
         page.errorSummary.shouldHaveError("Select all the possible risks from the device wearer's behaviour")
       })
 
-      it('should display error when no riskDetails selected', () => {
-        const page = Page.visit(InstallationAndRiskPage, { orderId: mockOrderId })
-
-        const validFormData = {
-          offence: 'Robbery',
-          possibleRisk: 'Sex offender',
-          riskDetails: '',
-          mappaLevel: 'MAPPA 1',
-          mappaCaseType: 'Serious Organised Crime',
-        }
-
-        page.form.fillInWith(validFormData)
-        page.form.saveAndContinueButton.click()
-
-        Page.verifyOnPage(InstallationAndRiskPage)
-        page.form.riskDetailsField.shouldHaveValidationMessage('Enter any other risks to be aware of')
-        page.errorSummary.shouldHaveError('Enter any other risks to be aware of')
-      })
-
       it('should display error message', () => {
         const page = Page.visit(InstallationAndRiskPage, { orderId: mockOrderId })
 

--- a/integration_tests/e2e/order/receipt.cy.ts
+++ b/integration_tests/e2e/order/receipt.cy.ts
@@ -152,7 +152,7 @@ context('Receipt', () => {
           key: "At installation what are the possible risks from the device wearer's behaviour?",
           value: 'Offensive towards someone because of their sex or gender',
         },
-        { key: 'Any other risks to be aware of?', value: 'Information about potential risks' },
+        { key: 'Any other risks to be aware of?(optional)', value: 'Information about potential risks' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Terrorism Act, Counter Terrorism' },
       ])

--- a/integration_tests/e2e/order/receipt.cy.ts
+++ b/integration_tests/e2e/order/receipt.cy.ts
@@ -152,7 +152,7 @@ context('Receipt', () => {
           key: "At installation what are the possible risks from the device wearer's behaviour?",
           value: 'Offensive towards someone because of their sex or gender',
         },
-        { key: 'Any other risks to be aware of?(optional)', value: 'Information about potential risks' },
+        { key: 'Any other risks to be aware of? (optional)', value: 'Information about potential risks' },
         { key: 'Which level of MAPPA applies? (optional)', value: 'MAPPA 1' },
         { key: 'What is the MAPPA case type? (optional)', value: 'Terrorism Act, Counter Terrorism' },
       ])

--- a/integration_tests/pages/components/formCheckboxesComponent.ts
+++ b/integration_tests/pages/components/formCheckboxesComponent.ts
@@ -28,6 +28,10 @@ export default class FormCheckboxesComponent {
     this.element.getByLabel(value).should('be.checked')
   }
 
+  shouldNotHaveValueChekced(value: string | RegExp): void {
+    this.element.getByLabel(value).should('not.be.checked')
+  }
+
   shouldNotHaveValue(): void {
     this.options.forEach(option => this.element.getByLabel(option).should('not.be.checked'))
   }

--- a/integration_tests/pages/components/forms/access-needs-installation-risk/installationAndRiskForm.ts
+++ b/integration_tests/pages/components/forms/access-needs-installation-risk/installationAndRiskForm.ts
@@ -66,7 +66,7 @@ export default class InstallationAndRiskFormComponent extends FormComponent {
   }
 
   get riskDetailsField(): FormTextareaComponent {
-    const label = 'Any other risks to be aware of?'
+    const label = 'Any other risks to be aware of?(optional)'
     return new FormTextareaComponent(this.form, label)
   }
 

--- a/integration_tests/pages/components/forms/access-needs-installation-risk/installationAndRiskForm.ts
+++ b/integration_tests/pages/components/forms/access-needs-installation-risk/installationAndRiskForm.ts
@@ -66,7 +66,7 @@ export default class InstallationAndRiskFormComponent extends FormComponent {
   }
 
   get riskDetailsField(): FormTextareaComponent {
-    const label = 'Any other risks to be aware of?(optional)'
+    const label = 'Any other risks to be aware of? (optional)'
     return new FormTextareaComponent(this.form, label)
   }
 

--- a/server/controllers/installationAndRisk/installationAndRiskController.ts
+++ b/server/controllers/installationAndRisk/installationAndRiskController.ts
@@ -1,13 +1,10 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
-import { InstallationAndRisk } from '../../models/InstallationAndRisk'
 import { isValidationResult } from '../../models/Validation'
 import { AuditService } from '../../services'
 import InstallationAndRiskService from '../../services/installationAndRiskService'
 import TaskListService from '../../services/taskListService'
-import InstallationAndRiskFormDataModel, {
-  InstallationAndRiskFormData,
-} from '../../models/form-data/installationAndRisk'
+import InstallationAndRiskFormDataModel from '../../models/form-data/installationAndRisk'
 import installationAndRiskViewModel from '../../models/view-models/installationAndRisk'
 
 export default class InstallationAndRiskController {
@@ -17,23 +14,11 @@ export default class InstallationAndRiskController {
     private readonly taskListService: TaskListService,
   ) {}
 
-  private createApiModelFromFormData(formData: InstallationAndRiskFormData): InstallationAndRisk {
-    return {
-      offence: formData.offence ?? null,
-      offenceAdditionalDetails: formData.offenceAdditionalDetails ?? null,
-      riskCategory: formData.riskCategory ?? null,
-      riskDetails: formData.riskDetails ?? null,
-      mappaLevel: formData.mappaLevel ?? null,
-      mappaCaseType: formData.mappaCaseType ?? null,
-    }
-  }
-
   view: RequestHandler = async (req: Request, res: Response) => {
     const order = req.order!
     const errors = req.flash('validationErrors')
     const formData = req.flash('formData')
     const viewModel = installationAndRiskViewModel.construct(order, formData as never, errors as never)
-
     res.render(`pages/order/installation-and-risk/index`, viewModel)
   }
 

--- a/server/i18n/en/pages/installationAndRisk.ts
+++ b/server/i18n/en/pages/installationAndRisk.ts
@@ -27,7 +27,7 @@ const installationAndRiskPageContent: InstallationAndRiskPageContent = {
       hint: "Risks relate to the device wearer's behaviour and installation address. Select all that apply",
     },
     riskDetails: {
-      text: 'Any other risks to be aware of?(optional)',
+      text: 'Any other risks to be aware of? (optional)',
       hint: "Provide additional risk information about the device wearer's behaviour or the installation address.",
     },
   },

--- a/server/i18n/en/pages/installationAndRisk.ts
+++ b/server/i18n/en/pages/installationAndRisk.ts
@@ -27,8 +27,8 @@ const installationAndRiskPageContent: InstallationAndRiskPageContent = {
       hint: "Risks relate to the device wearer's behaviour and installation address. Select all that apply",
     },
     riskDetails: {
-      text: 'Any other risks to be aware of?',
-      hint: "Provide additional risk information about the device wearer's behaviour or the installation address. If there is no risk to be aware of enter 'No risk'.",
+      text: 'Any other risks to be aware of?(optional)',
+      hint: "Provide additional risk information about the device wearer's behaviour or the installation address.",
     },
   },
   section: 'Risk information',

--- a/server/models/form-data/installationAndRisk.ts
+++ b/server/models/form-data/installationAndRisk.ts
@@ -11,7 +11,7 @@ const InstallationAndRiskFormDataModel = z.object({
   riskCategory: z
     .union([z.string(), z.array(z.string()).default([])])
     .transform(val => (Array.isArray(val) ? val : [val])),
-  riskDetails: z.string().nullable().default(null),
+  riskDetails: z.string().nullable().default(''),
   mappaLevel: z.string().nullable().default(null),
   mappaCaseType: z.string().nullable().default(null),
 })
@@ -22,10 +22,7 @@ const InstallationAndRiskFormDataValidator = z
     offence: z.string().nullable(),
     offenceAdditionalDetails: z.string(),
     riskCategory: z.array(z.string()),
-    riskDetails: z
-      .string()
-      .min(1, validationErrors.installationAndRisk.riskDetailsRequired)
-      .max(200, validationErrors.installationAndRisk.riskDetailsTooLong),
+    riskDetails: z.string().max(200, validationErrors.installationAndRisk.riskDetailsTooLong),
     mappaLevel: z.string().nullable(),
     mappaCaseType: z.string().nullable(),
   })

--- a/server/models/view-models/installationAndRisk.ts
+++ b/server/models/view-models/installationAndRisk.ts
@@ -88,11 +88,11 @@ const createFromEntity = (order: Order): InstallationAndRiskViewModel => {
 
 const construct = (
   order: Order,
-  formData: InstallationAndRiskFormData,
+  formData: [InstallationAndRiskFormData],
   errors: ValidationResult,
 ): InstallationAndRiskViewModel => {
   if (errors.length > 0) {
-    return constructFromFormData(formData, errors, order)
+    return constructFromFormData(formData[0], errors, order)
   }
 
   return createFromEntity(order)

--- a/server/utils/govukFrontEndTypes/checkBoxItem.ts
+++ b/server/utils/govukFrontEndTypes/checkBoxItem.ts
@@ -57,6 +57,11 @@ export type CheckboxItem = {
       HTML attributes (for example data attributes) to add to the checkbox input tag.
     */
   attributes?: Record<string, unknown>
+
+  /*
+     	If set to "exclusive", implements a ‘None of these’ type behaviour via JavaScript when checkboxes are clicked.
+    */
+  behaviour?: string
 }
 
 export type CheckboxItemConditional = {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -15,6 +15,7 @@ const toOptions = (
   disabled: boolean = false,
   includeEmptyOption: boolean = false,
   type: string = '',
+  lastItemExclusive: boolean = false,
 ): Array<CheckboxItem | RadiosItem> => {
   const options = Object.keys(values).map(key => {
     if (typeof values[key] === 'object') {
@@ -38,6 +39,10 @@ const toOptions = (
   if (includeEmptyOption) {
     if (type === 'Radio') options.push({ value: '', text: 'Not able to provide this information', disabled })
     else options.unshift({ value: '', text: 'Select', disabled })
+  }
+
+  if (lastItemExclusive) {
+    ;(options[options.length - 1] as CheckboxItem).behaviour = 'exclusive'
   }
 
   return options

--- a/server/views/pages/order/installation-and-risk/index.njk
+++ b/server/views/pages/order/installation-and-risk/index.njk
@@ -63,7 +63,7 @@
       hint: {
         text: content.pages.installationAndRisk.questions.possibleRisk.hint
       },
-      items: content.reference.possibleRisks | toOptions(not isOrderEditable) | addDivider(),
+      items: content.reference.possibleRisks | toOptions(not isOrderEditable, false, '', true) | addDivider(),
       errorMessage: possibleRisk.error,
       values: possibleRisk.values
     }) }}


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3968



### Changes proposed in this pull request

Fix issue where form data is not persisted after validation failed.

Make  ‘There are no risks that the installer should be aware of’ option exclusive.

Make risk details optional again

