### PR TITLE
skip licence upload for home office

### DIFF
--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -680,7 +680,7 @@ export default class TaskListService {
         completed:
           doesOrderHaveDocument(order, AttachmentType.COURT_ORDER) || order.orderParameters?.haveCourtOrder === false,
       })
-    } else {
+    } else if (order.interestedParties?.notifyingOrganisation !== 'HOME_OFFICE') {
       tasks.push({
         section: SECTIONS.additionalDocuments,
         name: PAGES.licenceUpload,


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4737

We also need to skip the licence / court order upload page when the notifying org is home office