### PR TITLE
Add sub navigation to index & search pages

### DIFF
--- a/integration_tests/e2e/index.cy.ts
+++ b/integration_tests/e2e/index.cy.ts
@@ -28,7 +28,13 @@ context('Index', () => {
       // Create buttons
       page.newOrderFormButton.should('exist')
       page.newVariationFormButton.should('exist')
-      page.searchFormButton.should('exist')
+
+      // Sub nav
+      page.subNav.should('exist')
+      page.subNav.contains('Draft forms').should('have.attr', 'href', `/`)
+      page.subNav.contains('Draft forms').should('have.attr', 'aria-current', 'page')
+      page.subNav.contains('Submitted forms').should('have.attr', 'href', `/search`)
+      page.subNav.contains('Submitted forms').should('not.have.attr', 'aria-current', `page`)
 
       // Order list
       page.orders.should('exist').should('have.length', 4)
@@ -43,6 +49,14 @@ context('Index', () => {
 
       // A11y
       page.checkIsAccessible()
+    })
+
+    it('navigates to the index page when we click the draft forms nav link', () => {
+      const page = Page.visit(IndexPage)
+
+      page.subNav.contains('Draft forms').should('have.attr', 'href', `/`)
+
+      Page.verifyOnPage(IndexPage)
     })
   })
 
