### PR TITLE
hotfix: account for no response upstream in address finder

### DIFF
--- a/server/data/postcode/osDataHub/addressMapper.test.ts
+++ b/server/data/postcode/osDataHub/addressMapper.test.ts
@@ -33,6 +33,14 @@ describe('address mapper', () => {
     expect(result).toEqual(expected)
   })
 
+  it('when postcode service returns with no result for postcode', () => {
+    const data = {} as OSDataHubPostcodeResponse
+
+    const result = addressMapper.mapToAddresses(data)
+
+    expect(result).toEqual([])
+  })
+
   it('can map address with building name', () => {
     const data: OSDataHubPostcodeResponse = createData({
       BUILDING_NAME: 'PM HOUSE',

--- a/server/data/postcode/osDataHub/addressMapper.ts
+++ b/server/data/postcode/osDataHub/addressMapper.ts
@@ -5,7 +5,7 @@ import logger from '../../../../logger'
 
 export default class AddressMapper {
   mapToAddresses(data: OSDataHubPostcodeResponse): AddressWithoutTypeUPRN[] {
-    return data.results.map(address => this.mapToAddress(address))
+    return data.results ? data.results.map(address => this.mapToAddress(address)) : []
   }
 
   private mapToAddress(dataHubAddress: OSDataHubAddress): AddressWithoutTypeUPRN {


### PR DESCRIPTION
Handle response when it doesn't contain any result from upstream 