### PR TITLE
fix column width + formatting

### DIFF
--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -121,18 +121,21 @@
 
   <div id="ordersList">
     {% if orders.length > 0 %}
-      {{ govukTable ({
-      firstCellIsHeader: false,
-      head: [
-        {
-          text: "Name"
-        },
-        {
-          text: "Status"
-        }
-      ],
-      rows: tableRows
-    })}}
+      {{
+        govukTable ({
+          firstCellIsHeader: false,
+          head: [
+            {
+              text: "Name",
+              classes: "govuk-!-width-two-thirds"
+            },
+            {
+              text: "Status"
+            }
+          ],
+          rows: tableRows
+        })
+      }}
     {% endif %}
 
     {% if orders.length == 0 %}


### PR DESCRIPTION
Small Pr just to fix the Name column to 2/3 of the table

When an order had multiple status tags, it would push the status column to 2/3rds of the table. This forces it to stay at 1/3
