### PR TITLE
Add a warning panel to the no-fixed-abode view.

### DIFF
--- a/server/i18n/en/pages/noFixedAbode.ts
+++ b/server/i18n/en/pages/noFixedAbode.ts
@@ -4,8 +4,9 @@ const noFixedAbodePageContent: NoFixedAbodePageContent = {
   helpText: [
     'A fixed address is the address the device wearer has registered as their home address. It can be temporary accommodation, an Approved Premises (AP), a fixed tenancy or a permanent address.',
     'A fixed address is required to process all monitoring orders apart from those that include Alcohol monitoring or where the device wearer is part of the Acquisitive Crime (AC) Project.',
-    "For all other orders you should not raise the order until you have the device wearer's address. If the address isn’t available at the time of release, probation will be responsible for the order.",
   ],
+  warning:
+    "For all other orders do not raise the order until you have the device wearer's address. If the address isn’t available at the time of release, probation will be responsible for the order.",
   legend: '',
   questions: {
     noFixedAbode: {

--- a/server/types/i18n/pages/noFixedAbode.ts
+++ b/server/types/i18n/pages/noFixedAbode.ts
@@ -1,5 +1,7 @@
 import PageContent from './page'
 
-type NoFixedAbodePageContent = PageContent<'noFixedAbode'>
+type NoFixedAbodePageContent = PageContent<'noFixedAbode'> & {
+  warning: string
+}
 
 export default NoFixedAbodePageContent

--- a/server/views/pages/order/contact-information/no-fixed-abode.njk
+++ b/server/views/pages/order/contact-information/no-fixed-abode.njk
@@ -1,5 +1,6 @@
 {% extends "../../../partials/form-layout.njk" %}
 
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
@@ -10,7 +11,12 @@
 
 {% block formInputs %}
 
- {{ govukRadios({
+  {{ govukWarningText({
+    text: content.pages.noFixedAbode.warning,
+    iconFallbackText: "Warning"
+  }) }}
+
+  {{ govukRadios({
     name: "noFixedAbode",
     classes: "govuk-radios--inline",
     fieldset: {


### PR DESCRIPTION
This PR moves some of the help text on the no fixed abode view into a warning panel.
This is a minor change requested following  https://dsdmoj.atlassian.net/browse/ELM-3966.
