### PR TITLE
Elm variation email order

### DIFF
--- a/integration_tests/e2e/search.cy.ts
+++ b/integration_tests/e2e/search.cy.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import SearchPage from '../pages/search'
 import Page from '../pages/page'
 import { mockApiOrder } from '../mockApis/cemo'
+import OrderTasksPage from '../pages/order/summary'
 
 const mockOrderId = uuidv4()
 
@@ -13,7 +14,7 @@ context('Search', () => {
       cy.task('reset')
       cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
       cy.task('stubCemoSearchOrders')
-      cy.task('stubCemoCreateOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
+      cy.task('stubCemoCreateOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS', type: 'VARIATION' })
       cy.task('stubCemoGetOrder', { httpStatus: 200, id: mockOrderId, status: 'IN_PROGRESS' })
       cy.signIn()
     })
@@ -61,12 +62,30 @@ context('Search', () => {
 
       const page = Page.visit(SearchPage)
 
-      page.searchButton.click()
-
       page.searchBox.type('Unknown name')
       page.searchButton.click()
 
       page.variationFormButton.should('exist').should('contain.text', 'Tell us about a change to a form sent by email')
+    })
+
+    it('should create a new variation order when the "Tell us about.." button is clicked', () => {
+      cy.task('stubCemoSearchOrders', { httpStatus: 200, orders: [] })
+      const page = Page.visit(SearchPage)
+
+      page.searchBox.type('Unknown name')
+      page.searchButton.click()
+
+      page.variationFormButton.click()
+
+      cy.task('stubCemoVerifyRequestReceived', {
+        uri: `/orders`,
+        method: 'POST',
+        body: {
+          type: 'VARIATION',
+        },
+      }).should('be.true')
+
+      Page.verifyOnPage(OrderTasksPage)
     })
 
     describe('when rendering an order', () => {

--- a/integration_tests/e2e/search.cy.ts
+++ b/integration_tests/e2e/search.cy.ts
@@ -56,6 +56,19 @@ context('Search', () => {
       )
     })
 
+    it('should show "Tell us about a change.." button when there are no results', () => {
+      cy.task('stubCemoSearchOrders', { httpStatus: 200, orders: [] })
+
+      const page = Page.visit(SearchPage)
+
+      page.searchButton.click()
+
+      page.searchBox.type('Unknown name')
+      page.searchButton.click()
+
+      page.variationFormButton.should('exist').should('contain.text', 'Tell us about a change to a form sent by email')
+    })
+
     describe('when rendering an order', () => {
       const mockDate = new Date(2000, 10, 20).toISOString()
       const mockOrder = {

--- a/integration_tests/pages/search.ts
+++ b/integration_tests/pages/search.ts
@@ -22,4 +22,8 @@ export default class SearchPage extends AppPage {
   get ordersList(): PageElement {
     return cy.get('#ordersList')
   }
+
+  get variationFormButton(): PageElement {
+    return cy.contains('Tell us about a change to a form sent by email')
+  }
 }

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -3,6 +3,7 @@
 {% set pageTitle = applicationName + " - Search" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "../components/search/macro.njk" import search %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
 
@@ -47,14 +48,25 @@
 	<p>Try searching using the device wearer's full name.</p>
 
 	<div class="govuk-warning-text">
-          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-visually-hidden">Warning</span>
-            <h2 class="govuk-heading-s">Can't find what you are looking for?</h2>
-            If the form is not listed in the search results, it may be an emailed form so not available online.
-            <br>
-          </strong>
-        </div>
+		<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+		<strong class="govuk-warning-text__text">
+			<span class="govuk-visually-hidden">Warning</span>
+			<h2 class="govuk-heading-s">Can't find what you are looking for?</h2>
+			If the form is not listed in the search results, it may be an emailed form so not available online.
+			<br>
+			{% if variationsEnabled %}
+			<form action="/order/create" method="post" class="govuk-!-margin-top-3">
+			<input type="hidden" name="_csrf" value="{{ csrfToken }}">
+				{{ govukButton({
+					text: "Tell us about a change to a form sent by email",
+					name: "type",
+					value: "VARIATION"
+				}) }}
+			</form>
+			{% endif %}	
+		</strong>
+	</div>
+
     {% elif orders.length > 0 %}
       {{ govukTable({
 	firstCellIsHeader: false,

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -60,7 +60,8 @@
 				{{ govukButton({
 					text: "Tell us about a change to a form sent by email",
 					name: "type",
-					value: "VARIATION"
+					value: "VARIATION",
+					classes: "govuk-button--secondary"
 				}) }}
 			</form>
 			{% endif %}	


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/4473?selectedIssue=ELM-3347

### Changes proposed in this pull request

User can update an order submitted by email.

From a coding perspective - we can now create a "variation order" via the search page if the user cannot find the order.
