### PR TITLE
ELM-4742 hide offences for home office users

### DIFF
--- a/integration_tests/e2e/order/summary.cy.ts
+++ b/integration_tests/e2e/order/summary.cy.ts
@@ -12,6 +12,7 @@ import ConfirmVariationPage from '../../pages/order/variation/confirmVariation'
 import { Order } from '../../../server/models/Order'
 import paths from '../../../server/constants/paths'
 import NotifyingOrganisationPage from './interested-parties/notifying-organisation/notifyingOrganisationPage'
+import DetailsOfInstallationPage from './access-needs-installation-risk/details-of-installation/DetailsOfInstallationPage'
 
 let mockOrderId = uuidv4()
 
@@ -110,6 +111,42 @@ context('Order Summary', () => {
       cy.get('.govuk-task-list__item')
         .contains('.govuk-task-list__name-and-hint', 'Contact information')
         .should('not.exist')
+    })
+
+    it('Home Officers users go to risk at installation from task list when offence flow is enabled', () => {
+      const testFlags = { OFFENCE_FLOW_ENABLED: true }
+      cy.task('setFeatureFlags', testFlags)
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+        order: {
+          dataDictionaryVersion: 'DDV6',
+          interestedParties: {
+            notifyingOrganisation: 'HOME_OFFICE',
+            notifyingOrganisationName: '',
+            notifyingOrganisationEmail: 'test@test.com',
+            responsibleOfficerName: 'John Smith',
+            responsibleOfficerPhoneNumber: '01234567890',
+            responsibleOrganisation: 'FIELD_MONITORING_SERVICE',
+            responsibleOrganisationRegion: '',
+            responsibleOrganisationEmail: '',
+          },
+        },
+      })
+
+      const page = Page.visit(OrderTasksPage, { orderId: mockOrderId })
+
+      page.riskInformationTask.shouldHaveStatus('Incomplete')
+      page.riskInformationTask.link.should(
+        'have.attr',
+        'href',
+        `/order/${mockOrderId}/installation-and-risk/details-of-installation`,
+      )
+      page.riskInformationTask.click()
+
+      Page.verifyOnPage(DetailsOfInstallationPage)
     })
   })
 

