### PR TITLE
ELM-3969: Frontend work to support backend vinput validation changes

### DIFF
--- a/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
@@ -103,15 +103,8 @@ context('About the device wearer - Responsible Adult', () => {
 
         page.form.saveAndContinueButton.click()
 
-        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`).then(requests => {
-          expect(requests).to.have.lengthOf(1)
-          expect(requests[0]).to.deep.equal({
-            fullName: '',
-            contactNumber: null,
-            relationship: '',
-            otherRelationshipDetails: '',
-          })
-        })
+        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`)
+
         cy.get('#relationship-error').should('contain', 'Relationship is required')
         cy.get('#fullName-error').should('contain', 'Full name is required')
         page.errorSummary.shouldExist()
@@ -126,10 +119,7 @@ context('About the device wearer - Responsible Adult', () => {
           httpStatus: 400,
           id: mockOrderId,
           subPath: '/device-wearer-responsible-adult',
-          response: [
-            { field: 'fullName', error: 'Full name is required' },
-            { field: 'contactNumber', error: 'Phone number is in an incorrect format' },
-          ],
+          response: [{ field: 'fullName', error: 'Full name is required' }],
         })
 
         cy.visit(`/order/${mockOrderId}/about-the-device-wearer/responsible-adult`)
@@ -138,19 +128,9 @@ context('About the device wearer - Responsible Adult', () => {
         page.form.relationshipField.set('Guardian')
         page.form.saveAndContinueButton.click()
 
-        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`).then(requests => {
-          expect(requests).to.have.lengthOf(1)
-          expect(requests[0]).to.deep.equal({
-            fullName: '',
-            contactNumber: null,
-            relationship: 'guardian',
-            otherRelationshipDetails: '',
-          })
-        })
-        cy.get('#contactNumber-error').should('contain', 'Phone number is in an incorrect format')
+        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`)
         cy.get('#fullName-error').should('contain', 'Full name is required')
         page.errorSummary.shouldExist()
-        page.errorSummary.shouldHaveError('Phone number is in an incorrect format')
         page.errorSummary.shouldHaveError('Full name is required')
       })
     })
@@ -173,19 +153,9 @@ context('About the device wearer - Responsible Adult', () => {
         page.form.fullNameField.set('Martha Steward')
         page.form.saveAndContinueButton.click()
 
-        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`).then(requests => {
-          expect(requests).to.have.lengthOf(1)
-          expect(requests[0]).to.deep.equal({
-            fullName: 'Martha Steward',
-            contactNumber: null,
-            relationship: '',
-            otherRelationshipDetails: '',
-          })
-        })
+        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`)
         cy.get('#relationship-error').should('contain', 'Relationship is required')
-        cy.get('#contactNumber-error').should('contain', 'Phone number is in an incorrect format')
         page.errorSummary.shouldExist()
-        page.errorSummary.shouldHaveError('Phone number is in an incorrect format')
         page.errorSummary.shouldHaveError('Relationship is required')
       })
     })
