### PR TITLE
Elm 4209 postcode lookup address confirmation

### DIFF
--- a/integration_tests/e2e/order/postcode-lookup/address-result/submission.cy.ts
+++ b/integration_tests/e2e/order/postcode-lookup/address-result/submission.cy.ts
@@ -13,6 +13,18 @@ context('address results', () => {
       httpStatus: 200,
       id: mockOrderId,
       status: 'IN_PROGRESS',
+      order: {
+        addresses: [
+          {
+            addressType: 'PRIMARY',
+            addressLine1: '10 Downing Street',
+            addressLine2: '',
+            addressLine3: 'London',
+            addressLine4: 'ENGLAND',
+            postcode: 'SW1A 2AA',
+          },
+        ],
+      },
     })
 
     cy.signIn()

--- a/integration_tests/e2e/order/postcode-lookup/confirm-address/confirmAddressComponent.ts
+++ b/integration_tests/e2e/order/postcode-lookup/confirm-address/confirmAddressComponent.ts
@@ -1,8 +1,20 @@
 import SingleQuestionFormComponent from '../../../../pages/components/SingleQuestionFormComponent'
+import { PageElement } from '../../../../pages/page'
 
 export default class ConfirmAddressComponent extends SingleQuestionFormComponent {
   fillInWith(value: string) {
-    // TODO implement fillInWith method
     throw new Error(`Method not implemented.${value}`)
+  }
+
+  get useDifferentAddressLink(): PageElement {
+    return this.form.contains('Use a different address')
+  }
+
+  get enterAddressManuallyLink(): PageElement {
+    return this.form.contains('Enter address manually')
+  }
+
+  get useAddressButton(): PageElement {
+    return this.form.contains('Use this address')
   }
 }

--- a/integration_tests/e2e/order/postcode-lookup/confirm-address/confirmAddressComponent.ts
+++ b/integration_tests/e2e/order/postcode-lookup/confirm-address/confirmAddressComponent.ts
@@ -1,11 +1,7 @@
-import SingleQuestionFormComponent from '../../../../pages/components/SingleQuestionFormComponent'
+import FormComponent from '../../../../pages/components/formComponent'
 import { PageElement } from '../../../../pages/page'
 
