### PR TITLE
hasAnotherAddress functionality flow

### DIFF
--- a/server/controllers/contact-information/addressController.test.ts
+++ b/server/controllers/contact-information/addressController.test.ts
@@ -441,5 +441,53 @@ describe('AddressController', () => {
       expect(req.flash).not.toHaveBeenCalled()
       expect(res.redirect).toHaveBeenCalledWith(`/order/${mockOrder.id}/contact-information/interested-parties`)
     })
+
+    it.each([
+      ['true', true],
+      ['false', false],
+    ])(
+      'should call the address service with hasAnotherAddress converted to a boolean',
+      async (submittedValue: string, expectedBoolean: boolean) => {
+        const req = createMockRequest({
+          order: mockOrder,
+          body: {
+            action: 'continue',
+            addressLine1: 'a',
+            addressLine2: 'b',
+            addressLine3: 'c',
+            addressLine4: 'd',
+            postcode: 'e',
+            hasAnotherAddress: submittedValue,
+          },
+          params: {
+            orderId: mockOrder.id,
+            addressType: 'primary',
+          },
+        })
+        const res = createMockResponse()
+        const next = jest.fn()
+
+        mockAddressService.updateAddress.mockResolvedValue({
+          addressType: 'PRIMARY',
+          addressLine1: 'a',
+          addressLine2: 'b',
+          addressLine3: 'c',
+          addressLine4: 'd',
+          postcode: 'e',
+        })
+
+        taskListService.getNextPage = jest.fn().mockReturnValue([])
+
+        await addressController.update(req, res, next)
+
+        expect(mockAddressService.updateAddress).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              hasAnotherAddress: expectedBoolean,
+            }),
+          }),
+        )
+      },
+    )
   })
 })

--- a/server/controllers/contact-information/addressController.test.ts
+++ b/server/controllers/contact-information/addressController.test.ts
@@ -135,7 +135,7 @@ describe('AddressController', () => {
       },
     )
 