@@ -208,20 +178,42 @@ context('About the device wearer - Responsible Adult', () => {
         page.form.contactNumberField.set('999999')
         page.form.saveAndContinueButton.click()
 
-        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`).then(requests => {
-          expect(requests).to.have.lengthOf(1)
-          expect(requests[0]).to.deep.equal({
-            fullName: '',
-            contactNumber: '999999',
-            relationship: '',
-            otherRelationshipDetails: '',
-          })
-        })
+        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`)
         cy.get('#relationship-error').should('contain', 'Relationship is required')
         cy.get('#fullName-error').should('contain', 'Full name is required')
         page.errorSummary.shouldExist()
         page.errorSummary.shouldHaveError('Full name is required')
         page.errorSummary.shouldHaveError('Relationship is required')
+      })
+    })
+
+    context('Entering an invalid contact number', () => {
+      it('should not continue to collect the responsible officer details', () => {
+        cy.task('stubCemoSubmitOrder', {
+          httpStatus: 400,
+          id: mockOrderId,
+          subPath: '/device-wearer-responsible-adult',
+          response: [{ field: 'contactNumber', error: 'Phone number is in an incorrect format' }],
+        })
+
+        cy.visit(`/order/${mockOrderId}/about-the-device-wearer/responsible-adult`)
+        const page = Page.verifyOnPage(ResponsibleAdultPage)
+
+        const invalidContactNumberData = {
+          relationship: 'Other',
+          otherRelationshipDetails: 'Partner',
+          fullName: 'Audrey Taylor',
+          contactNumber: '123',
+        }
+
+        page.form.fillInWith(invalidContactNumberData)
+        page.form.saveAndContinueButton.click()
+
+        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`)
+
+        cy.get('#contactNumber-error').should('contain', 'Phone number is in an incorrect format')
+        page.errorSummary.shouldExist()
+        page.errorSummary.shouldHaveError('Phone number is in an incorrect format')
       })
     })
   })

--- a/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/responsible-adult.cy.ts
@@ -99,7 +99,6 @@ context('About the device wearer - Responsible Adult', () => {
 
         cy.visit(`/order/${mockOrderId}/about-the-device-wearer/responsible-adult`)
         const page = Page.verifyOnPage(ResponsibleAdultPage)
-        // const page = Page.visit(ResponsibleAdultPage, { orderId: mockOrderId })
 
         page.form.saveAndContinueButton.click()
 
@@ -113,7 +112,7 @@ context('About the device wearer - Responsible Adult', () => {
       })
     })
 
-    context('Only entering relationship', () => {
+    context('Not entering full name', () => {
       it('should not continue to collect the responsible officer details', () => {
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 400,
@@ -135,7 +134,7 @@ context('About the device wearer - Responsible Adult', () => {
       })
     })
 
-    context('Only entering full name', () => {
+    context('Not entering relationship', () => {
       it('should not continue to collect the responsible officer details', () => {
         cy.task('stubCemoSubmitOrder', {
           httpStatus: 400,
@@ -156,33 +155,6 @@ context('About the device wearer - Responsible Adult', () => {
         cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`)
         cy.get('#relationship-error').should('contain', 'Relationship is required')
         page.errorSummary.shouldExist()
-        page.errorSummary.shouldHaveError('Relationship is required')
-      })
-    })
-
-    context('Only entering contact number', () => {
-      it('should not continue to collect the responsible officer details', () => {
-        cy.task('stubCemoSubmitOrder', {
-          httpStatus: 400,
-          id: mockOrderId,
-          subPath: '/device-wearer-responsible-adult',
-          response: [
-            { field: 'relationship', error: 'Relationship is required' },
-            { field: 'fullName', error: 'Full name is required' },
-          ],
-        })
-
-        cy.visit(`/order/${mockOrderId}/about-the-device-wearer/responsible-adult`)
-        const page = Page.verifyOnPage(ResponsibleAdultPage)
-
-        page.form.contactNumberField.set('999999')
-        page.form.saveAndContinueButton.click()
-
-        cy.task('getStubbedRequest', `/orders/${mockOrderId}/device-wearer-responsible-adult`)
-        cy.get('#relationship-error').should('contain', 'Relationship is required')
-        cy.get('#fullName-error').should('contain', 'Full name is required')
-        page.errorSummary.shouldExist()
-        page.errorSummary.shouldHaveError('Full name is required')
         page.errorSummary.shouldHaveError('Relationship is required')
       })
     })

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -16,13 +16,6 @@ interface ValidationErrors {
     responsibleAdultRequired: string
     sexRequired: string
   }
