### PR TITLE
only show licence answer if not home office

### DIFF
--- a/server/models/view-models/additionalDocumentsCheckAnswers.ts
+++ b/server/models/view-models/additionalDocumentsCheckAnswers.ts
@@ -41,7 +41,7 @@ const createViewModel = (order: Order, content: I18n | undefined) => {
         ),
       )
     }
-  } else {
+  } else if (order.interestedParties?.notifyingOrganisation !== 'HOME_OFFICE') {
     answers.push(
       createAttachmentAnswer(
         licence,


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4737

As we now skip straight to the upload photo question, there is no need to show the court order / licence question for home office users in the CYA page