-    it('should render the form using submitted data when there are validaiton errors', async () => {
+    it('should render the form using submitted data when there are validation errors', async () => {
       // Given
       const req = createMockRequest({
         order: mockOrder,
@@ -443,11 +443,12 @@ describe('AddressController', () => {
     })
 
     it.each([
-      ['true', true],
-      ['false', false],
+      { submittedValue: 'true', expectedBoolean: true },
+      { submittedValue: 'false', expectedBoolean: false },
     ])(
-      'should call the address service with hasAnotherAddress converted to a boolean',
-      async (submittedValue: string, expectedBoolean: boolean) => {
+      'should call the address service with hasAnotherAddress converted to a boolean ($expectedBoolean)',
+      async ({ submittedValue, expectedBoolean }) => {
+        // Given
         const req = createMockRequest({
           order: mockOrder,
           body: {
@@ -475,18 +476,27 @@ describe('AddressController', () => {
           addressLine4: 'd',
           postcode: 'e',
         })
+        taskListService.getNextPage.mockReturnValue('')
 
-        taskListService.getNextPage = jest.fn().mockReturnValue([])
+        const expectedPayload = {
+          accessToken: 'fakeUserToken',
+          orderId: mockOrder.id,
+          data: {
+            addressType: 'PRIMARY',
+            addressLine1: 'a',
+            addressLine2: 'b',
+            addressLine3: 'c',
+            addressLine4: 'd',
+            postcode: 'e',
+            hasAnotherAddress: expectedBoolean,
+          },
+        }
 
+        // When
         await addressController.update(req, res, next)
 
-        expect(mockAddressService.updateAddress).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.objectContaining({
-              hasAnotherAddress: expectedBoolean,
-            }),
-          }),
-        )
+        // Then
+        expect(mockAddressService.updateAddress).toHaveBeenCalledWith(expectedPayload)
       },
     )
   })

--- a/server/controllers/contact-information/addressController.ts
+++ b/server/controllers/contact-information/addressController.ts
@@ -58,6 +58,7 @@ export default class AddressController {
       data: {
         addressType: addressType.toUpperCase(),
         ...formData,
+        hasAnotherAddress: hasAnotherAddress === 'true',
       },
     })
 

--- a/server/services/addressService.test.ts
+++ b/server/services/addressService.test.ts
@@ -1,0 +1,89 @@
+import RestClient from '../data/restClient'
+import AddressService from './addressService'
+import { Address, AddressTypeEnum } from '../models/Address'
+
+jest.mock('../data/restClient')
+
+describe('AddressService', () => {
+  let mockRestClient: jest.Mocked<RestClient>
+  let addressService: AddressService
+
+  beforeEach(() => {
+    mockRestClient = new RestClient('cemoApi', {
+      url: '',
+      timeout: { response: 0, deadline: 0 },
+      agent: { timeout: 0 },
+    }) as jest.Mocked<RestClient>
+    addressService = new AddressService(mockRestClient)
+    jest.clearAllMocks()
+  })
+
+  describe('updateAddress', () => {
+    it('should call  API with the correct data and return parsed Address on success', async () => {
+      const mockOrderId = 'mockUid'
+      const mockAccessToken = 'mockToken'
+      const mockRequestData = {
+        addressType: 'PRIMARY',
+        addressLine1: 'Mock Address Line 1',
+        addressLine2: 'Mock Address Line 2',
+        postcode: 'SW1A 1AA',
+        hasAnotherAddress: false,
+      }
+      const mockApiResponse: Address = {
+        addressType: AddressTypeEnum.Enum.PRIMARY,
+        addressLine1: 'Mock Address Line 1',
+        addressLine2: 'Mock Address Line 2',
+        addressLine3: '',
+        addressLine4: '',
+        postcode: 'SW1A 1AA',
+      }
+
+      mockRestClient.put.mockResolvedValue(mockApiResponse)
+
+      const result = await addressService.updateAddress({
+        orderId: mockOrderId,
+        accessToken: mockAccessToken,
+        data: mockRequestData,
+      })
+
+      expect(mockRestClient.put).toHaveBeenCalledTimes(1)
+      expect(mockRestClient.put).toHaveBeenCalledWith({
+        path: `/api/orders/${mockOrderId}/address`,
+        data: mockRequestData,
+        token: mockAccessToken,
+      })
+
+      expect(result).toEqual(mockApiResponse)
+    })
+
+    it('should correctly send the "hasAnotherAddress: true" flag to the API', async () => {
+      const mockOrderId = 'mockUuid'
+      const mockAccessToken = 'testmockToken'
+      const mockRequestData = {
+        addressType: 'SECONDARY',
+        addressLine1: 'Mock Secondary Address Line 1',
+        addressLine2: 'Mock Secondary Address Line 2',
+        postcode: 'SS2 2SS',
+        hasAnotherAddress: true,
+      }
+
+      const mockApiResponse: Address = {
+        addressType: AddressTypeEnum.Enum.SECONDARY,
+        addressLine1: 'Mock Secondary Address Line 1',
+        addressLine2: 'Mock Secondary Address Line 2',
+        addressLine3: '',
+        addressLine4: '',
+        postcode: 'SS2 2SS',
+      }
+      mockRestClient.put.mockResolvedValue(mockApiResponse)
+
+      await addressService.updateAddress({ orderId: mockOrderId, accessToken: mockAccessToken, data: mockRequestData })
+
+      expect(mockRestClient.put).toHaveBeenCalledWith({
+        path: `/api/orders/${mockOrderId}/address`,
+        data: mockRequestData,
+        token: mockAccessToken,
+      })
+    })
+  })
+})

--- a/server/services/addressService.ts
+++ b/server/services/addressService.ts
@@ -14,6 +14,7 @@ type UpdateAddressRequest = AuthenticatedRequestInput & {
     addressLine3?: string
     addressLine4?: string
     postcode?: string
+    hasAnotherAddress?: boolean
   }
 }
 


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/ELM/boards/4473?selectedIssue=ELM-3987

Fixes issue in "Contact information" CYA page. Secondary and Tertiary address no longer persists after user edits primary address to indicate they no longer have additional addresses.