-  identityNumbers: {
-    nomisIdMaxLength: string
-    pncIdMaxLength: string
-    deliusIdMaxLength: string
-    prisonNumberMaxLength: string
-    homeOfficeRefMaxLength: string
-  }
   monitoringConditions: {
     conditionTypeRequired: string
     monitoringTypeRequired: string
@@ -174,13 +167,6 @@ const validationErrors: ValidationErrors = {
     preferredNameMaxLength: 'Preferred name must be 200 characters or less',
     responsibleAdultRequired: 'Select yes if a responsible adult is required',
     sexRequired: "Select the device wearer's sex, or select 'Not able to provide this information'",
-  },
-  identityNumbers: {
-    nomisIdMaxLength: 'NOMIS ID must be 200 characters or less',
-    pncIdMaxLength: 'PNC ID must be 200 characters or less',
-    deliusIdMaxLength: 'Delius ID must be 200 characters or less',
-    prisonNumberMaxLength: 'Prison number must be 200 characters or less',
-    homeOfficeRefMaxLength: 'Home Office Reference Number must be 200 characters or less',
   },
   monitoringConditions: {
     conditionTypeRequired: 'Select order type condition',

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -16,6 +16,10 @@ interface ValidationErrors {
     responsibleAdultRequired: string
     sexRequired: string
   }
+  responsibleAdult: {
+    relationshipRequired: string
+    fullNameMaxLength: string
+  }
   monitoringConditions: {
     conditionTypeRequired: string
     monitoringTypeRequired: string
@@ -167,6 +171,10 @@ const validationErrors: ValidationErrors = {
     preferredNameMaxLength: 'Preferred name must be 200 characters or less',
     responsibleAdultRequired: 'Select yes if a responsible adult is required',
     sexRequired: "Select the device wearer's sex, or select 'Not able to provide this information'",
+  },
+  responsibleAdult: {
+    relationshipRequired: 'Select their relationship to the device wearer',
+    fullNameMaxLength: 'Full name must be 200 characters or less',
   },
   monitoringConditions: {
     conditionTypeRequired: 'Select order type condition',

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -16,6 +16,13 @@ interface ValidationErrors {
     responsibleAdultRequired: string
     sexRequired: string
   }
+  identityNumbers: {
+    nomisIdMaxLength: string
+    pncIdMaxLength: string
+    deliusIdMaxLength: string
+    prisonNumberMaxLength: string
+    homeOfficeRefMaxLength: string
+  }
   responsibleAdult: {
     relationshipRequired: string
     fullNameMaxLength: string
@@ -171,6 +178,13 @@ const validationErrors: ValidationErrors = {
     preferredNameMaxLength: 'Preferred name must be 200 characters or less',
     responsibleAdultRequired: 'Select yes if a responsible adult is required',
     sexRequired: "Select the device wearer's sex, or select 'Not able to provide this information'",
+  },
+  identityNumbers: {
+    nomisIdMaxLength: 'NOMIS ID must be 200 characters or less',
+    pncIdMaxLength: 'PNC ID must be 200 characters or less',
+    deliusIdMaxLength: 'Delius ID must be 200 characters or less',
+    prisonNumberMaxLength: 'Prison number must be 200 characters or less',
+    homeOfficeRefMaxLength: 'Home Office Reference Number must be 200 characters or less',
   },
   responsibleAdult: {
     relationshipRequired: 'Select their relationship to the device wearer',

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -23,13 +23,6 @@ interface ValidationErrors {
     prisonNumberMaxLength: string
     homeOfficeRefMaxLength: string
   }
-  responsibleAdult: {
-    relationshipRequired: string
-    otherRelationshipMaxLength: string
-    fullNameRequired: string
-    fullNameMaxLength: string
-    telephoneNumberMaxLength: string
-  }
   monitoringConditions: {
     conditionTypeRequired: string
     monitoringTypeRequired: string
@@ -188,13 +181,6 @@ const validationErrors: ValidationErrors = {
     deliusIdMaxLength: 'Delius ID must be 200 characters or less',
     prisonNumberMaxLength: 'Prison number must be 200 characters or less',
     homeOfficeRefMaxLength: 'Home Office Reference Number must be 200 characters or less',
-  },
-  responsibleAdult: {
-    relationshipRequired: 'Relationship is required',
-    otherRelationshipMaxLength: 'Relationship description must be 200 characters or less',
-    fullNameRequired: 'Full name is required',
-    fullNameMaxLength: 'Full name must be 200 characters or less',
-    telephoneNumberMaxLength: 'Telephone number must be 200 characters or less',
   },
   monitoringConditions: {
     conditionTypeRequired: 'Select order type condition',

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -25,7 +25,10 @@ interface ValidationErrors {
   }
   responsibleAdult: {
     relationshipRequired: string
+    otherRelationshipMaxLength: string
+    fullNameRequired: string
     fullNameMaxLength: string
+    telephoneNumberMaxLength: string
   }
   monitoringConditions: {
     conditionTypeRequired: string
@@ -187,8 +190,11 @@ const validationErrors: ValidationErrors = {
     homeOfficeRefMaxLength: 'Home Office Reference Number must be 200 characters or less',
   },
   responsibleAdult: {
-    relationshipRequired: 'Select their relationship to the device wearer',
+    relationshipRequired: 'Relationship is required',
+    otherRelationshipMaxLength: 'Relationship description must be 200 characters or less',
+    fullNameRequired: 'Full name is required',
     fullNameMaxLength: 'Full name must be 200 characters or less',
+    telephoneNumberMaxLength: 'Telephone number must be 200 characters or less',
   },
   monitoringConditions: {
     conditionTypeRequired: 'Select order type condition',

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -5,11 +5,14 @@ interface ValidationErrors {
   }
   deviceWearer: {
     dateOfBirth: DateErrorMessages
+    firstNameMaxLength: string
     firstNameRequired: string
     genderRequired: string
     interpreterRequired: string
     languageRequired: string
+    lastNameMaxLength: string
     lastNameRequired: string
+    preferredNameMaxLength: string
     responsibleAdultRequired: string
     sexRequired: string
   }
@@ -154,11 +157,14 @@ const validationErrors: ValidationErrors = {
       required: 'Enter date of birth',
       yearMustIncludeFourNumbers: 'Year must include 4 numbers',
     },
+    firstNameMaxLength: 'First name must be 200 characters or less',
     firstNameRequired: "Enter device wearer's first name",
     genderRequired: "Select the device wearer's gender, or select 'Not able to provide this information'",
     interpreterRequired: 'Select yes if the device wearer requires an interpreter',
     languageRequired: 'Select the language required',
+    lastNameMaxLength: 'Last name must be 200 characters or less',
     lastNameRequired: "Enter device wearer's last name",
+    preferredNameMaxLength: 'Preferred name must be 200 characters or less',
     responsibleAdultRequired: 'Select yes if a responsible adult is required',
     sexRequired: "Select the device wearer's sex, or select 'Not able to provide this information'",
   },

--- a/server/controllers/monitoringConditions/attendanceMonitoringController.test.ts
+++ b/server/controllers/monitoringConditions/attendanceMonitoringController.test.ts
@@ -97,7 +97,7 @@ describe('attendanceMonitoringController', () => {
     addressLine2: 'add 2',
     addressLine3: 'add 3',
     addressLine4: '',
-    addressPostcode: 'PC13DE',
+    postcode: 'PC13DE',
     addAnother: 'false',
   }
 
@@ -127,7 +127,7 @@ describe('attendanceMonitoringController', () => {
     addressLine2: 'add 2',
     addressLine3: 'add 3',
     addressLine4: '',
-    addressPostcode: 'PC13DE',
+    postcode: 'PC13DE',
     addAnother: 'false',
   }
 
@@ -213,7 +213,7 @@ describe('attendanceMonitoringController', () => {
               addressLine2: '',
               addressLine3: '',
               addressLine4: '',
-              addressPostcode: '',
+              postcode: '',
               appointmentDay: '',
               startDate: {
                 day: '',

--- a/server/models/form-data/attendanceMonitoring.ts
+++ b/server/models/form-data/attendanceMonitoring.ts
@@ -30,7 +30,7 @@ const AttendanceMonitoringFormDataModel = z.object({
   addressLine2: z.string(),
   addressLine3: z.string(),
   addressLine4: z.string(),
-  addressPostcode: z.string(),
+  postcode: z.string(),
   addAnother: z.string().default('false'),
 })
 
@@ -49,16 +49,16 @@ const AttendanceMonitoringFormDataValidator = z
     addressLine2: z.string(),
     addressLine3: z.string(),
     addressLine4: z.string(),
-    addressPostcode: z.string(),
+    postcode: z.string(),
     startTimeHours: z.string(),
     startTimeMinutes: z.string(),
     endTimeHours: z.string(),
     endTimeMinutes: z.string(),
   })
-  .transform(({ startTimeHours, startTimeMinutes, endTimeHours, endTimeMinutes, addressPostcode, ...formData }) => ({
+  .transform(({ startTimeHours, startTimeMinutes, endTimeHours, endTimeMinutes, postcode, ...formData }) => ({
     startTime: serialiseTime(startTimeHours, startTimeMinutes),
     endTime: serialiseTime(endTimeHours, endTimeMinutes),
-    postcode: addressPostcode === '' ? null : addressPostcode,
+    postcode: postcode === '' ? null : postcode,
     ...formData,
   }))
 

--- a/server/models/form-data/deviceWearer.ts
+++ b/server/models/form-data/deviceWearer.ts
@@ -64,14 +64,6 @@ const IdentityNumbersFormDataModel = FormDataModel.extend({
 
 type IdentityNumbersFormData = Omit<z.infer<typeof IdentityNumbersFormDataModel>, 'action'>
 
-const IdentityNumbersFormDataValidator = IdentityNumbersFormDataModel.omit({ action: true }).extend({
-  nomisId: z.string().max(200, validationErrors.identityNumbers.nomisIdMaxLength),
-  pncId: z.string().max(200, validationErrors.identityNumbers.pncIdMaxLength),
-  deliusId: z.string().max(200, validationErrors.identityNumbers.deliusIdMaxLength),
-  prisonNumber: z.string().max(200, validationErrors.identityNumbers.prisonNumberMaxLength),
-  homeOfficeReferenceNumber: z.string().max(200, validationErrors.identityNumbers.homeOfficeRefMaxLength),
-})
-
 export {
   DeviceWearerFormData,
   DeviceWearerFormDataParser,
@@ -79,5 +71,4 @@ export {
   DeviceWearerFormDataValidator,
   IdentityNumbersFormData,
   IdentityNumbersFormDataModel,
-  IdentityNumbersFormDataValidator,
 }

--- a/server/models/form-data/deviceWearer.ts
+++ b/server/models/form-data/deviceWearer.ts
@@ -34,7 +34,7 @@ const DeviceWearerFormDataValidator = z.object({
     .string()
     .min(1, validationErrors.deviceWearer.lastNameRequired)
     .max(200, validationErrors.deviceWearer.lastNameMaxLength),
-  alias: z.string().max(200, validationErrors.deviceWearer.lastNameMaxLength),
+  alias: z.string().max(200, validationErrors.deviceWearer.preferredNameMaxLength),
   dateOfBirth: DateInputModel(validationErrors.deviceWearer.dateOfBirth),
   language: z.string().min(0, validationErrors.deviceWearer.languageRequired), // TODO ELM-3376 this needs changing to be conditional on interpreter needed
   interpreterRequired: BooleanInputModel.pipe(
@@ -62,9 +62,9 @@ const IdentityNumbersFormDataModel = FormDataModel.extend({
   homeOfficeReferenceNumber: z.string(),
 })
 
-type IdentityNumbersFormData = z.infer<typeof IdentityNumbersFormDataModel>
+type IdentityNumbersFormData = Omit<z.infer<typeof IdentityNumbersFormDataModel>, 'action'>
 
-const IdentityNumbersFormDataValidator = FormDataModel.extend({
+const IdentityNumbersFormDataValidator = IdentityNumbersFormDataModel.omit({ action: true }).extend({
   nomisId: z.string().max(200, validationErrors.identityNumbers.nomisIdMaxLength),
   pncId: z.string().max(200, validationErrors.identityNumbers.pncIdMaxLength),
   deliusId: z.string().max(200, validationErrors.identityNumbers.deliusIdMaxLength),

--- a/server/models/form-data/deviceWearer.ts
+++ b/server/models/form-data/deviceWearer.ts
@@ -26,9 +26,15 @@ type DeviceWearerFormData = Omit<z.infer<typeof DeviceWearerFormDataParser>, 'ac
 
 // Validate form data on the client to ensure creation of successful api requests
 const DeviceWearerFormDataValidator = z.object({
-  firstName: z.string().min(1, validationErrors.deviceWearer.firstNameRequired),
-  lastName: z.string().min(1, validationErrors.deviceWearer.lastNameRequired),
-  alias: z.string(),
+  firstName: z
+    .string()
+    .min(1, validationErrors.deviceWearer.firstNameRequired)
+    .max(200, validationErrors.deviceWearer.firstNameMaxLength),
+  lastName: z
+    .string()
+    .min(1, validationErrors.deviceWearer.lastNameRequired)
+    .max(200, validationErrors.deviceWearer.lastNameMaxLength),
+  alias: z.string().max(200, validationErrors.deviceWearer.lastNameMaxLength),
   dateOfBirth: DateInputModel(validationErrors.deviceWearer.dateOfBirth),
   language: z.string().min(0, validationErrors.deviceWearer.languageRequired), // TODO ELM-3376 this needs changing to be conditional on interpreter needed
   interpreterRequired: BooleanInputModel.pipe(

--- a/server/models/form-data/deviceWearer.ts
+++ b/server/models/form-data/deviceWearer.ts
@@ -64,6 +64,14 @@ const IdentityNumbersFormDataModel = FormDataModel.extend({
 
 type IdentityNumbersFormData = z.infer<typeof IdentityNumbersFormDataModel>
 
+const IdentityNumbersFormDataValidator = FormDataModel.extend({
+  nomisId: z.string().max(200, validationErrors.identityNumbers.nomisIdMaxLength),
+  pncId: z.string().max(200, validationErrors.identityNumbers.pncIdMaxLength),
+  deliusId: z.string().max(200, validationErrors.identityNumbers.deliusIdMaxLength),
+  prisonNumber: z.string().max(200, validationErrors.identityNumbers.prisonNumberMaxLength),
+  homeOfficeReferenceNumber: z.string().max(200, validationErrors.identityNumbers.homeOfficeRefMaxLength),
+})
+
 export {
   DeviceWearerFormData,
   DeviceWearerFormDataParser,
@@ -71,4 +79,5 @@ export {
   DeviceWearerFormDataValidator,
   IdentityNumbersFormData,
   IdentityNumbersFormDataModel,
+  IdentityNumbersFormDataValidator,
 }

--- a/server/models/form-data/responsibleAdult.ts
+++ b/server/models/form-data/responsibleAdult.ts
@@ -1,15 +1,28 @@
 import z from 'zod'
+import { validationErrors } from '../../constants/validationErrors'
+import { FormDataModel } from './formData'
 
-const DeviceWearerResponsibleAdultFormDataModel = z.object({
-  action: z.string(),
+const DeviceWearerResponsibleAdultFormDataModel = FormDataModel.extend({
   relationship: z.string().default(''),
   otherRelationshipDetails: z.string(),
   fullName: z.string(),
-  contactNumber: z.string().transform(val => (val === '' ? null : val)),
+  contactNumber: z
+    .string()
+    .nullable()
+    .transform(val => (val === '' ? null : val)),
 })
 
-type DeviceWearerResponsibleAdultFormData = z.infer<typeof DeviceWearerResponsibleAdultFormDataModel>
+type DeviceWearerResponsibleAdultFormData = Omit<z.infer<typeof DeviceWearerResponsibleAdultFormDataModel>, 'action'>
+
+const DeviceWearerResponsibleAdultFormDataValidator = z.object({
+  relationship: z.string().min(1, validationErrors.responsibleAdult.relationshipRequired),
+  fullName: z.string().max(200, validationErrors.responsibleAdult.fullNameMaxLength),
+  contactNumber: z
+    .string()
+    .nullable()
+    .transform(val => (val === '' ? null : val)),
+})
 
 export default DeviceWearerResponsibleAdultFormDataModel
 
-export { DeviceWearerResponsibleAdultFormData }
+export { DeviceWearerResponsibleAdultFormData, DeviceWearerResponsibleAdultFormDataValidator }

--- a/server/models/form-data/responsibleAdult.ts
+++ b/server/models/form-data/responsibleAdult.ts
@@ -16,7 +16,11 @@ type DeviceWearerResponsibleAdultFormData = Omit<z.infer<typeof DeviceWearerResp
 
 const DeviceWearerResponsibleAdultFormDataValidator = z.object({
   relationship: z.string().min(1, validationErrors.responsibleAdult.relationshipRequired),
-  fullName: z.string().max(200, validationErrors.responsibleAdult.fullNameMaxLength),
+  otherRelationshipDetails: z.string().max(200, validationErrors.responsibleAdult.otherRelationshipMaxLength),
+  fullName: z
+    .string()
+    .min(1, validationErrors.responsibleAdult.fullNameRequired)
+    .max(200, validationErrors.responsibleAdult.fullNameMaxLength),
   contactNumber: z
     .string()
     .nullable()

--- a/server/models/form-data/responsibleAdult.ts
+++ b/server/models/form-data/responsibleAdult.ts
@@ -1,5 +1,4 @@
 import z from 'zod'
-import { validationErrors } from '../../constants/validationErrors'
 import { FormDataModel } from './formData'
 
 const DeviceWearerResponsibleAdultFormDataModel = FormDataModel.extend({
@@ -14,19 +13,6 @@ const DeviceWearerResponsibleAdultFormDataModel = FormDataModel.extend({
 
 type DeviceWearerResponsibleAdultFormData = Omit<z.infer<typeof DeviceWearerResponsibleAdultFormDataModel>, 'action'>
 
-const DeviceWearerResponsibleAdultFormDataValidator = z.object({
-  relationship: z.string().min(1, validationErrors.responsibleAdult.relationshipRequired),
-  otherRelationshipDetails: z.string().max(200, validationErrors.responsibleAdult.otherRelationshipMaxLength),
-  fullName: z
-    .string()
-    .min(1, validationErrors.responsibleAdult.fullNameRequired)
-    .max(200, validationErrors.responsibleAdult.fullNameMaxLength),
-  contactNumber: z
-    .string()
-    .nullable()
-    .transform(val => (val === '' ? null : val)),
-})
-
 export default DeviceWearerResponsibleAdultFormDataModel
 
-export { DeviceWearerResponsibleAdultFormData, DeviceWearerResponsibleAdultFormDataValidator }
+export { DeviceWearerResponsibleAdultFormData }

--- a/server/models/view-models/attendanceMonitoring.ts
+++ b/server/models/view-models/attendanceMonitoring.ts
@@ -24,7 +24,7 @@ const constructFromFormData = (
         line2: formData.addressLine2,
         line3: formData.addressLine3,
         line4: formData.addressLine4,
-        postcode: formData.addressPostcode,
+        postcode: formData.postcode,
       },
       error: getError(validationErrors, 'address'),
     },

--- a/server/services/deviceWearerResponsibleAdultService.ts
+++ b/server/services/deviceWearerResponsibleAdultService.ts
@@ -2,7 +2,6 @@ import { ZodError } from 'zod'
 import RestClient from '../data/restClient'
 import { AuthenticatedRequestInput } from '../interfaces/request'
 import DeviceWearerResponsibleAdultModel, { DeviceWearerResponsibleAdult } from '../models/DeviceWearerResponsibleAdult'
-import { DeviceWearerResponsibleAdultFormDataValidator } from '../models/form-data/responsibleAdult'
 import { ValidationResult } from '../models/Validation'
 import { SanitisedError } from '../sanitisedError'
 import { convertBackendErrorToValidationError, convertZodErrorToValidationError } from '../utils/errors'
@@ -23,11 +22,9 @@ export default class DeviceWearerResponsibleAdultService {
     input: UpdateDeviceWearerResponsibleAdultRequestInput,
   ): Promise<DeviceWearerResponsibleAdult | ValidationResult> {
     try {
-      const requestBody = DeviceWearerResponsibleAdultFormDataValidator.parse(input.data)
-
       const result = await this.apiClient.put({
         path: `/api/orders/${input.orderId}/device-wearer-responsible-adult`,
-        data: requestBody,
+        data: input.data,
         token: input.accessToken,
       })
 

--- a/server/services/deviceWearerService.ts
+++ b/server/services/deviceWearerService.ts
@@ -2,11 +2,7 @@ import { ZodError } from 'zod'
 import RestClient from '../data/restClient'
 import { AuthenticatedRequestInput } from '../interfaces/request'
 import DeviceWearerModel, { DeviceWearer } from '../models/DeviceWearer'
-import {
-  DeviceWearerFormDataValidator,
-  DeviceWearerFormData,
-  IdentityNumbersFormDataValidator,
-} from '../models/form-data/deviceWearer'
+import { DeviceWearerFormDataValidator, DeviceWearerFormData } from '../models/form-data/deviceWearer'
 import { ValidationResult } from '../models/Validation'
 import { SanitisedError } from '../sanitisedError'
 import { convertZodErrorToValidationError, convertBackendErrorToValidationError } from '../utils/errors'
@@ -56,10 +52,9 @@ export default class DeviceWearerService {
 
   async updateIdentityNumbers(input: UpdateIdentityNumbersRequest): Promise<DeviceWearer | ValidationResult> {
     try {
-      const requestBody = IdentityNumbersFormDataValidator.parse(input.data)
       const result = await this.apiClient.put({
         path: `/api/orders/${input.orderId}/device-wearer/identity-numbers`,
-        data: requestBody,
+        data: input.data,
         token: input.accessToken,
       })
 

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -36,6 +36,8 @@ export const convertBackendErrorToValidationError = (sanitisedError: SanitisedEr
     releaseDate: 'day',
     startDate: 'day',
     variationDate: 'day',
+    startTime: 'hours',
+    endTime: 'hours',
   }
 
   const parsedErrors = ValidationResultModel.parse(sanitisedError.data)

--- a/server/views/pages/order/monitoring-conditions/attendance-monitoring.njk
+++ b/server/views/pages/order/monitoring-conditions/attendance-monitoring.njk
@@ -108,6 +108,13 @@
       name: "address",
       value: address.value,
       errorMessage: address.error,
+      errors: {
+        line1: addressLine1.error,
+        line2: addressLine2.error,
+        line3: addressLine3.error,
+        line4: addressLine4.error,
+        postcode: postcode.error
+      },
       disabled: not isOrderEditable
     }) }}
 

--- a/server/views/partials/addressInput.njk
+++ b/server/views/partials/addressInput.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
 {% macro addressInput(input) %}
   <div id="{{input.id}}-form" class="govuk-form-group{% if input.errorMessage %} govuk-form-group--error{% endif %}">
       <fieldset class="govuk-fieldset">
@@ -5,46 +7,65 @@
           {% if input.hint %}<div class="govuk-hint">{{ input.hint }}</div>{% endif %}
           {% if input.errorMessage %}<div class="govuk-error-message" id="{{input.id}}-error">{{ input.errorMessage.text }}</div>{% endif %}
 
-          <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="{{input.id}}-line1">Address line 1</label>
-              <input class="govuk-input govuk-date-input__input govuk-!-width-one-half"
-                      id="{{input.id}}-line1"
-                      name="{{input.name}}Line1"
-                      value="{{input.value.line1}}"
-                      type="text" {% if input.disabled %}disabled {% endif %}/>
-          </div>
-          <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="{{input.id}}-line2">Address line 2 (optional)</label>
-              <input class="govuk-input govuk-date-input__input govuk-!-width-one-half"
-                      id="{{input.id}}-line2"
-                      name="{{input.name}}Line2"
-                      value="{{input.value.line2}}"
-                      type="text" {% if input.disabled %}disabled {% endif %}/>
-          </div>
-          <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="{{input.id}}-line3">Town or city</label>
-              <input class="govuk-input govuk-date-input__input govuk-!-width-one-half"
-                      id="{{input.id}}-line3"
-                      name="{{input.name}}Line3"
-                      value="{{input.value.line3}}"
-                      type="text" {% if input.disabled %}disabled {% endif %}/>
-          </div>
-          <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="{{input.id}}-line4">County (optional)</label>
-              <input class="govuk-input govuk-date-input__input govuk-!-width-one-half"
-                      id="{{input.id}}-line4"
-                      name="{{input.name}}Line4"
-                      value="{{input.value.line4}}"
-                      type="text" {% if input.disabled %}disabled {% endif %}/>
-          </div>
-          <div class="govuk-form-group">
-              <label class="govuk-label govuk-date-input__label" for="{{input.id}}-postcode">Postcode</label>
-              <input class="govuk-input govuk-date-input__input govuk-!-width-one-quarter"
-                      id="{{input.id}}-postcode"
-                      name="{{input.name}}Postcode"
-                      value="{{input.value.postcode}}"
-                      type="text" {% if input.disabled %}disabled {% endif %}/>
-          </div>
+        {{ govukInput({
+            label: {
+                text: "Address line 1"
+            },
+            classes: "govuk-!-width-one-half",
+            id: "addressLine1",
+            name: "addressLine1",
+            value: input.value.line1,
+            errorMessage: input.errors.line1,
+            disabled: input.disabled
+        }) }}
+
+        {{ govukInput({
+            label: {
+                text: "Address line 2 (optional)"
+            },
+            classes: "govuk-!-width-one-half",
+            id: "addressLine2",
+            name: "addressLine2",
+            value: input.value.line2,
+            errorMessage: input.errors.line2,
+            disabled: input.disabled
+        }) }}
+
+        {{ govukInput({
+            label: {
+                text: "Town or city"
+            },
+            classes: "govuk-!-width-one-half",
+            id: "addressLine3",
+            name: "addressLine3",
+            value: input.value.line3,
+            errorMessage: input.errors.line3,
+            disabled: input.disabled
+        }) }}
+
+        {{ govukInput({
+            label: {
+                text: "County (optional)"
+            },
+            classes: "govuk-!-width-one-half",
+            id: "addressLine4",
+            name: "addressLine4",
+            value: input.value.line4,
+            errorMessage: input.errors.line4,
+            disabled: input.disabled
+        }) }}
+
+        {{ govukInput({
+            label: {
+                text: "Postcode"
+            },
+            classes: "govuk-input--width-10",
+            id: "postcode",
+            name: "postcode",
+            value: input.value.postcode,
+            errorMessage: input.errors.postcode,
+            disabled: input.disabled
+        }) }}
 
       </fieldset>
   </div>


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3969

- Text fields require validation that string length is ≤200 characters for submission to the Serco API.
- Most of this validation is handled on the backend. These frontend changes support that work.

### Changes proposed in this pull request

- Some form datasets are currently validated on the frontend, notably those with date fields. Providing partial test coverage on the frontend and additional coverage on the backend gives a bad user experience, as after clearing all frontend validation errors they then receive new backend validation errors. So for these views, the backend validation has also been reproduced on the frontend.
- Validation in the Attendance Monitoring view was not functioning correctly. Most of these problems are fixed in this PR and the implementation is normalised somewhat. There's one remaining issue: address validation errors don't currently render directly above the address fields. A separate ticket is being created for that issue.
  
 Some other small improvements:
 - Improved integration tests for Responsible adult
 - Backend time validation errors can now generate links to time fields in the UI