### PR TITLE
dont show change links if order is in error

### DIFF
--- a/integration_tests/e2e/order/attachments/index.page.failed.cy.ts
+++ b/integration_tests/e2e/order/attachments/index.page.failed.cy.ts
@@ -27,7 +27,7 @@ context('Attachments', () => {
         cy.signIn()
       })
 
-      it('Should render summary page with no download links and no delete links', () => {
+      it('Should render summary page with download links but no change links', () => {
         const page = Page.visit(AttachmentSummaryPage, { orderId: mockOrderId }, {}, 'View answers')
 
         // Header
@@ -53,6 +53,8 @@ context('Attachments', () => {
           .find('.govuk-summary-list__value')
           .contains('photo.jpeg')
           .should('have.attr', 'href', `/order/${mockOrderId}/attachments/photo_Id/photo.jpeg`)
+
+        page.changeLinks.should('not.exist')
 
         // Buttons
         page.backToSummaryButton.should('exist')

--- a/server/models/view-models/additionalDocumentsCheckAnswers.ts
+++ b/server/models/view-models/additionalDocumentsCheckAnswers.ts
@@ -43,7 +43,7 @@ export default createViewModel
 function createAttachmentAnswer(attachment: Attachment | undefined, text: string, uri: string, order: Order) {
   return createAnswer(text, createFileNameLink(attachment, order.id), uri, {
     valueType: 'html',
-    ignoreActions: order.status === 'SUBMITTED',
+    ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR',
   })
 }
 


### PR DESCRIPTION
Fix to an issue found in review of the attachment flow for a failed app
