### PR TITLE
ELM-4090: increase default timeout for api to 25 seconds

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -104,10 +104,10 @@ export default {
     cemoApi: {
       url: get('CEMO_API_URL', 'http://localhost:8080', requiredInProduction),
       timeout: {
-        response: Number(get('CEMO_API_TIMEOUT_RESPONSE', 20000)),
-        deadline: Number(get('CEMO_VERIFICATION_API_TIMEOUT_DEADLINE', 20000)),
+        response: Number(get('CEMO_API_TIMEOUT_RESPONSE', 25000)),
+        deadline: Number(get('CEMO_VERIFICATION_API_TIMEOUT_DEADLINE', 25000)),
       },
-      agent: new AgentConfig(Number(get('CEMO_API_TIMEOUT_RESPONSE', 20000))),
+      agent: new AgentConfig(Number(get('CEMO_API_TIMEOUT_RESPONSE', 25000))),
     },
   },
   sqs: {


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4090


### Changes proposed in this pull request

Increase default timeout for calling CEMO api to 25 seconds to prevent 500 errors causing by slow Serco response 