-export default class ConfirmAddressComponent extends SingleQuestionFormComponent {
-  fillInWith(value: string) {
-    throw new Error(`Method not implemented.${value}`)
-  }
-
+export default class ConfirmAddressComponent extends FormComponent {
   get useDifferentAddressLink(): PageElement {
     return this.form.contains('Use a different address')
   }

--- a/integration_tests/e2e/order/postcode-lookup/confirm-address/confirmAddressPage.ts
+++ b/integration_tests/e2e/order/postcode-lookup/confirm-address/confirmAddressPage.ts
@@ -6,6 +6,6 @@ export default class ConfirmAddressPage extends AppFormPage {
   public form = new ConfirmAddressComponent()
 
   constructor() {
-    super('WIP Confirm Address', paths.POSTCODE_LOOKUP.FIND_ADDRESS)
+    super(/Confirm the .* address/, paths.POSTCODE_LOOKUP.CONFIRM_ADDRESS)
   }
 }

--- a/integration_tests/e2e/order/postcode-lookup/confirm-address/draft.cy.ts
+++ b/integration_tests/e2e/order/postcode-lookup/confirm-address/draft.cy.ts
@@ -25,7 +25,7 @@ context('confirm address page', () => {
           },
           {
             addressType: 'SECONDARY',
-            addressLine1: '10 Downing Street',
+            addressLine1: '11 Downing Street',
             addressLine2: '',
             addressLine3: 'London',
             addressLine4: 'ENGLAND',
@@ -33,38 +33,11 @@ context('confirm address page', () => {
           },
           {
             addressType: 'INSTALLATION',
-            addressLine1: '10 Downing Street',
+            addressLine1: '12 Downing Street',
             addressLine2: '',
             addressLine3: 'London',
             addressLine4: 'ENGLAND',
             postcode: 'SW1A 2AA',
-          },
-        ],
-      },
-    })
-
-    cy.task('stubOSDataHubPostcode', {
-      httpStatus: 200,
-      postcode: 'SW1A2AA',
-      body: {
-        results: [
-          {
-            DPA: {
-              BUILDING_NUMBER: 10,
-              THOROUGHFARE_NAME: 'DOWNING STREET',
-              POST_TOWN: 'LONDON',
-              POSTCODE: 'SW1A 2AA',
-              UPRN: '101',
-            },
-          },
-          {
-            DPA: {
-              BUILDING_NUMBER: 11,
-              THOROUGHFARE_NAME: 'DOWNING STREET',
-              POST_TOWN: 'LONDON',
-              POSTCODE: 'SW1A 2AA',
-              UPRN: '102',
-            },
           },
         ],
       },
@@ -82,8 +55,6 @@ context('confirm address page', () => {
 
     cy.contains('About the device wearer')
     cy.contains("Confirm the device wearer's address")
-    cy.contains('1 address found for SW1A 2AA and 10.')
-    cy.contains('Search again')
     cy.contains('10 Downing Street')
     cy.contains('London')
     cy.contains('SW1A 2AA')
@@ -110,9 +81,7 @@ context('confirm address page', () => {
 
     cy.contains('About the device wearer')
     cy.contains('Confirm the curfew address')
-    cy.contains('1 address found for SW1A 2AA and 10.')
-    cy.contains('Search again')
-    cy.contains('10 Downing Street')
+    cy.contains('11 Downing Street')
     cy.contains('London')
     cy.contains('SW1A 2AA')
 
@@ -129,7 +98,7 @@ context('confirm address page', () => {
     )
   })
 
-  it('has correct elements for instlalation address confirmation', () => {
+  it('has correct elements for installation address confirmation', () => {
     const page = Page.visit(
       ConfirmAddressPage,
       { orderId: mockOrderId, addressType: 'INSTALLATION' },
@@ -138,9 +107,7 @@ context('confirm address page', () => {
 
     cy.contains('Electronic monitoring required')
     cy.contains('Confirm the installation address')
-    cy.contains('1 address found for SW1A 2AA and 10.')
-    cy.contains('Search again')
-    cy.contains('10 Downing Street')
+    cy.contains('12 Downing Street')
     cy.contains('London')
     cy.contains('SW1A 2AA')
 

--- a/integration_tests/e2e/order/postcode-lookup/confirm-address/draft.cy.ts
+++ b/integration_tests/e2e/order/postcode-lookup/confirm-address/draft.cy.ts
@@ -1,0 +1,159 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../../pages/page'
+import ConfirmAddressPage from './confirmAddressPage'
+import paths from '../../../../../server/constants/paths'
+
+context('confirm address page', () => {
+  const mockOrderId = uuidv4()
+
+  beforeEach(() => {
+    cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+    cy.task('stubCemoGetOrder', {
+      httpStatus: 200,
+      id: mockOrderId,
+      status: 'IN_PROGRESS',
+      order: {
+        addresses: [
+          {
+            addressType: 'PRIMARY',
+            addressLine1: '10 Downing Street',
+            addressLine2: '',
+            addressLine3: 'London',
+            addressLine4: 'ENGLAND',
+            postcode: 'SW1A 2AA',
+          },
+          {
+            addressType: 'SECONDARY',
+            addressLine1: '10 Downing Street',
+            addressLine2: '',
+            addressLine3: 'London',
+            addressLine4: 'ENGLAND',
+            postcode: 'SW1A 2AA',
+          },
+          {
+            addressType: 'INSTALLATION',
+            addressLine1: '10 Downing Street',
+            addressLine2: '',
+            addressLine3: 'London',
+            addressLine4: 'ENGLAND',
+            postcode: 'SW1A 2AA',
+          },
+        ],
+      },
+    })
+
+    cy.task('stubOSDataHubPostcode', {
+      httpStatus: 200,
+      postcode: 'SW1A2AA',
+      body: {
+        results: [
+          {
+            DPA: {
+              BUILDING_NUMBER: 10,
+              THOROUGHFARE_NAME: 'DOWNING STREET',
+              POST_TOWN: 'LONDON',
+              POSTCODE: 'SW1A 2AA',
+              UPRN: '101',
+            },
+          },
+          {
+            DPA: {
+              BUILDING_NUMBER: 11,
+              THOROUGHFARE_NAME: 'DOWNING STREET',
+              POST_TOWN: 'LONDON',
+              POSTCODE: 'SW1A 2AA',
+              UPRN: '102',
+            },
+          },
+        ],
+      },
+    })
+
+    cy.signIn()
+  })
+
+  it('has correct elements for device wearer address confirmation', () => {
+    const page = Page.visit(
+      ConfirmAddressPage,
+      { orderId: mockOrderId, addressType: 'PRIMARY' },
+      { postcode: 'SW1A 2AA', buildingId: '10' },
+    )
+
+    cy.contains('About the device wearer')
+    cy.contains("Confirm the device wearer's address")
+    cy.contains('1 address found for SW1A 2AA and 10.')
+    cy.contains('Search again')
+    cy.contains('10 Downing Street')
+    cy.contains('London')
+    cy.contains('SW1A 2AA')
+
+    page.form.useDifferentAddressLink.should(
+      'have.attr',
+      'href',
+      `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', mockOrderId).replace(':addressType', 'PRIMARY')}?postcode=SW1A+2AA&buildingId=10`,
+    )
+
+    page.form.enterAddressManuallyLink.should(
+      'have.attr',
+      'href',
+      paths.POSTCODE_LOOKUP.ENTER_ADDRESS.replace(':orderId', mockOrderId).replace(':addressType', 'PRIMARY'),
+    )
+  })
+
+  it('has correct elements for curfew address confirmation', () => {
+    const page = Page.visit(
+      ConfirmAddressPage,
+      { orderId: mockOrderId, addressType: 'SECONDARY' },
+      { postcode: 'SW1A 2AA', buildingId: '10' },
+    )
+
+    cy.contains('About the device wearer')
+    cy.contains('Confirm the curfew address')
+    cy.contains('1 address found for SW1A 2AA and 10.')
+    cy.contains('Search again')
+    cy.contains('10 Downing Street')
+    cy.contains('London')
+    cy.contains('SW1A 2AA')
+
+    page.form.useDifferentAddressLink.should(
+      'have.attr',
+      'href',
+      `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', mockOrderId).replace(':addressType', 'SECONDARY')}?postcode=SW1A+2AA&buildingId=10`,
+    )
+
+    page.form.enterAddressManuallyLink.should(
+      'have.attr',
+      'href',
+      paths.POSTCODE_LOOKUP.ENTER_ADDRESS.replace(':orderId', mockOrderId).replace(':addressType', 'SECONDARY'),
+    )
+  })
+
+  it('has correct elements for instlalation address confirmation', () => {
+    const page = Page.visit(
+      ConfirmAddressPage,
+      { orderId: mockOrderId, addressType: 'INSTALLATION' },
+      { postcode: 'SW1A 2AA', buildingId: '10' },
+    )
+
+    cy.contains('Electronic monitoring required')
+    cy.contains('Confirm the installation address')
+    cy.contains('1 address found for SW1A 2AA and 10.')
+    cy.contains('Search again')
+    cy.contains('10 Downing Street')
+    cy.contains('London')
+    cy.contains('SW1A 2AA')
+
+    page.form.useDifferentAddressLink.should(
+      'have.attr',
+      'href',
+      `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', mockOrderId).replace(':addressType', 'INSTALLATION')}?postcode=SW1A+2AA&buildingId=10`,
+    )
+
+    page.form.enterAddressManuallyLink.should(
+      'have.attr',
+      'href',
+      paths.POSTCODE_LOOKUP.ENTER_ADDRESS.replace(':orderId', mockOrderId).replace(':addressType', 'INSTALLATION'),
+    )
+  })
+})

--- a/integration_tests/e2e/order/postcode-lookup/confirm-address/submission.cy.ts
+++ b/integration_tests/e2e/order/postcode-lookup/confirm-address/submission.cy.ts
@@ -1,0 +1,201 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../../pages/page'
+import ConfirmAddressPage from './confirmAddressPage'
+import AddressListPage from '../address-list/addressListPage'
+import OrderSummaryPage from '../../../../pages/order/summary'
+import MonitoringConditionsCheckYourAnswersPage from '../../../../pages/order/monitoring-conditions/check-your-answers'
+
+context('confirm address page submission', () => {
+  context('device wearer and curfew addresses', () => {
+    const mockOrderId = uuidv4()
+
+    beforeEach(() => {
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+        order: {
+          addresses: [
+            {
+              addressType: 'PRIMARY',
+              addressLine1: '10 downing street',
+              addressLine2: '',
+              addressLine3: 'London',
+              addressLine4: 'ENGLAND',
+              postcode: 'SW1A 2AA',
+            },
+            {
+              addressType: 'SECONDARY',
+              addressLine1: '10 downing street',
+              addressLine2: '',
+              addressLine3: 'London',
+              addressLine4: 'ENGLAND',
+              postcode: 'SW1A 2AA',
+            },
+            {
+              addressType: 'INSTALLATION',
+              addressLine1: '10 downing street',
+              addressLine2: '',
+              addressLine3: 'London',
+              addressLine4: 'ENGLAND',
+              postcode: 'SW1A 2AA',
+            },
+          ],
+        },
+      })
+
+      cy.task('stubOSDataHubPostcode', {
+        httpStatus: 200,
+        postcode: 'SW1A2AA',
+        body: {
+          results: [
+            {
+              DPA: {
+                BUILDING_NUMBER: 10,
+                THOROUGHFARE_NAME: 'DOWNING STREET',
+                POST_TOWN: 'LONDON',
+                POSTCODE: 'SW1A 2AA',
+                UPRN: '101',
+              },
+            },
+            {
+              DPA: {
+                BUILDING_NUMBER: 11,
+                THOROUGHFARE_NAME: 'DOWNING STREET',
+                POST_TOWN: 'LONDON',
+                POSTCODE: 'SW1A 2AA',
+                UPRN: '102',
+              },
+            },
+          ],
+        },
+      })
+
+      cy.signIn()
+    })
+
+    it('continues to address list for device wearer address', () => {
+      const page = Page.visit(
+        ConfirmAddressPage,
+        { orderId: mockOrderId, addressType: 'PRIMARY' },
+        { postcode: 'SW1A 2AA', buildingId: '10' },
+      )
+
+      page.form.useAddressButton.click()
+
+      Page.verifyOnPage(AddressListPage, { orderId: mockOrderId })
+    })
+
+    it('continues to the address list for the curfew address', () => {
+      const page = Page.visit(
+        ConfirmAddressPage,
+        { orderId: mockOrderId, addressType: 'SECONDARY' },
+        { postcode: 'SW1A 2AA', buildingId: '10' },
+      )
+
+      page.form.useAddressButton.click()
+
+      Page.verifyOnPage(AddressListPage, { orderId: mockOrderId })
+    })
+
+    it('return to summmary when save as draft', () => {
+      const page = Page.visit(
+        ConfirmAddressPage,
+        { orderId: mockOrderId, addressType: 'INSTALLATION' },
+        { postcode: 'SW1A 2AA', buildingId: '10' },
+      )
+
+      page.form.saveAsDraftButton.click()
+      Page.verifyOnPage(OrderSummaryPage)
+    })
+  })
+  context('installation address', () => {
+    const mockOrderId = uuidv4()
+
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+        order: {
+          monitoringConditions: {
+            orderType: null,
+            curfew: false,
+            exclusionZone: false,
+            trail: false,
+            mandatoryAttendance: false,
+            alcohol: true,
+            orderTypeDescription: null,
+            conditionType: null,
+            startDate: null,
+            endDate: null,
+            sentenceType: null,
+            issp: null,
+            hdc: null,
+            offenceType: null,
+            prarr: null,
+            pilot: null,
+            dapolMissedInError: null,
+            isValid: false,
+          },
+          addresses: [
+            {
+              addressType: 'INSTALLATION',
+              addressLine1: '10 downing street',
+              addressLine2: '',
+              addressLine3: 'London',
+              addressLine4: 'ENGLAND',
+              postcode: 'SW1A 2AA',
+            },
+          ],
+        },
+      })
+
+      cy.task('stubOSDataHubPostcode', {
+        httpStatus: 200,
+        postcode: 'SW1A2AA',
+        body: {
+          results: [
+            {
+              DPA: {
+                BUILDING_NUMBER: 10,
+                THOROUGHFARE_NAME: 'DOWNING STREET',
+                POST_TOWN: 'LONDON',
+                POSTCODE: 'SW1A 2AA',
+                UPRN: '101',
+              },
+            },
+            {
+              DPA: {
+                BUILDING_NUMBER: 11,
+                THOROUGHFARE_NAME: 'DOWNING STREET',
+                POST_TOWN: 'LONDON',
+                POSTCODE: 'SW1A 2AA',
+                UPRN: '102',
+              },
+            },
+          ],
+        },
+      })
+
+      cy.signIn()
+    })
+
+    it('continues to next page using task list', () => {
+      const page = Page.visit(
+        ConfirmAddressPage,
+        { orderId: mockOrderId, addressType: 'INSTALLATION' },
+        { postcode: 'SW1A 2AA', buildingId: '10' },
+      )
+
+      page.form.useAddressButton.click()
+
+      Page.verifyOnPage(MonitoringConditionsCheckYourAnswersPage, 'Check your answers')
+    })
+  })
+})

--- a/integration_tests/e2e/order/postcode-lookup/confirm-address/submission.cy.ts
+++ b/integration_tests/e2e/order/postcode-lookup/confirm-address/submission.cy.ts
@@ -129,33 +129,6 @@ context('confirm address page submission', () => {
         },
       })
 
-      cy.task('stubOSDataHubPostcode', {
-        httpStatus: 200,
-        postcode: 'SW1A2AA',
-        body: {
-          results: [
-            {
-              DPA: {
-                BUILDING_NUMBER: 10,
-                THOROUGHFARE_NAME: 'DOWNING STREET',
-                POST_TOWN: 'LONDON',
-                POSTCODE: 'SW1A 2AA',
-                UPRN: '101',
-              },
-            },
-            {
-              DPA: {
-                BUILDING_NUMBER: 11,
-                THOROUGHFARE_NAME: 'DOWNING STREET',
-                POST_TOWN: 'LONDON',
-                POSTCODE: 'SW1A 2AA',
-                UPRN: '102',
-              },
-            },
-          ],
-        },
-      })
-
       cy.signIn()
     })
 

--- a/integration_tests/e2e/order/postcode-lookup/confirm-address/submission.cy.ts
+++ b/integration_tests/e2e/order/postcode-lookup/confirm-address/submission.cy.ts
@@ -46,33 +46,6 @@ context('confirm address page submission', () => {
         },
       })
 
-      cy.task('stubOSDataHubPostcode', {
-        httpStatus: 200,
-        postcode: 'SW1A2AA',
-        body: {
-          results: [
-            {
-              DPA: {
-                BUILDING_NUMBER: 10,
-                THOROUGHFARE_NAME: 'DOWNING STREET',
-                POST_TOWN: 'LONDON',
-                POSTCODE: 'SW1A 2AA',
-                UPRN: '101',
-              },
-            },
-            {
-              DPA: {
-                BUILDING_NUMBER: 11,
-                THOROUGHFARE_NAME: 'DOWNING STREET',
-                POST_TOWN: 'LONDON',
-                POSTCODE: 'SW1A 2AA',
-                UPRN: '102',
-              },
-            },
-          ],
-        },
-      })
-
       cy.signIn()
     })
 

--- a/integration_tests/scenarios/order/postcode-lookup/postcode-lookup.cy.ts
+++ b/integration_tests/scenarios/order/postcode-lookup/postcode-lookup.cy.ts
@@ -85,7 +85,9 @@ context('Postcode Lookup', () => {
     // TODO Check answer
   })
 
-  it('Should able to enter address manually', () => {
+  // disabled as confirm address page relies on address existing
+  // re-enable when manual address page is added
+  it.skip('Should able to enter address manually', () => {
     orderSummaryPage.fillInGeneralOrderDetailsWith({
       deviceWearerDetails,
     })

--- a/integration_tests/utils/scenario-flows/postcode-lookup.cy.ts
+++ b/integration_tests/utils/scenario-flows/postcode-lookup.cy.ts
@@ -24,7 +24,7 @@ export default function fillinAddress({ findAddress, addressResult }) {
   }
 
   const confirmAddressPage = Page.verifyOnPage(ConfirmAddressPage)
-  confirmAddressPage.form.continueButton.click()
+  confirmAddressPage.form.useAddressButton.click()
 
   const addressListPage = Page.verifyOnPage(AddressListPage)
   addressListPage.form.continueButton.click()

--- a/server/i18n/en/index.ts
+++ b/server/i18n/en/index.ts
@@ -46,10 +46,19 @@ import dapaClauseListPageContent from './pages/dapoClauseListPage'
 import notifyingOrganisationPageContent from './pages/notifyingOrganisation'
 import responsibleOrganisationPageContent from './pages/responsibleOrganisation'
 import responsibleOfficerPageContent from './pages/responsibleOfficer'
-import deviceWearerAddressPageContent, { deviceWearerAddressResultPageContent } from './pages/deviceWearerAddress'
-import tagAtSourceAddressPageContent, { tagAtSourceAddressResultPageContent } from './pages/tagAtSourceAddress'
-import curfewAddressPageContent, { curfewAddressResultPageContent } from './pages/curfewAddress'
-import appointmentAddressPageContent from './pages/appointmentAddress'
+import deviceWearerAddressPageContent, {
+  deviceWearerAddressConfirmPageContent,
+  deviceWearerAddressResultPageContent,
+} from './pages/deviceWearerAddress'
+import tagAtSourceAddressPageContent, {
+  tagAtSourceAddressConfirmPageContent,
+  tagAtSourceAddressResultPageContent,
+} from './pages/tagAtSourceAddress'
+import curfewAddressPageContent, {
+  curfewAddressConfirmPageContent,
+  curfewAddressResultPageContent,
+} from './pages/curfewAddress'
+import appointmentAddressPageContent, { appointmentAddressConfirmPageContent } from './pages/appointmentAddress'
 import nationalSecurityDirectoratePageConetent from './pages/national-security-directorate'
 import isAddressChangePageContent from './pages/isAddressChange'
 
@@ -103,11 +112,15 @@ const getEnglishContent = (ddVersion: DataDictionaryVersion): I18n => {
       responsibleOfficer: responsibleOfficerPageContent,
       deviceWearerAddress: deviceWearerAddressPageContent,
       deviceWearerAddressResult: deviceWearerAddressResultPageContent,
+      deviceWearerAddressConfirm: deviceWearerAddressConfirmPageContent,
       tagAtSourceAddress: tagAtSourceAddressPageContent,
       tagAtSourceAddressResult: tagAtSourceAddressResultPageContent,
+      tagAtSourceAddressConfirm: tagAtSourceAddressConfirmPageContent,
       curfewAddress: curfewAddressPageContent,
       curfewAddressResult: curfewAddressResultPageContent,
+      curfewAddressConfirm: curfewAddressConfirmPageContent,
       appointmentAddress: appointmentAddressPageContent,
+      appointmentAddressConfirm: appointmentAddressConfirmPageContent,
       nationalSecurityDirectorate: nationalSecurityDirectoratePageConetent,
       isAddressChange: isAddressChangePageContent,
     },

--- a/server/i18n/en/pages/appointmentAddress.ts
+++ b/server/i18n/en/pages/appointmentAddress.ts
@@ -1,4 +1,4 @@
-import PostcodeLookupPageContent from '../../../types/i18n/pages/postcodeLookup'
+import PostcodeLookupPageContent, { ConfirmAddressPageContent } from '../../../types/i18n/pages/postcodeLookup'
 
 const appointmentAddressPageContent: PostcodeLookupPageContent = {
   title: 'Find the appointment address',
@@ -15,6 +15,13 @@ const appointmentAddressPageContent: PostcodeLookupPageContent = {
       hint: 'For example, 15 or Prospect Cottage',
     },
   },
+}
+
+export const appointmentAddressConfirmPageContent: ConfirmAddressPageContent = {
+  title: 'Confirm the appointment address',
+  section: 'Electronic monitoring required',
+  legend: '',
+  helpText: '',
 }
 
 export default appointmentAddressPageContent

--- a/server/i18n/en/pages/curfewAddress.ts
+++ b/server/i18n/en/pages/curfewAddress.ts
@@ -1,4 +1,7 @@
-import PostcodeLookupPageContent, { AddressResultPageContent } from '../../../types/i18n/pages/postcodeLookup'
+import PostcodeLookupPageContent, {
+  AddressResultPageContent,
+  ConfirmAddressPageContent,
+} from '../../../types/i18n/pages/postcodeLookup'
 
 const curfewAddressPageContent: PostcodeLookupPageContent = {
   title: 'Find the curfew address',
@@ -19,6 +22,13 @@ const curfewAddressPageContent: PostcodeLookupPageContent = {
 
 export const curfewAddressResultPageContent: AddressResultPageContent = {
   title: 'Select the curfew address',
+  section: 'About the device wearer',
+  legend: '',
+  helpText: '',
+}
+
+export const curfewAddressConfirmPageContent: ConfirmAddressPageContent = {
+  title: 'Confirm the curfew address',
   section: 'About the device wearer',
   legend: '',
   helpText: '',

--- a/server/i18n/en/pages/deviceWearerAddress.ts
+++ b/server/i18n/en/pages/deviceWearerAddress.ts
@@ -1,4 +1,7 @@
-import PostcodeLookupPageContent, { AddressResultPageContent } from '../../../types/i18n/pages/postcodeLookup'
+import PostcodeLookupPageContent, {
+  AddressResultPageContent,
+  ConfirmAddressPageContent,
+} from '../../../types/i18n/pages/postcodeLookup'
 
 const deviceWearerAddressPageContent: PostcodeLookupPageContent = {
   title: "Find the device wearer's address",
@@ -19,6 +22,13 @@ const deviceWearerAddressPageContent: PostcodeLookupPageContent = {
 
 export const deviceWearerAddressResultPageContent: AddressResultPageContent = {
   title: "Select the device wearer's address",
+  section: 'About the device wearer',
+  legend: '',
+  helpText: '',
+}
+
+export const deviceWearerAddressConfirmPageContent: ConfirmAddressPageContent = {
+  title: "Confirm the device wearer's address",
   section: 'About the device wearer',
   legend: '',
   helpText: '',

--- a/server/i18n/en/pages/tagAtSourceAddress.ts
+++ b/server/i18n/en/pages/tagAtSourceAddress.ts
@@ -1,4 +1,7 @@
-import PostcodeLookupPageContent, { AddressResultPageContent } from '../../../types/i18n/pages/postcodeLookup'
+import PostcodeLookupPageContent, {
+  AddressResultPageContent,
+  ConfirmAddressPageContent,
+} from '../../../types/i18n/pages/postcodeLookup'
 
 const tagAtSourceAddressPageContent: PostcodeLookupPageContent = {
   title: 'Find the installation address',
@@ -19,6 +22,13 @@ const tagAtSourceAddressPageContent: PostcodeLookupPageContent = {
 
 export const tagAtSourceAddressResultPageContent: AddressResultPageContent = {
   title: 'Select the installation address',
+  section: 'Electronic monitoring required',
+  legend: '',
+  helpText: '',
+}
+
+export const tagAtSourceAddressConfirmPageContent: ConfirmAddressPageContent = {
+  title: 'Confirm the installation address',
   section: 'Electronic monitoring required',
   legend: '',
   helpText: '',

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -411,7 +411,7 @@ export default function routes({
     }),
   )
 
-  router.use(paths.ORDER.BASE_URL, createPostcodeLookupRouter({ postcodeService, addressService }))
+  router.use(paths.ORDER.BASE_URL, createPostcodeLookupRouter({ postcodeService, addressService, taskListService }))
 
   router.use(
     paths.INTEREST_PARTIES.BASE_PATH,

--- a/server/routes/postcode-lookup/address-result/controller.ts
+++ b/server/routes/postcode-lookup/address-result/controller.ts
@@ -77,7 +77,7 @@ export default class AddressResultController {
     })
 
     const redirectUrl = this.postcodeService.buildUrl(
-      paths.POSTCODE_LOOKUP.ADDRESS_RESULT,
+      paths.POSTCODE_LOOKUP.CONFIRM_ADDRESS,
       order.id,
       addressType,
       postcode,

--- a/server/routes/postcode-lookup/address-result/controller.ts
+++ b/server/routes/postcode-lookup/address-result/controller.ts
@@ -76,8 +76,13 @@ export default class AddressResultController {
       data: { ...address, addressType },
     })
 
-    res.redirect(
-      paths.POSTCODE_LOOKUP.CONFIRM_ADDRESS.replace(':orderId', order.id).replace(':addressType', addressType),
+    const redirectUrl = this.postcodeService.buildUrl(
+      paths.POSTCODE_LOOKUP.ADDRESS_RESULT,
+      order.id,
+      addressType,
+      postcode,
+      buildingId,
     )
+    res.redirect(redirectUrl)
   }
 }

--- a/server/routes/postcode-lookup/confirm-address/controller.ts
+++ b/server/routes/postcode-lookup/confirm-address/controller.ts
@@ -24,11 +24,10 @@ export default class ConfirmAddressController {
       res.send(404)
       return
     }
-    const addresses = postcode ? await this.postcodeService.lookupByPostcode(postcode, addressType, buildingId) : []
 
     const useDifferentAddressLink =
       postcode === undefined
-        ? paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', order.id).replace(':addressType', addressType)
+        ? paths.POSTCODE_LOOKUP.FIND_ADDRESS.replace(':orderId', order.id).replace(':addressType', addressType)
         : this.postcodeService.buildUrl(
             paths.POSTCODE_LOOKUP.ADDRESS_RESULT,
             order.id,
@@ -42,7 +41,6 @@ export default class ConfirmAddressController {
       addressType,
       postcode,
       buildingId,
-      addressCount: addresses.length,
       useDifferentAddressLink,
     })
 

--- a/server/routes/postcode-lookup/confirm-address/controller.ts
+++ b/server/routes/postcode-lookup/confirm-address/controller.ts
@@ -1,20 +1,70 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../../constants/paths'
+import PostcodeService from '../postcodeService'
+import Model from './model'
+import { AddressType, AddressWithoutType } from '../../../models/Address'
+import I18n from '../../../types/i18n'
+import TaskListService from '../../../services/taskListService'
 
 export default class ConfirmAddressController {
-  constructor() {}
+  constructor(
+    private readonly postcodeService: PostcodeService,
+    private readonly tasklistService: TaskListService,
+  ) {}
 
   view: RequestHandler = async (req: Request, res: Response) => {
-    res.render('pages/WIP', {
-      pageName: 'Confirm Address',
-      errorSummary: null,
+    const order = req.order!
+    const addressType = req.params.addressType as AddressType
+    const postcode = req.query.postcode as string
+    const buildingId = req.query.buildingId as string | undefined
+
+    const address = order.addresses.find(item => item.addressType === addressType) as AddressWithoutType | undefined
+
+    if (!address) {
+      res.send(404)
+      return
+    }
+    const addresses = postcode ? await this.postcodeService.lookupByPostcode(postcode, addressType, buildingId) : []
+
+    const useDifferentAddressLink =
+      postcode === undefined
+        ? paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', order.id).replace(':addressType', addressType)
+        : this.postcodeService.buildUrl(
+            paths.POSTCODE_LOOKUP.ADDRESS_RESULT,
+            order.id,
+            addressType,
+            postcode,
+            buildingId,
+          )
+
+    const model = Model.construct(address, res.locals.content as I18n, {
+      orderId: order.id,
+      addressType,
+      postcode,
+      buildingId,
+      addressCount: addresses.length,
+      useDifferentAddressLink,
     })
+
+    res.render('pages/order/postcode-lookup/confirm-address', model)
   }
 
   update: RequestHandler = async (req: Request, res: Response) => {
     const order = req.order!
-    const { addressType } = req.params
+    const addressType = req.params.addressType.toUpperCase()
 
-    res.redirect(paths.POSTCODE_LOOKUP.ADDRESS_LIST.replace(':orderId', order.id).replace(':addressType', addressType))
+    const { action } = req.body
+
+    if (action === 'continue') {
+      if (addressType === 'INSTALLATION') {
+        res.redirect(this.tasklistService.getNextPage('INSTALLATION_ADDRESS', order))
+        return
+      }
+
+      res.redirect(paths.POSTCODE_LOOKUP.ADDRESS_LIST.replace(':orderId', order.id))
+      return
+    }
+
+    res.redirect(paths.ORDER.SUMMARY.replace(':orderId', order.id))
   }
 }

--- a/server/routes/postcode-lookup/confirm-address/model.test.ts
+++ b/server/routes/postcode-lookup/confirm-address/model.test.ts
@@ -21,21 +21,13 @@ describe('confirm address model', () => {
       addressType: 'PRIMARY',
       postcode: 'wr11nl',
       buildingId: '1',
-      addressCount: 6,
       useDifferentAddressLink: `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', orderId).replace(':addressType', 'PRIMARY')}?postcode=wr11nl&buildingId=1`,
     })
 
     expect(model.content).toEqual(content.pages.deviceWearerAddressConfirm)
     expect(model.postcode).toBe('wr11nl')
-    expect(model.addressCount).toBe(6)
     expect(model.buildingId).toBe('1')
-    expect(model.address).toEqual({
-      addressLine1: '1 Washington Street',
-      addressLine2: '',
-      addressLine3: 'Worcester',
-      addressLine4: '',
-      postcode: 'WR1 1NL',
-    })
+    expect(model.addressLines).toEqual(['1 Washington Street', 'Worcester', 'WR1 1NL'])
 
     expect(model.searchAgainLink).toBe(
       paths.POSTCODE_LOOKUP.FIND_ADDRESS.replace(':orderId', orderId).replace(':addressType', 'PRIMARY'),
@@ -56,7 +48,6 @@ describe('confirm address model', () => {
       addressType: 'SECONDARY',
       postcode: 'wr11nl',
       buildingId: '1',
-      addressCount: 6,
       useDifferentAddressLink: `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', orderId).replace(':addressType', 'SECONDARY')}?postcode=wr11nl&buildingId=1`,
     })
 
@@ -69,7 +60,6 @@ describe('confirm address model', () => {
       addressType: 'INSTALLATION',
       postcode: 'wr11nl',
       buildingId: '1',
-      addressCount: 6,
       useDifferentAddressLink: `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', orderId).replace(':addressType', 'INSTALLATION')}?postcode=wr11nl&buildingId=1`,
     })
 

--- a/server/routes/postcode-lookup/confirm-address/model.test.ts
+++ b/server/routes/postcode-lookup/confirm-address/model.test.ts
@@ -1,0 +1,78 @@
+import { v4 as uuidv4 } from 'uuid'
+import Model from './model'
+import paths from '../../../constants/paths'
+import getContent from '../../../i18n'
+import { createAddress } from '../../../../test/mocks/mockOrder'
+
+describe('confirm address model', () => {
+  const orderId = uuidv4()
+  const content = getContent('en', 'DDV6')
+  const address = createAddress({
+    addressLine1: '1 Washington Street',
+    addressLine2: '',
+    addressLine3: 'Worcester',
+    addressLine4: '',
+    postcode: 'WR1 1NL',
+  })
+
+  it('device wearer confirmation page model', () => {
+    const model = Model.construct(address, content, {
+      orderId,
+      addressType: 'PRIMARY',
+      postcode: 'wr11nl',
+      buildingId: '1',
+      addressCount: 6,
+      useDifferentAddressLink: `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', orderId).replace(':addressType', 'PRIMARY')}?postcode=wr11nl&buildingId=1`,
+    })
+
+    expect(model.content).toEqual(content.pages.deviceWearerAddressConfirm)
+    expect(model.postcode).toBe('wr11nl')
+    expect(model.addressCount).toBe(6)
+    expect(model.buildingId).toBe('1')
+    expect(model.address).toEqual({
+      addressLine1: '1 Washington Street',
+      addressLine2: '',
+      addressLine3: 'Worcester',
+      addressLine4: '',
+      postcode: 'WR1 1NL',
+    })
+
+    expect(model.searchAgainLink).toBe(
+      paths.POSTCODE_LOOKUP.FIND_ADDRESS.replace(':orderId', orderId).replace(':addressType', 'PRIMARY'),
+    )
+
+    expect(model.manualAddressLink).toBe(
+      paths.POSTCODE_LOOKUP.ENTER_ADDRESS.replace(':orderId', orderId).replace(':addressType', 'PRIMARY'),
+    )
+
+    expect(model.useDifferentAddressLink).toBe(
+      `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', orderId).replace(':addressType', 'PRIMARY')}?postcode=wr11nl&buildingId=1`,
+    )
+  })
+
+  it('curfew confirmation page model', () => {
+    const model = Model.construct(address, content, {
+      orderId,
+      addressType: 'SECONDARY',
+      postcode: 'wr11nl',
+      buildingId: '1',
+      addressCount: 6,
+      useDifferentAddressLink: `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', orderId).replace(':addressType', 'SECONDARY')}?postcode=wr11nl&buildingId=1`,
+    })
+
+    expect(model.content).toEqual(content.pages.curfewAddressConfirm)
+  })
+
+  it('installation confirmation page model', () => {
+    const model = Model.construct(address, content, {
+      orderId,
+      addressType: 'INSTALLATION',
+      postcode: 'wr11nl',
+      buildingId: '1',
+      addressCount: 6,
+      useDifferentAddressLink: `${paths.POSTCODE_LOOKUP.ADDRESS_RESULT.replace(':orderId', orderId).replace(':addressType', 'INSTALLATION')}?postcode=wr11nl&buildingId=1`,
+    })
+
+    expect(model.content).toEqual(content.pages.tagAtSourceAddressConfirm)
+  })
+})

--- a/server/routes/postcode-lookup/confirm-address/model.ts
+++ b/server/routes/postcode-lookup/confirm-address/model.ts
@@ -1,0 +1,78 @@
+import paths from '../../../constants/paths'
+import { AddressType, AddressWithoutType } from '../../../models/Address'
+import I18n from '../../../types/i18n'
+import { ConfirmAddressPageContent } from '../../../types/i18n/pages/postcodeLookup'
+
+type ConfirmationAddressType = AddressType | 'APPOINTMENT'
+
+type ConfirmAddressModel = {
+  content: ConfirmAddressPageContent
+  postcode: string
+  addressCount: number
+  buildingId?: string
+  address: AddressWithoutType
+  searchAgainLink: string
+  manualAddressLink: string
+  useDifferentAddressLink: string
+}
+
+const construct = (
+  address: AddressWithoutType,
+  content: I18n,
+  opts: {
+    orderId: string
+    addressType: ConfirmationAddressType
+    postcode?: string
+    buildingId?: string
+    addressCount: number
+    useDifferentAddressLink: string
+  },
+): ConfirmAddressModel => {
+  const addressType = opts.addressType.toUpperCase() as ConfirmationAddressType
+  const searchAgainLink = paths.POSTCODE_LOOKUP.FIND_ADDRESS.replace(':orderId', opts.orderId).replace(
+    ':addressType',
+    addressType,
+  )
+  const manualAddressLink = paths.POSTCODE_LOOKUP.ENTER_ADDRESS.replace(':orderId', opts.orderId).replace(
+    ':addressType',
+    addressType,
+  )
+
+  return {
+    content: getContent(content, addressType),
+    postcode: opts.postcode || '',
+    addressCount: opts.addressCount,
+    buildingId: opts.buildingId,
+    address: {
+      addressLine1: address.addressLine1,
+      addressLine2: address.addressLine2,
+      addressLine3: address.addressLine3,
+      addressLine4: address.addressLine4,
+      postcode: address.postcode,
+    },
+    searchAgainLink,
+    manualAddressLink,
+    useDifferentAddressLink: opts.useDifferentAddressLink,
+  }
+}
+
+function getContent(content: I18n, addressType: ConfirmationAddressType): ConfirmAddressPageContent {
+  const mapping: Record<ConfirmationAddressType, ConfirmAddressPageContent> = {
+    PRIMARY: content.pages.deviceWearerAddressConfirm,
+    INSTALLATION: content.pages.tagAtSourceAddressConfirm,
+    TERTIARY: content.pages.curfewAddressConfirm,
+    SECONDARY: content.pages.curfewAddressConfirm,
+
+    // These are also not used currently, can potentially be removed
+    RESPONSIBLE_ADULT: content.pages.deviceWearerAddressConfirm,
+    RESPONSIBLE_ORGANISATION: content.pages.deviceWearerAddressConfirm,
+    // Currently, mandatory attendence monitoring address is not stored as a separate address
+    APPOINTMENT: content.pages.appointmentAddressConfirm,
+  }
+
+  return mapping[addressType]
+}
+
+export default { construct }
+
+export type { ConfirmAddressModel, ConfirmationAddressType }

--- a/server/routes/postcode-lookup/confirm-address/model.ts
+++ b/server/routes/postcode-lookup/confirm-address/model.ts
@@ -3,7 +3,7 @@ import { AddressType, AddressWithoutType } from '../../../models/Address'
 import I18n from '../../../types/i18n'
 import { ConfirmAddressPageContent } from '../../../types/i18n/pages/postcodeLookup'
 
-type ConfirmationAddressType = AddressType | 'APPOINTMENT'
+type ConfirmationAddressType = AddressType
 
 type ConfirmAddressModel = {
   content: ConfirmAddressPageContent
@@ -65,8 +65,6 @@ function getContent(content: I18n, addressType: ConfirmationAddressType): Confir
     // These are also not used currently, can potentially be removed
     RESPONSIBLE_ADULT: content.pages.deviceWearerAddressConfirm,
     RESPONSIBLE_ORGANISATION: content.pages.deviceWearerAddressConfirm,
-    // Currently, mandatory attendence monitoring address is not stored as a separate address
-    APPOINTMENT: content.pages.appointmentAddressConfirm,
   }
 
   return mapping[addressType]

--- a/server/routes/postcode-lookup/confirm-address/model.ts
+++ b/server/routes/postcode-lookup/confirm-address/model.ts
@@ -8,9 +8,8 @@ type ConfirmationAddressType = AddressType | 'APPOINTMENT'
 type ConfirmAddressModel = {
   content: ConfirmAddressPageContent
   postcode: string
-  addressCount: number
   buildingId?: string
-  address: AddressWithoutType
+  addressLines: string[]
   searchAgainLink: string
   manualAddressLink: string
   useDifferentAddressLink: string
@@ -24,7 +23,6 @@ const construct = (
     addressType: ConfirmationAddressType
     postcode?: string
     buildingId?: string
-    addressCount: number
     useDifferentAddressLink: string
   },
 ): ConfirmAddressModel => {
@@ -38,18 +36,19 @@ const construct = (
     addressType,
   )
 
+  const addressLines = [
+    address.addressLine1,
+    address.addressLine2,
+    address.addressLine3,
+    address.addressLine4,
+    address.postcode,
+  ].filter(line => line !== '')
+
   return {
     content: getContent(content, addressType),
     postcode: opts.postcode || '',
-    addressCount: opts.addressCount,
     buildingId: opts.buildingId,
-    address: {
-      addressLine1: address.addressLine1,
-      addressLine2: address.addressLine2,
-      addressLine3: address.addressLine3,
-      addressLine4: address.addressLine4,
-      postcode: address.postcode,
-    },
+    addressLines,
     searchAgainLink,
     manualAddressLink,
     useDifferentAddressLink: opts.useDifferentAddressLink,

--- a/server/routes/postcode-lookup/postcodeService.test.ts
+++ b/server/routes/postcode-lookup/postcodeService.test.ts
@@ -60,4 +60,15 @@ describe('postcode service', () => {
       expect(postcodeLookupStub.lookupByUPRN).toHaveBeenCalledWith('101')
     })
   })
+
+  describe('build url', () => {
+    it('adds postcode and building id query params when given', async () => {
+      postcodeLookupStub.lookupByUPRN.mockResolvedValue(addresses[0])
+      const service = new PostcodeService(postcodeLookupStub)
+
+      expect(
+        service.buildUrl('/order/:orderId/address-result/:addressType', 'mockOrderId', 'PRIMARY', 'wr11nl', '1'),
+      ).toBe('/order/mockOrderId/address-result/PRIMARY?postcode=wr11nl&buildingId=1')
+    })
+  })
 })

--- a/server/routes/postcode-lookup/router.ts
+++ b/server/routes/postcode-lookup/router.ts
@@ -7,12 +7,14 @@ import AddressListController from './address-list/controller'
 import EnterAddressController from './enter-address/controller'
 import { Services } from '../../services'
 
-const createPostcodeLookupRouter = (services: Pick<Services, 'postcodeService' | 'addressService'>): Router => {
+const createPostcodeLookupRouter = (
+  services: Pick<Services, 'postcodeService' | 'addressService' | 'taskListService'>,
+): Router => {
   const router = Router()
 
   const findAddressController = new FindAddressController(services.postcodeService)
   const addressResultController = new AddressResultController(services.postcodeService, services.addressService)
-  const confirmAddressController = new ConfirmAddressController()
+  const confirmAddressController = new ConfirmAddressController(services.postcodeService, services.taskListService)
   const addressListController = new AddressListController()
   const enterAddressController = new EnterAddressController()
   router.get('/find-address/:addressType', asyncMiddleware(findAddressController.view))

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -301,6 +301,7 @@ export default class TaskListService {
         state: STATES.required,
         completed: isNotNullOrUndefined(order.deviceWearer.noFixedAbode),
       })
+
       if (FeatureFlags.getInstance().get('POSTCODE_LOOKUP_ENABLED')) {
         tasks.push({
           section: SECTIONS.contactInformation,

--- a/server/types/i18n/index.ts
+++ b/server/types/i18n/index.ts
@@ -37,7 +37,7 @@ import DapoClauseListPageConent from './pages/dapoClauseListPage'
 import NotifyingOrganisationPageContent from './pages/notifyingOrganisation'
 import ResponsibleOrganisationPageContent from './pages/responsibleOrganisation'
 import ResponsibleOfficerPageContent from './pages/responsibleOfficer'
-import PostcodeLookupPageContent, { AddressResultPageContent } from './pages/postcodeLookup'
+import PostcodeLookupPageContent, { AddressResultPageContent, ConfirmAddressPageContent } from './pages/postcodeLookup'
 import NationalSecurityDirectoratePageConetent from './pages/national-security-directorate'
 import IsAddressChangePageContent from './pages/isAddressChange'
 
@@ -90,11 +90,15 @@ type I18n = {
     pdu: ProbationDeliveryUnit
     deviceWearerAddress: PostcodeLookupPageContent
     deviceWearerAddressResult: AddressResultPageContent
+    deviceWearerAddressConfirm: ConfirmAddressPageContent
     tagAtSourceAddress: PostcodeLookupPageContent
     tagAtSourceAddressResult: AddressResultPageContent
+    tagAtSourceAddressConfirm: ConfirmAddressPageContent
     curfewAddress: PostcodeLookupPageContent
     curfewAddressResult: AddressResultPageContent
+    curfewAddressConfirm: ConfirmAddressPageContent
     appointmentAddress: PostcodeLookupPageContent
+    appointmentAddressConfirm: ConfirmAddressPageContent
     nationalSecurityDirectorate: NationalSecurityDirectoratePageConetent
     isAddressChange: IsAddressChangePageContent
   }

--- a/server/types/i18n/pages/postcodeLookup.ts
+++ b/server/types/i18n/pages/postcodeLookup.ts
@@ -3,5 +3,6 @@ import QuestionPageContent from './questionPage'
 type PostcodeLookupPageContent = QuestionPageContent<'postcode' | 'buildingId'>
 
 export type AddressResultPageContent = Omit<QuestionPageContent<''>, 'questions'>
+export type ConfirmAddressPageContent = Omit<QuestionPageContent<''>, 'questions'>
 
 export default PostcodeLookupPageContent

--- a/server/views/pages/order/postcode-lookup/confirm-address.njk
+++ b/server/views/pages/order/postcode-lookup/confirm-address.njk
@@ -7,44 +7,24 @@
 {% set legend = "" %}
 {% set continueButtonText = "Use this address" %}
 
-{% if addressCount > 1 %}
-  {% set addressText = " addresses" %}
-{% else %}
-  {% set addressText = " address" %}
-{% endif %}
-
-{% set addressHtml = address.addressLine1 %}
-{% if address.addressLine2 %}
-    {% set addressHtml = addressHtml + "<br>" + address.addressLine2 %}
-{% endif %}
-{% if address.addressLine3 %}
-    {% set addressHtml = addressHtml + "<br>" + address.addressLine3 %}
-{% endif %}
-{% if address.addressLine4 %}
-    {% set addressHtml = addressHtml + "<br>" + address.addressLine4 %}
-{% endif %}
-{% set addressHtml = addressHtml + "<br>" + address.postcode %}
+{% set addressHtml %}
+  {% for line in addressLines %}
+    {{ line }}{% if not loop.last %}<br>{% endif %}
+  {% endfor %}
+{% endset %}
 
 {% block formInputs %}
-    <p class="govuk-body">
-        {% if postcode and buildingId %}
-            {{ addressCount }} {{addressText }} found for <b>{{ postcode }}</b> and <b>{{ buildingId}}</b>. <a href="{{ searchAgainLink }}" class="govuk-link">Search again</a>
-        {% elseif postcode %}
-            {{ addressCount }} {{addressText }} found for <b>{{ postcode }}</b>. <a href="{{ searchAgainLink }}" class="govuk-link">Search again</a>
-        {% else %}
-            <a href="{{ searchAgainLink}}" class="govuk-link">Search again</a>
-        {% endif %}
-    </p>
 
     {{ govukInsetText({
-    html: addressHtml
+      html: addressHtml
     }) }}
 
     <p class="govuk-body">
-        <a href="{{ useDifferentAddressLink}}" class="govuk-link">Use a different address</a>
+      <a href="{{ useDifferentAddressLink}}" class="govuk-link">Use a different address</a>
     </p>
 
     <p class="govuk-body">
-        <a href="{{ manualAddressLink }}" class="govuk-link">Enter address manually</a>
+      <a href="{{ manualAddressLink }}" class="govuk-link">Enter address manually</a>
     </p>
+
 {% endblock %}

--- a/server/views/pages/order/postcode-lookup/confirm-address.njk
+++ b/server/views/pages/order/postcode-lookup/confirm-address.njk
@@ -1,0 +1,50 @@
+{% extends "../../../partials/form-layout.njk" %}
+
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set section = content.section %}
+{% set heading = content.title %}
+{% set legend = "" %}
+{% set continueButtonText = "Use this address" %}
+
+{% if addressCount > 1 %}
+  {% set addressText = " addresses" %}
+{% else %}
+  {% set addressText = " address" %}
+{% endif %}
+
+{% set addressHtml = address.addressLine1 %}
+{% if address.addressLine2 %}
+    {% set addressHtml = addressHtml + "<br>" + address.addressLine2 %}
+{% endif %}
+{% if address.addressLine3 %}
+    {% set addressHtml = addressHtml + "<br>" + address.addressLine3 %}
+{% endif %}
+{% if address.addressLine4 %}
+    {% set addressHtml = addressHtml + "<br>" + address.addressLine4 %}
+{% endif %}
+{% set addressHtml = addressHtml + "<br>" + address.postcode %}
+
+{% block formInputs %}
+    <p class="govuk-body">
+        {% if postcode and buildingId %}
+            {{ addressCount }} {{addressText }} found for <b>{{ postcode }}</b> and <b>{{ buildingId}}</b>. <a href="{{ searchAgainLink }}" class="govuk-link">Search again</a>
+        {% elseif postcode %}
+            {{ addressCount }} {{addressText }} found for <b>{{ postcode }}</b>. <a href="{{ searchAgainLink }}" class="govuk-link">Search again</a>
+        {% else %}
+            <a href="{{ searchAgainLink}}" class="govuk-link">Search again</a>
+        {% endif %}
+    </p>
+
+    {{ govukInsetText({
+    html: addressHtml
+    }) }}
+
+    <p class="govuk-body">
+        <a href="{{ useDifferentAddressLink}}" class="govuk-link">Use a different address</a>
+    </p>
+
+    <p class="govuk-body">
+        <a href="{{ manualAddressLink }}" class="govuk-link">Enter address manually</a>
+    </p>
+{% endblock %}


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4209

As a notifying officer, I want their to be a fast way to add addresses that I can be confident is accurate, so that I don’t have to deal with address rejections or possibility of device wearer being untagged as the address isn’t valid

### Changes proposed in this pull request

Adding an address confirmation page