@@ -121,7 +135,7 @@ context('Index', () => {
     it('should navigate to the search page', () => {
       const page = Page.visit(IndexPage)
 
-      page.searchFormButton.click()
+      page.subNav.contains('Submitted forms').click()
 
       Page.verifyOnPage(SearchPage)
     })

--- a/integration_tests/e2e/search.cy.ts
+++ b/integration_tests/e2e/search.cy.ts
@@ -3,13 +3,14 @@ import SearchPage from '../pages/search'
 import Page from '../pages/page'
 import { mockApiOrder } from '../mockApis/cemo'
 import OrderTasksPage from '../pages/order/summary'
+import IndexPage from '../pages'
 
 const mockOrderId = uuidv4()
 
 const basicOrder = mockApiOrder()
 
 context('Search', () => {
-  context('Searching for sumitted orders', () => {
+  context('Searching for submitted orders', () => {
     beforeEach(() => {
       cy.task('reset')
       cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
@@ -26,9 +27,31 @@ context('Search', () => {
       page.header.userName().should('contain.text', 'J. Smith')
       page.header.phaseBanner().should('contain.text', 'dev')
 
+      page.subNav.should('exist')
+      page.subNav.contains('Draft forms').should('have.attr', 'href', `/`)
+      page.subNav.contains('Draft forms').should('not.have.attr', 'aria-current', 'page')
+      page.subNav.contains('Submitted forms').should('have.attr', 'href', `/search`)
+      page.subNav.contains('Submitted forms').should('have.attr', 'aria-current', `page`)
+
       // Search
       page.searchButton.should('exist')
       page.searchBox.should('exist')
+    })
+
+    it('should navigate to index when the draft forms nav link is clicked', () => {
+      const page = Page.visit(SearchPage)
+
+      page.subNav.contains('Draft forms').click()
+
+      Page.verifyOnPage(IndexPage)
+    })
+
+    it('should navigate to search page when the submitted forms nav link is clicked', () => {
+      const page = Page.visit(SearchPage)
+
+      page.subNav.contains('Submitted forms').click()
+
+      Page.verifyOnPage(SearchPage)
     })
 
     it('should show a message when the search button is clicked without input', () => {

--- a/integration_tests/pages/appPage.ts
+++ b/integration_tests/pages/appPage.ts
@@ -25,6 +25,10 @@ export default class AppPage extends Page {
     return cy.get('.govuk-notification-banner')
   }
 
+  get subNav(): PageElement {
+    return cy.get('.moj-sub-navigation')
+  }
+
   checkOnPage(): void {
     super.checkOnPage()
 

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -4,7 +4,7 @@ import { PageElement } from './page'
 
 export default class IndexPage extends AppPage {
   constructor() {
-    super('Electronic Monitoring Order (EMO) forms', '/', 'Existing application forms')
+    super('Electronic Monitoring Order (EMO) forms', '/')
   }
 
   get newOrderFormButton(): PageElement {

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -15,10 +15,6 @@ export default class IndexPage extends AppPage {
     return cy.contains('Change submitted form')
   }
 
-  get searchFormButton(): PageElement {
-    return cy.contains('Search submitted form')
-  }
-
   get ordersList(): PageElement {
     return cy.get('#ordersList')
   }

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -27,6 +27,10 @@ export default class IndexPage extends AppPage {
     return this.ordersList.get('.govuk-table__body').find('.govuk-table__row')
   }
 
+  get subNav(): PageElement {
+    return cy.get('.moj-sub-navigation')
+  }
+
   OrderFor(name: string): PageElement {
     return this.ordersList.contains('td', name)
   }

--- a/integration_tests/pages/search.ts
+++ b/integration_tests/pages/search.ts
@@ -11,6 +11,14 @@ export default class SearchPage extends AppPage {
     super('Electronic Monitoring Order (EMO) forms', '/search')
   }
 
+  get newOrderFormButton(): PageElement {
+    return cy.contains('Start new form')
+  }
+
+  get newVariationFormButton(): PageElement {
+    return cy.contains('Change submitted form')
+  }
+
   get searchButton(): PageElement {
     return cy.get('.govuk-button').contains('Search')
   }

--- a/integration_tests/pages/search.ts
+++ b/integration_tests/pages/search.ts
@@ -8,7 +8,7 @@ export default class SearchPage extends AppPage {
   protected elementCacheId: string = uuidv4()
 
   constructor() {
-    super('Search for a submitted form', '/search')
+    super('Electronic Monitoring Order (EMO) forms', '/search')
   }
 
   get searchButton(): PageElement {

--- a/server/views/pages/createOrderButtons.njk
+++ b/server/views/pages/createOrderButtons.njk
@@ -1,0 +1,22 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+<form action="/order/create" method="post">
+  <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+          text: "Start new form",
+          name: "type",
+          value: "REQUEST"
+      }) }}
+    {% if variationAsNewOrderEnabled %}
+      {{ govukButton({
+            text: "Change submitted form",
+            name: "type",
+            value: "VARIATION",
+      classes: "govuk-button--secondary"
+        }) }}
+    {% endif %}
+  </div>
+  
+</form>

--- a/server/views/pages/formsNav.njk
+++ b/server/views/pages/formsNav.njk
@@ -1,0 +1,12 @@
+{{ mojSubNavigation({
+  label: "Sub navigation",
+  items: [{
+    text: "Draft forms",
+    href: "/",
+    active: draftActive
+  },{
+    text: "Submitted forms",
+    href: "/search",
+    active: submittedActive
+  }]
+}) }}

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -38,18 +38,8 @@
 
   <h2>Existing application forms</h2>
 
-  {{ mojSubNavigation({
-  label: "Sub navigation",
-  items: [{
-    text: "Draft forms",
-    href: "/",
-    active: true
-  },{
-    text: "Submitted forms",
-    href: "/search",
-    active: false
-  }]
-}) }}
+  {% set draftActive = true %}
+  {% include "./formsNav.njk" %}
 
   {% include "./orderList.njk" %}
 

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -36,8 +36,6 @@
     </div>
   </form>
 
-  <h2>Existing application forms</h2>
-
   {% set draftActive = true %}
   {% include "./formsNav.njk" %}
 

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -5,7 +5,6 @@
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 {%- from "moj/components/search/macro.njk" import mojSearch -%}
 {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
@@ -16,25 +15,8 @@
     } })
   }}
 
-  <form action="/order/create" method="post">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-    <div class="govuk-button-group">
-      {{ govukButton({
-            text: "Start new form",
-            name: "type",
-            value: "REQUEST"
-        }) }}
-      {% if variationAsNewOrderEnabled %}
-        {{ govukButton({
-              text: "Change submitted form",
-              name: "type",
-              value: "VARIATION",
-	      classes: "govuk-button--secondary"
-          }) }}
-      {% endif %}
-    </div>
-  </form>
+  {% set csrfToken = csrfToken %}
+  {% include "./createOrderButtons.njk"%}
 
   {% set draftActive = true %}
   {% include "./formsNav.njk" %}

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -7,6 +7,7 @@
 {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
 {% block content %}
   {{ mojPageHeaderActions({
@@ -19,28 +20,36 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
     <div class="govuk-button-group">
-        {{ govukButton({
+      {{ govukButton({
             text: "Start new form",
             name: "type",
             value: "REQUEST"
         }) }}
-        {% if variationAsNewOrderEnabled %}
-          {{ govukButton({
+      {% if variationAsNewOrderEnabled %}
+        {{ govukButton({
               text: "Change submitted form",
               name: "type",
               value: "VARIATION",
 	      classes: "govuk-button--secondary"
           }) }}
-        {% endif %}
-        {{ govukButton({
-            text: "Search submitted form",
-            href: "/search",
-	    classes: "govuk-button--secondary"
-        }) }}
+      {% endif %}
     </div>
   </form>
 
   <h2>Existing application forms</h2>
+
+  {{ mojSubNavigation({
+  label: "Sub navigation",
+  items: [{
+    text: "Draft forms",
+    href: "/",
+    active: true
+  },{
+    text: "Submitted forms",
+    href: "/search",
+    active: false
+  }]
+}) }}
 
   {% include "./orderList.njk" %}
 

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -7,17 +7,8 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
 {% block content %}
-  {{ mojSubNavigation({
-  label: "Sub navigation",
-  items: [{
-    text: "Draft forms",
-    href: "/"
-  },{
-    text: "Submitted forms",
-    href: "/search",
-    active: true
-  }]
-}) }}
-	{% include "./searchList.njk" %}
+    {% set submittedActive = true %}
+    {% include "./formsNav.njk" %}
+    {% include "./searchList.njk" %}
 {% endblock %}
 

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -1,14 +1,17 @@
 {% extends "../partials/layout.njk" %}
-
 {% set pageTitle = applicationName + " - Search" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "../components/search/macro.njk" import search %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
-
+{% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 {% block content %}
-    {% set submittedActive = true %}
-    {% include "./formsNav.njk" %}
-    {% include "./searchList.njk" %}
+  {{ mojPageHeaderActions({
+    heading: {
+      text: 'Electronic Monitoring Order (EMO) forms'
+    }
+  }) }}
+  {% set submittedActive = true %}
+  {% include "./formsNav.njk" %}
+  {% include "./searchList.njk" %}
 {% endblock %}
-

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -4,8 +4,20 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "../components/search/macro.njk" import search %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
 {% block content %}
+  {{ mojSubNavigation({
+  label: "Sub navigation",
+  items: [{
+    text: "Draft forms",
+    href: "/"
+  },{
+    text: "Submitted forms",
+    href: "/search",
+    active: true
+  }]
+}) }}
 	{% include "./searchList.njk" %}
 {% endblock %}
 

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -5,13 +5,19 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+
 {% block content %}
   {{ mojPageHeaderActions({
     heading: {
       text: 'Electronic Monitoring Order (EMO) forms'
     }
   }) }}
+
+  {% set csrfToken = csrfToken %}
+  {% include "./createOrderButtons.njk"%}
+
   {% set submittedActive = true %}
   {% include "./formsNav.njk" %}
+
   {% include "./searchList.njk" %}
 {% endblock %}

--- a/server/views/pages/searchList.njk
+++ b/server/views/pages/searchList.njk
@@ -1,7 +1,3 @@
-
-<h1 class="govuk-heading-l">Search for a submitted form</h1>
-
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     {{ search({
@@ -11,6 +7,10 @@
         id: 'search',
         name: 'searchTerm',
         value: searchTerm
+      },
+      label: {
+        text: 'Search for a submitted form',
+        classes: "govuk-!-font-weight-bold"
       },
       hint: {
         text: 'Enter the device wearer\'s full name. For example Bob Smith.'


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-3834

Adds [sub navigation](https://design-patterns.service.justice.gov.uk/components/sub-navigation/) component to index and search page, with the aim of making the index and search pages easier for users to understand and navigate.

### Changes proposed in this pull request

- Create a form sub navigation component
- Place this in the index and search pages
- Update cypress tests

### Images of the changes

#### Index page:
<img width="877" height="430" alt="image" src="https://github.com/user-attachments/assets/e2a83dee-14ec-4577-a508-7eae5ecd417c" />

#### Search page:
<img width="879" height="477" alt="image" src="https://github.com/user-attachments/assets/95791c1d-396f-4a80-8e27-020b2e8a676f" />
