### PR TITLE
ELM-4784: Fix tasklist navigation for notifying and responsible org

### DIFF
--- a/integration_tests/scenarios/order/interested-parties/variation.cy.ts
+++ b/integration_tests/scenarios/order/interested-parties/variation.cy.ts
@@ -106,6 +106,9 @@ context('Interested parties flow', () => {
     const orderSummaryPage = Page.verifyOnPage(OrderSummaryPage)
 
     orderSummaryPage.interestedPartiesTask.click()
+    const interestedPartiesCyaPage = Page.verifyOnPage(InterestedPartiesCheckYourAnswersPage)
+    interestedPartiesCyaPage.changeLinkByQuestion('What organisation or related organisation are you part of?')
+
     const input = {
       notifyingOrganisation: {
         notifyingOrganisation: 'Prison service',

--- a/integration_tests/scenarios/order/interested-parties/variation.cy.ts
+++ b/integration_tests/scenarios/order/interested-parties/variation.cy.ts
@@ -107,7 +107,7 @@ context('Interested parties flow', () => {
 
     orderSummaryPage.interestedPartiesTask.click()
     const interestedPartiesCyaPage = Page.verifyOnPage(InterestedPartiesCheckYourAnswersPage)
-    interestedPartiesCyaPage.changeLinkByQuestion('What organisation or related organisation are you part of?')
+    interestedPartiesCyaPage.changeLinkByQuestion('What organisation or related organisation are you part of?').click()
 
     const input = {
       notifyingOrganisation: {

--- a/integration_tests/utils/scenario-flows/interested-parties.cy.ts
+++ b/integration_tests/utils/scenario-flows/interested-parties.cy.ts
@@ -9,9 +9,9 @@ import Page from '../../pages/page'
 
 export default function fillInInterestedPartiesWith({
   notifyingOrganisation,
-  responsibleOfficer = null,
-  responsibleOrganisation = null,
-  pdu = null,
+  responsibleOfficer = undefined,
+  responsibleOrganisation = undefined,
+  pdu = undefined,
   continueOnCya = true,
 }): void {
   const notifyingOrganisationPage = Page.verifyOnPage(NotifyingOrganisationPage)

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -1385,24 +1385,6 @@ describe('TaskListService', () => {
           paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
         )
       })
-
-      it('should navigate to CYA when viewing notifying and responsible organisations are complete', async () => {
-        const order = getMockOrder({
-          status: 'SUBMITTED',
-        })
-
-        const taskListService = new TaskListService(mockOrderChecklistService)
-
-        const sections = await taskListService.getSections(order)
-
-        const interestedPartiesSection = sections.find(
-          section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-        )
-
-        expect(interestedPartiesSection?.path).toBe(
-          paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-        )
-      })
     })
 
     it('should navigate to dapo page when offence flow is enabled and notifyingOrganisation is FAMILY_COURT', async () => {

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -1328,7 +1328,22 @@ describe('TaskListService', () => {
         )
       })
 
-      it('should navigate to CYA when viewing notifying and responsible organisations for submitted order', async () => {
+      it('should navigate to notify organisation when notifying and responsible organisations is incomplete', async () => {
+        const order = getMockOrder()
+        const taskListService = new TaskListService(mockOrderChecklistService)
+
+        const sections = await taskListService.getSections(order)
+
+        const interestedPartiesSection = sections.find(
+          section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
+        )
+
+        expect(interestedPartiesSection?.path).toBe(
+          paths.INTEREST_PARTIES.NOTIFYING_ORGANISATION.replace(':orderId', order.id),
+        )
+      })
+
+      it('should navigate to CYA when viewing notifying and responsible organisations are complete', async () => {
         const order = getMockOrder({
           status: 'SUBMITTED',
         })

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -1294,6 +1294,59 @@ describe('TaskListService', () => {
       expect(contactInformationSection?.completed).toBe(false)
     })
 
+    describe('when interested parties flow is enabled', () => {
+      beforeEach(() => {
+        const mockGet = jest.fn((flag: string) => flag === 'INTERESTED_PARTIES_FLOW_ENABLED')
+        const mockGetValue = jest.fn(() => '')
+        jest.spyOn(FeatureFlags, 'getInstance').mockReturnValue({
+          get: mockGet,
+          getValue: mockGetValue,
+        } as never)
+      })
+
+      afterEach(() => {
+        jest.restoreAllMocks()
+      })
+
+      it('should navigate to CYA when notifying and responsible organisations are to check', async () => {
+        const order = getMockOrder({
+          interestedParties: createInterestedParties(),
+        })
+        const taskListService = new TaskListService(mockOrderChecklistService)
+
+        const sections = await taskListService.getSections(order)
+
+        const interestedPartiesSection = sections.find(
+          section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
+        )
+        expect(interestedPartiesSection).toEqual(
+          expect.objectContaining({
+            checked: false,
+            completed: true,
+            path: paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
+          }),
+        )
+      })
+
+      it('should navigate to CYA when viewing notifying and responsible organisations for submitted order', async () => {
+        const order = getMockOrder({
+          status: 'SUBMITTED',
+        })
+
+        const taskListService = new TaskListService(mockOrderChecklistService)
+
+        const sections = await taskListService.getSections(order)
+
+        const interestedPartiesSection = sections.find(
+          section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
+        )
+
+        expect(interestedPartiesSection?.path).toBe(
+          paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
+        )
+      })
+    })
+
     it('should navigate to dapo page when offence flow is enabled and notifyingOrganisation is FAMILY_COURT', async () => {
       const mockGet = jest.fn((flag: string) => flag === 'OFFENCE_FLOW_ENABLED')
       const mockGetValue = jest.fn(() => '')

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -1328,6 +1328,31 @@ describe('TaskListService', () => {
         )
       })
 
+      it('should navigate to CYA when notifying and responsible organisations are complete', async () => {
+        const order = getMockOrder({
+          interestedParties: createInterestedParties(),
+        })
+        mockOrderChecklistService.getChecklist.mockResolvedValueOnce({
+          ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS: true,
+          ABOUT_THE_CHANGES_IN_THIS_VERSION_OF_THE_FORM: false,
+          ABOUT_THE_DEVICE_WEARER: false,
+          CONTACT_INFORMATION: false,
+          RISK_INFORMATION: false,
+          ELECTRONIC_MONITORING_CONDITIONS: false,
+          ADDITIONAL_DOCUMENTS: false,
+        })
+        const taskListService = new TaskListService(mockOrderChecklistService)
+
+        const sections = await taskListService.getSections(order)
+
+        const interestedPartiesSection = sections.find(
+          section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
+        )
+        expect(interestedPartiesSection?.path).toBe(
+          paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
+        )
+      })
+
       it('should navigate to notify organisation when notifying and responsible organisations is incomplete', async () => {
         const order = getMockOrder()
         const taskListService = new TaskListService(mockOrderChecklistService)
@@ -1340,6 +1365,24 @@ describe('TaskListService', () => {
 
         expect(interestedPartiesSection?.path).toBe(
           paths.INTEREST_PARTIES.NOTIFYING_ORGANISATION.replace(':orderId', order.id),
+        )
+      })
+
+      it('should navigate to CYA when viewing notifying and responsible organisations', async () => {
+        const order = getMockOrder({
+          status: 'SUBMITTED',
+        })
+
+        const taskListService = new TaskListService(mockOrderChecklistService)
+
+        const sections = await taskListService.getSections(order)
+
+        const interestedPartiesSection = sections.find(
+          section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
+        )
+
+        expect(interestedPartiesSection?.path).toBe(
+          paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
         )
       })
 

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -898,7 +898,7 @@ export default class TaskListService {
         const sectionsTasks = this.findTaskBySection(tasks, section)
         const completed = this.isSectionComplete(sectionsTasks, order, section)
         let path: string
-        if (order.status === 'SUBMITTED' || completed) {
+        if (order.status !== 'IN_PROGRESS' || completed) {
           path = this.getCheckYourAnswersPathForSection(sectionsTasks)
         } else {
           const firstAvailableTask = sectionsTasks.find(task => canBeCompleted(task, {}))
@@ -926,12 +926,6 @@ export default class TaskListService {
       return sectionTasks[sectionTasks.length - 1].path // TODO: refactor path so that additional docs includes string
     }
 
-    if (
-      sectionTasks[0].section === SECTIONS.interestParties &&
-      FeatureFlags.getInstance().get('INTERESTED_PARTIES_FLOW_ENABLED')
-    ) {
-      return paths.INTEREST_PARTIES.NOTIFYING_ORGANISATION
-    }
     return (sectionTasks.find(task => task.path.includes('check-your-answers')) || sectionTasks[0]).path
   }
 }


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4784

### Changes proposed in this pull request

When the user clicks to view the Notifying and responsible organisation from the task list:

- If the status is ‘Incomplete’ the first page in the section should be displayed

- If the status is To check' the check your answers page should be displayed

- If the status is ‘Complete’ the check your answers page should be displayed

- If the user is viewing not editing the the check your answers page should be displayed