### PR TITLE
Enforcement zone map upload: Update help text declaring permitted file types.

### DIFF
--- a/server/views/pages/order/monitoring-conditions/enforcement-zone.njk
+++ b/server/views/pages/order/monitoring-conditions/enforcement-zone.njk
@@ -68,7 +68,7 @@
       </p>
 
       <p class="govuk-hint">
-        You can upload a PDF or JPEG under 10MB.
+        You can upload a PDF, PNG, JPEG or JPG under 10MB.
       </p>
     {% endset %}
 


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4023

Users should be able to upload PNG format enforcement zone maps.

### Changes proposed in this pull request

Update the help text in the enforcement zone map upload field to specify that PNGs are permitted.
Validation is updated in the backend ([PR here](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order-api/pull/262)).
