### PR TITLE
Elm 4743 sending install appointment without ias or tas

### DIFF
--- a/integration_tests/e2e/order/monitoring-conditions/installation-appointment.page.submission.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/installation-appointment.page.submission.cy.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import Page from '../../../pages/page'
 import InstallationAppointmentPage from '../../../pages/order/monitoring-conditions/installation-appointment'
 import InstallationAddressPage from '../../../pages/order/monitoring-conditions/installation-address'
+import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 
 const mockOrderId = uuidv4()
 const apiPath = '/installation-appointment'
@@ -49,6 +50,26 @@ context('Monitoring conditions', () => {
           },
         }).should('be.true')
         Page.verifyOnPage(InstallationAddressPage)
+      })
+
+      context('when the address is primary', () => {
+        it('should continue to check your answers', () => {
+          cy.task('stubCemoGetOrder', {
+            httpStatus: 200,
+            id: mockOrderId,
+            status: 'IN_PROGRESS',
+            order: {
+              installationLocation: {
+                location: 'PRIMARY',
+              },
+            },
+          })
+          const page = Page.visit(InstallationAppointmentPage, { orderId: mockOrderId })
+          page.form.fillInWith(validFormData)
+          page.form.saveAndContinueButton.click()
+
+          Page.verifyOnPage(MonitoringConditionsCheckYourAnswersPage, 'Check your answers')
+        })
       })
     })
   })

--- a/integration_tests/e2e/order/monitoring-conditions/installation-location.page.draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/installation-location.page.draft.cy.ts
@@ -118,6 +118,14 @@ context('Installation location page', () => {
     page.form.locationField.shouldNotHaveOption('At an immigration removal centre')
   })
 