--- a/integration_tests/scenarios/all-condition-default-start-and-end-times.cy.ts
+++ b/integration_tests/scenarios/all-condition-default-start-and-end-times.cy.ts
@@ -270,7 +270,7 @@ context('The kitchen sink', () => {
             no_name: interestedParties.notifyingOrganisationName,
             no_phone_number: '',
             offence: installationAndRisk.offence,
-            offence_additional_details: 'PFA: Avon and Somerset',
+            offence_additional_details: 'PFA: Avon and Somerset Constabulary',
             offence_date: '',
             order_end: formatAsFmsDateTime(trailMonitoringOrder.endDate, 23, 59),
             order_id: orderId,

--- a/integration_tests/scenarios/order/access-needs-installation-risk/mappa.cy.ts
+++ b/integration_tests/scenarios/order/access-needs-installation-risk/mappa.cy.ts
@@ -1,3 +1,4 @@
+import DetailsOfInstallationPage from '../../../e2e/order/access-needs-installation-risk/details-of-installation/DetailsOfInstallationPage'
 import IsMappaPage from '../../../e2e/order/access-needs-installation-risk/is-mappa/IsMappaPage'
 import MappaPage from '../../../e2e/order/access-needs-installation-risk/mappa/MappaPage'
 import { createFakeAdultDeviceWearer, createFakeInterestedParties } from '../../../mockApis/faker'
@@ -5,7 +6,6 @@ import IndexPage from '../../../pages'
 import InstallationAndRiskCheckYourAnswersPage from '../../../pages/order/installation-and-risk/check-your-answers'
 import OrderSummaryPage from '../../../pages/order/summary'
 import Page from '../../../pages/page'
-import fillInOffenceWith from '../../../utils/scenario-flows/offence.cy'
 
 context('offences', () => {
   let orderSummaryPage: OrderSummaryPage
@@ -19,8 +19,6 @@ context('offences', () => {
     hasFixedAddress: 'No',
   }
 
-  const offenceDetails = { offenceType: 'Criminal damage and arson' }
-  const offenceOtherInfo = { hasOtherInformation: 'No' }
   const detailsOfInstallationInfo = {
     possibleRisks: ['Violent behaviour or threats of violence'],
     riskCategories: ['Safeguarding child'],
@@ -57,7 +55,9 @@ context('offences', () => {
       interestedParties,
     })
 
-    fillInOffenceWith({ offenceDetails, offenceOtherInfo, detailsOfInstallationInfo })
+    const detailsOfInstallationPage = Page.verifyOnPage(DetailsOfInstallationPage)
+    detailsOfInstallationPage.form.fillInWith(detailsOfInstallationInfo)
+    detailsOfInstallationPage.form.saveAndContinueButton.click()
 
     const isMappaPage = Page.verifyOnPage(IsMappaPage)
     isMappaPage.form.fillInWith({ isMappa: 'Yes' })
@@ -68,6 +68,11 @@ context('offences', () => {
     mappaPage.form.saveAndContinueButton.click()
 
     const cyaPage = Page.verifyOnPage(InstallationAndRiskCheckYourAnswersPage, 'Check your answers')
+    cyaPage.installationRiskSection.shouldNotHaveItem('What type of offence did the device wearer commit?')
+    cyaPage.installationRiskSection.shouldNotHaveItem(
+      'Any other information to be aware of about the offence committed?',
+    )
+    cyaPage.installationRiskSection.shouldNotHaveItem('Offences')
     cyaPage.installationRiskSection.shouldHaveItem(
       'Is the device wearer a Multi-Agency Public Protection Arrangements (MAPPA) offender?',
       'Yes',
@@ -86,13 +91,20 @@ context('offences', () => {
       interestedParties,
     })
 
-    fillInOffenceWith({ offenceDetails, offenceOtherInfo, detailsOfInstallationInfo })
+    const detailsOfInstallationPage = Page.verifyOnPage(DetailsOfInstallationPage)
+    detailsOfInstallationPage.form.fillInWith(detailsOfInstallationInfo)
+    detailsOfInstallationPage.form.saveAndContinueButton.click()
 
     const isMappaPage = Page.verifyOnPage(IsMappaPage)
     isMappaPage.form.fillInWith({ isMappa: 'No' })
     isMappaPage.form.saveAndContinueButton.click()
 
     const cyaPage = Page.verifyOnPage(InstallationAndRiskCheckYourAnswersPage, 'Check your answers')
+    cyaPage.installationRiskSection.shouldNotHaveItem('What type of offence did the device wearer commit?')
+    cyaPage.installationRiskSection.shouldNotHaveItem(
+      'Any other information to be aware of about the offence committed?',
+    )
+    cyaPage.installationRiskSection.shouldNotHaveItem('Offences')
     cyaPage.installationRiskSection.shouldHaveItem(
       'Is the device wearer a Multi-Agency Public Protection Arrangements (MAPPA) offender?',
       'No',

--- a/integration_tests/scenarios/order/access-needs-installation-risk/offences.cy.ts
+++ b/integration_tests/scenarios/order/access-needs-installation-risk/offences.cy.ts
@@ -217,20 +217,13 @@ context('offences', () => {
       },
     ])
   })
-  it('Notifying organisation is Home Office, no offence committed flow', () => {
+  it('Notifying organisation is Home Office, skips to risk at installation', () => {
     const interestedParties = createFakeInterestedParties('Home Office', 'Home Office')
     orderSummaryPage.fillInGeneralOrderDetailsWith({
       deviceWearerDetails,
       interestedParties,
     })
 
-    const offencePage = Page.verifyOnPage(OffencePage)
-
-    offencePage.form.fillInWith({ offenceType: 'They have not committed an offence' })
-    offencePage.form.saveAndContinueButton.click()
-    const offenceOtherInfoPage = Page.verifyOnPage(OffenceOtherInfoPage)
-    offenceOtherInfoPage.form.hasOtherInformationField.set('No')
-    offenceOtherInfoPage.form.saveAndContinueButton.click()
     const detailsOfInstallationPage = Page.verifyOnPage(DetailsOfInstallationPage)
     detailsOfInstallationPage.form.fillInWith(detailsOfInstallation)
     detailsOfInstallationPage.form.saveAndContinueButton.click()
@@ -238,33 +231,11 @@ context('offences', () => {
     isMappaPage.form.fillInWith({ isMappa: 'No' })
     isMappaPage.form.saveAndContinueButton.click()
     const cyaPage = Page.verifyOnPage(InstallationAndRiskCheckYourAnswersPage, 'Check your answer')
-    cyaPage.installationRiskSection.shouldHaveItems([
-      {
-        key: 'What type of offence did the device wearer commit?',
-        value: 'They have not committed an offence', // verify new option for home office
-      },
-      {
-        key: 'Any other information to be aware of about the offence committed?',
-        value: '',
-      },
-      {
-        key: "At installation what are the possible risks from the device wearer's behaviour?",
-        value: 'Violent behaviour or threats of violence',
-      },
-      {
-        key: 'What are the possible risks at the installation address? (optional)',
-        value: 'Safeguarding child',
-      },
-      {
-        key: 'Any other risks to be aware of? (optional)',
-        value: 'some details',
-      },
-      {
-        key: 'Is the device wearer a Multi-Agency Public Protection Arrangements (MAPPA) offender?',
-
-        value: 'No',
-      },
-    ])
+    cyaPage.installationRiskSection.shouldNotHaveItem('What type of offence did the device wearer commit?')
+    cyaPage.installationRiskSection.shouldNotHaveItem(
+      'Any other information to be aware of about the offence committed?',
+    )
+    cyaPage.installationRiskSection.shouldNotHaveItem('Offences')
   })
   it('Should able to delete dapo', () => {
     const interestedParties = createFakeInterestedParties('Family Court', 'Home Office', 'Altcourse Prison', null)

--- a/server/models/view-models/riskInformationCheckAnswers.ts
+++ b/server/models/view-models/riskInformationCheckAnswers.ts
@@ -14,6 +14,8 @@ const createViewModel = (order: Order, content: I18n, uri: string = '') => {
   const answerOpts = { ignoreActions: order.status === 'SUBMITTED' || order.status === 'ERROR' }
   const answers = []
 
+  const isHomeOfficeUser = order.interestedParties?.notifyingOrganisation === 'HOME_OFFICE'
+
   const isNewOffenceFlow =
     isOrderDataDictionarySameOrAbove('DDV6', order) && FeatureFlags.getInstance().get('OFFENCE_FLOW_ENABLED')
 
@@ -44,7 +46,7 @@ const createViewModel = (order: Order, content: I18n, uri: string = '') => {
           paths.INSTALLATION_AND_RISK.OFFENCE_LIST.replace(':orderId', order.id),
         ),
       )
-    } else {
+    } else if (!isHomeOfficeUser) {
       answers.push(
         createAnswer(
           questions.offence.text,
@@ -55,14 +57,16 @@ const createViewModel = (order: Order, content: I18n, uri: string = '') => {
       )
     }
 
-    answers.push(
-      createAnswer(
-        'Any other information to be aware of about the offence committed?',
-        order.offenceAdditionalDetails?.additionalDetails || '',
-        paths.INSTALLATION_AND_RISK.OFFENCE_OTHER_INFO.replace(':orderId', order.id),
-        answerOpts,
-      ),
-    )
+    if (!isHomeOfficeUser) {
+      answers.push(
+        createAnswer(
+          'Any other information to be aware of about the offence committed?',
+          order.offenceAdditionalDetails?.additionalDetails || '',
+          paths.INSTALLATION_AND_RISK.OFFENCE_OTHER_INFO.replace(':orderId', order.id),
+          answerOpts,
+        ),
+      )
+    }
   } else {
     answers.push(
       createAnswer(
@@ -124,7 +128,7 @@ const createViewModel = (order: Order, content: I18n, uri: string = '') => {
 
   answers.push(createAnswer(questions.riskDetails.text, riskDetailsFromOrder, riskDetailsUri, answerOpts))
 
-  if (order.interestedParties?.notifyingOrganisation === 'HOME_OFFICE') {
+  if (isHomeOfficeUser) {
     const isMappaQuestions = content.pages.isMappa.questions
     const mappaQuestions = content.pages.mappa.questions
     answers.push(

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -1299,6 +1299,33 @@ describe('TaskListService', () => {
       jest.restoreAllMocks()
     })
 
+    it('should navigate to risk at installation page when offence flow is enabled and notifyingOrganisation is HOME_OFFICE', async () => {
+      const mockGet = jest.fn((flag: string) => flag === 'OFFENCE_FLOW_ENABLED')
+      const mockGetValue = jest.fn(() => '')
+      jest.spyOn(FeatureFlags, 'getInstance').mockReturnValue({
+        get: mockGet,
+        getValue: mockGetValue,
+      } as never)
+
+      const order = getMockOrder({
+        interestedParties: createInterestedParties({
+          notifyingOrganisation: 'HOME_OFFICE',
+        }),
+      })
+
+      const taskListService = new TaskListService(mockOrderChecklistService)
+
+      const sections = await taskListService.getSections(order)
+
+      const riskInformationSection = sections.find(section => section.name === 'RISK_INFORMATION')
+
+      expect(riskInformationSection?.path).toBe(
+        paths.INSTALLATION_AND_RISK.DETAILS_OF_INSTALLATION.replace(':orderId', order.id),
+      )
+
+      jest.restoreAllMocks()
+    })
+
     it('should mark RISK_INFORMATION section as complete when offence flow is enabled and section is filled in, offence flow', async () => {
       const mockGet = jest.fn((flag: string) => flag === 'OFFENCE_FLOW_ENABLED')
       const mockGetValue = jest.fn(() => '')

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -397,7 +397,8 @@ export default class TaskListService {
         name: PAGES.offence,
         path: paths.INSTALLATION_AND_RISK.OFFENCE_NEW_ITEM,
         state: convertBooleanToEnum<State>(
-          order.interestedParties?.notifyingOrganisation !== 'FAMILY_COURT',
+          order.interestedParties?.notifyingOrganisation !== 'FAMILY_COURT' &&
+            order.interestedParties?.notifyingOrganisation !== 'HOME_OFFICE',
           STATES.cantBeStarted,
           STATES.required,
           STATES.notRequired,
@@ -409,7 +410,8 @@ export default class TaskListService {
         name: PAGES.offenceOtherInfo,
         path: paths.INSTALLATION_AND_RISK.OFFENCE_OTHER_INFO,
         state: convertBooleanToEnum<State>(
-          order.interestedParties?.notifyingOrganisation !== 'FAMILY_COURT',
+          order.interestedParties?.notifyingOrganisation !== 'FAMILY_COURT' &&
+            order.interestedParties?.notifyingOrganisation !== 'HOME_OFFICE',
           STATES.cantBeStarted,
           STATES.required,
           STATES.notRequired,


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4742

Offence pages should be hidden for Home Office users.

When users click Risk Information from the task list, they're now sent to 'details of installation" page.

On CYA page I can't see details of the offence questions.
