### PR TITLE
Reconfigure navigation from Check Your Answers pages

### DIFF
--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -792,12 +792,16 @@ describe('TaskListService', () => {
       ['INSTALLATION_AND_RISK', paths.INSTALLATION_AND_RISK.CHECK_YOUR_ANSWERS],
       ['MONITORING_CONDITIONS', paths.MONITORING_CONDITIONS.CHECK_YOUR_ANSWERS],
     ])(
-      'should return check your answers if all other pages have been completed for that section',
+      'should return check your answers if all pages have been completed for that section',
       (page: string, url: string) => {
         // Given
         const currentPage = page as Page
         const taskListService = new TaskListService()
-        const order = getFilledMockOrder()
+        const order = getFilledMockOrder({
+          monitoringConditions: createMonitoringConditions({
+            isValid: true,
+          }),
+        })
 
         // When
         const nextPage = taskListService.getNextPage(currentPage, order)
@@ -1134,7 +1138,7 @@ describe('TaskListService', () => {
 
       const taskListService = new TaskListService()
 
-      const result = taskListService.getCheckYourAnswerPathForSection(tasks)
+      const result = taskListService.getCheckYourAnswersPathForSection(tasks)
 
       expect(result).toBe(paths.INSTALLATION_AND_RISK.CHECK_YOUR_ANSWERS)
     })
@@ -1158,7 +1162,7 @@ describe('TaskListService', () => {
 
       const taskListService = new TaskListService()
 
-      const result = taskListService.getCheckYourAnswerPathForSection(tasks)
+      const result = taskListService.getCheckYourAnswersPathForSection(tasks)
 
       expect(result).toBe(paths.INSTALLATION_AND_RISK.CHECK_YOUR_ANSWERS)
     })
@@ -1175,7 +1179,7 @@ describe('TaskListService', () => {
 
       const taskListService = new TaskListService()
 
-      const result = taskListService.getCheckYourAnswerPathForSection(tasks)
+      const result = taskListService.getCheckYourAnswersPathForSection(tasks)
 
       expect(result).toBe(paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK)
     })


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3996

Navigation from the Check Your Answers page via the continue button isn't working as expected. These changes rectify that.

### Changes proposed in this pull request

Update navigation. When leaving a CYA page via the continue button:
- If the next section is incomplete, navigate to the first question of the next section.
- If the next section is complete, navigate to the next section's CYA page, 