+  it('should show options for another address', () => {
+    const page = Page.visit(InstallationLocationPage, {
+      orderId: mockOrderId,
+    })
+
+    page.form.locationField.shouldHaveOption('At another address')
+  })
+
   context('when no fixed address', () => {
     beforeEach(() =>
       stubGetOrder({
@@ -136,9 +144,7 @@ context('Installation location page', () => {
       const page = Page.visit(InstallationLocationPage, {
         orderId: mockOrderId,
       })
-      page.form.locationField.shouldHaveOption(
-        "At another address (for example, a relatives address they don't live at)",
-      )
+      page.form.locationField.shouldHaveOption('At another address')
     })
   })
 

--- a/integration_tests/e2e/order/monitoring-conditions/installation-location.page.submission.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/installation-location.page.submission.cy.ts
@@ -5,7 +5,6 @@ import InstallationAppointmentPage from '../../../pages/order/monitoring-conditi
 
 import MonitoringConditionsCheckYourAnswersPage from '../../../pages/order/monitoring-conditions/check-your-answers'
 import CheckYourAnswersPage from '../../../pages/checkYourAnswersPage'
-import InstallationAddressPage from '../../../pages/order/monitoring-conditions/installation-address'
 
 const mockOrderId = uuidv4()
 const apiPath = '/installation-location'
@@ -219,7 +218,7 @@ context('Monitoring conditions', () => {
           Page.verifyOnPage(InstallationAppointmentPage)
         })
 
-        it('no selecting at another address', () => {
+        it('when selecting at another address', () => {
           const orderWithoutFixedAddress = { ...mockDefaultOrder }
           orderWithoutFixedAddress.addresses = []
           orderWithoutFixedAddress.deviceWearer.noFixedAbode = true
@@ -245,7 +244,7 @@ context('Monitoring conditions', () => {
           }
           page.form.fillInWith(validFormData)
           page.form.saveAndContinueButton.click()
-          Page.verifyOnPage(InstallationAddressPage)
+          Page.verifyOnPage(InstallationAppointmentPage)
 
           cy.task('stubCemoVerifyRequestReceived', {
             uri: `/orders/${mockOrderId}${apiPath}`,

--- a/integration_tests/e2e/order/monitoring-conditions/installation-location.page.submission.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/installation-location.page.submission.cy.ts
@@ -254,6 +254,47 @@ context('Monitoring conditions', () => {
             },
           }).should('be.true')
         })
+
+        context('when home office', () => {
+          it('and I select primary address', () => {
+            const homeOfficeOrder = {
+              ...mockDefaultOrder,
+              interestedParties: {
+                notifyingOrganisation: 'HOME_OFFICE',
+                notifyingOrganisationName: '',
+                notifyingOrganisationEmail: 'notifying@organisation',
+                responsibleOrganisation: 'POLICE',
+                responsibleOfficerPhoneNumber: '01234567891',
+                responsibleOrganisationEmail: 'responsible@organisation',
+                responsibleOrganisationRegion: '',
+                responsibleOfficerName: 'name',
+              },
+            }
+            cy.task('stubCemoGetOrder', {
+              httpStatus: 200,
+              id: mockOrderId,
+              status: 'IN_PROGRESS',
+              order: homeOfficeOrder,
+            })
+
+            cy.task('stubCemoSubmitOrder', {
+              httpStatus: 200,
+              id: mockOrderId,
+              subPath: apiPath,
+              response: {
+                location: 'PRIMARY',
+              },
+            })
+
+            const page = Page.visit(InstallationLocationPage, { orderId: mockOrderId })
+            const validFormData = {
+              location: '10',
+            }
+            page.form.fillInWith(validFormData)
+            page.form.saveAndContinueButton.click()
+            Page.verifyOnPage(InstallationAppointmentPage)
+          })
+        })
       })
 
       context('When changing an answer from the Check your Answers page', () => {

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -800,6 +800,10 @@ describe('TaskListService', () => {
         curfewConditions: createCurfewConditions(),
         curfewTimeTable: createCurfewTimeTable(),
         installationLocation: { location: 'INSTALLATION' },
+        installationAppointment: {
+          placeName: 'primary',
+          appointmentDate: 'date',
+        },
         additionalDocuments: [createAttatchment(), createAttatchment({ fileType: AttachmentType.PHOTO_ID })],
         orderParameters: { havePhoto: true },
       })
@@ -875,6 +879,10 @@ describe('TaskListService', () => {
         curfewConditions: createCurfewConditions(),
         curfewTimeTable: createCurfewTimeTable(),
         installationLocation: { location: 'INSTALLATION' },
+        installationAppointment: {
+          placeName: 'primary',
+          appointmentDate: 'date',
+        },
         additionalDocuments: [createAttatchment(), createAttatchment({ fileType: AttachmentType.PHOTO_ID })],
         orderParameters: { havePhoto: true },
       })

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -623,6 +623,7 @@ export default class TaskListService {
         order.installationLocation?.location === 'PRISON' ||
           order.installationLocation?.location === 'PROBATION_OFFICE' ||
           order.installationLocation?.location === 'IMMIGRATION_REMOVAL_CENTRE' ||
+          order.installationLocation?.location === 'INSTALLATION' ||
           order.interestedParties?.notifyingOrganisation === 'HOME_OFFICE',
         STATES.cantBeStarted,
         STATES.required,

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -622,7 +622,8 @@ export default class TaskListService {
       state: convertBooleanToEnum<State>(
         order.installationLocation?.location === 'PRISON' ||
           order.installationLocation?.location === 'PROBATION_OFFICE' ||
-          order.installationLocation?.location === 'IMMIGRATION_REMOVAL_CENTRE',
+          order.installationLocation?.location === 'IMMIGRATION_REMOVAL_CENTRE' ||
+          order.interestedParties?.notifyingOrganisation === 'HOME_OFFICE',
         STATES.cantBeStarted,
         STATES.required,
         STATES.notRequired,

--- a/server/views/pages/order/monitoring-conditions/installation-location.njk
+++ b/server/views/pages/order/monitoring-conditions/installation-location.njk
@@ -57,13 +57,12 @@
       disabled: not isOrderEditable
     }]) %}
   {% endif %}
-  {% if not fixedAddressExist %}
-    {% set items = items.concat([{
-      value: "INSTALLATION",
-      text: "At another address (for example, a relatives address they don't live at)",
-      disabled: not isOrderEditable
-    }]) %}
-  {% endif %}
+
+  {% set items = items.concat([{
+    value: "INSTALLATION",
+    text: "At another address",
+    disabled: not isOrderEditable
+  }]) %}
 
   {{ govukRadios({
     name: "location",

--- a/test/mocks/mockOrder.ts
+++ b/test/mocks/mockOrder.ts
@@ -65,7 +65,7 @@ export const createInstallationAndRisk = (overrideProperties?: Partial<Installat
 })
 
 export const createInterestedParties = (overrideProperties?: Partial<InterestedParties>): InterestedParties => ({
-  notifyingOrganisation: 'HOME_OFFICE',
+  notifyingOrganisation: 'PRISON',
   notifyingOrganisationName: '',
   notifyingOrganisationEmail: '',
   responsibleOfficerName: '',

--- a/test/mocks/mockOrder.ts
+++ b/test/mocks/mockOrder.ts
@@ -267,6 +267,10 @@ export const getFilledMockOrder = (overrideProperties?: Partial<Order>): Order =
   installationLocation: {
     location: 'INSTALLATION',
   },
+  installationAppointment: {
+    placeName: 'place',
+    appointmentDate: 'date',
+  },
   orderParameters: null,
   versionId: randomUUID(),
   dapoClauses: [],


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4743

Serco have also reported that they need an appointment for install at another address

Home Office install at another address

Add the ability for anyone to select "at another address", even when a primary address exists