### PR TITLE
ELM-4824: Installation appointment time for HO

### DIFF
--- a/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
@@ -275,6 +275,10 @@ context('Check your answers', () => {
         status: 'IN_PROGRESS',
         order: {
           ...mockOrder,
+          interestedParties: {
+            ...mockOrder.interestedParties,
+            notifyingOrganisation: 'HOME_OFFICE',
+          },
           installationLocation: {
             location: 'PRIMARY',
           },

--- a/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
@@ -307,6 +307,45 @@ context('Check your answers', () => {
       ])
     })
 
+    it('shows default appointment time question for Home Office, installing at prison', () => {
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+        order: {
+          ...mockOrder,
+          interestedParties: {
+            ...mockOrder.interestedParties,
+            notifyingOrganisation: 'HOME_OFFICE',
+          },
+          installationLocation: {
+            location: 'PRISON',
+          },
+          installationAppointment: {
+            placeName: 'Mock Place',
+            appointmentDate: '2027-02-01T10:30:00Z',
+          },
+        },
+      })
+
+      const page = Page.visit(CheckYourAnswers, { orderId: mockOrderId }, {}, pageHeading)
+      page.installationAppointmentSection().shouldExist()
+      page.installationAppointmentSection().shouldHaveItems([
+        {
+          key: 'What is the name of the place where installation will take place?',
+          value: 'Mock Place',
+        },
+        {
+          key: 'What date will installation take place?',
+          value: '01/02/2027',
+        },
+        {
+          key: 'What time will installation take place?',
+          value: '10:30',
+        },
+      ])
+    })
+
     it('shows installation address', () => {
       cy.task('stubCemoGetOrder', {
         httpStatus: 200,

--- a/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
@@ -235,6 +235,10 @@ context('Check your answers', () => {
         status: 'IN_PROGRESS',
         order: {
           ...mockOrder,
+          interestedParties: {
+            ...mockOrder.interestedParties,
+            notifyingOrganisation: 'PRISON',
+          },
           installationLocation: {
             location: 'INSTALLATION',
           },
@@ -262,6 +266,41 @@ context('Check your answers', () => {
         },
       ])
       page.installationAddressSection().shouldExist()
+    })
+
+    it('shows installation appointment for Home Office with primary address', () => {
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+        order: {
+          ...mockOrder,
+          installationLocation: {
+            location: 'PRIMARY',
+          },
+          installationAppointment: {
+            placeName: 'Mock Place',
+            appointmentDate: '2027-02-01T10:30:00Z',
+          },
+        },
+      })
+
+      const page = Page.visit(CheckYourAnswers, { orderId: mockOrderId }, {}, pageHeading)
+      page.installationAppointmentSection().shouldExist()
+      page.installationAppointmentSection().shouldHaveItems([
+        {
+          key: 'What is the name of the place where installation will take place?',
+          value: 'Mock Place',
+        },
+        {
+          key: 'What date will installation take place?',
+          value: '01/02/2027',
+        },
+        {
+          key: 'What is the preferred time for installation to take place?',
+          value: '10:30',
+        },
+      ])
     })
 
     it('shows installation address', () => {
@@ -336,7 +375,7 @@ context('Check your answers', () => {
         )
     })
 
-    it('should not show end dates for curfew and enforcemnt zone if not exist', () => {
+    it('should not show end dates for curfew and enforcement zone if not exist', () => {
       cy.task('stubCemoGetOrder', {
         httpStatus: 200,
         id: mockOrderId,

--- a/integration_tests/e2e/order/monitoring-conditions/installation-appointment.page.draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/installation-appointment.page.draft.cy.ts
@@ -44,7 +44,7 @@ const mockDefaultOrder = {
     offenceType: '',
   },
 }
-const stubGetOrder = ({ notifyingOrg = 'PRISON' } = {}) => {
+const stubGetOrder = ({ notifyingOrg = 'PRISON', installationLocation = 'PRIMARY' } = {}) => {
   cy.task('stubCemoGetOrder', {
     httpStatus: 200,
     id: mockOrderId,
@@ -61,6 +61,9 @@ const stubGetOrder = ({ notifyingOrg = 'PRISON' } = {}) => {
         responsibleOrganisationRegion: '',
         responsibleOfficerName: 'name',
       },
+      installationLocation: {
+        location: installationLocation,
+      },
     },
   })
 }
@@ -75,7 +78,7 @@ context('Monitoring conditions', () => {
         cy.signIn()
       })
 
-      it('Should display Home Office specific appointment time question text', () => {
+      it('Should display Home Office specific appointment time question text when installing at a primary address', () => {
         Page.visit(InstallationAppointmentPage, {
           orderId: mockOrderId,
         })
@@ -86,6 +89,18 @@ context('Monitoring conditions', () => {
         cy.get('.form-time .govuk-hint').should(
           'contains.text',
           "If the installation can't be done at this time, it will happen during standard hours. Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm",
+        )
+      })
+
+      it('Should display default appointment time question text when installing at a prison', () => {
+        stubGetOrder({ notifyingOrg: 'HOME_OFFICE', installationLocation: 'PRISON' })
+        Page.visit(InstallationAppointmentPage, {
+          orderId: mockOrderId,
+        })
+        cy.get('.form-time legend').should('contains.text', 'What time will installation take place?')
+        cy.get('.form-time .govuk-hint').should(
+          'contains.text',
+          'Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm',
         )
       })
     })

--- a/integration_tests/e2e/order/monitoring-conditions/installation-appointment.page.draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/installation-appointment.page.draft.cy.ts
@@ -3,6 +3,7 @@ import Page from '../../../pages/page'
 import InstallationAppointmentPage from '../../../pages/order/monitoring-conditions/installation-appointment'
 
 const mockOrderId = uuidv4()
+
 const mockDefaultOrder = {
   deviceWearer: {
     nomisId: 'nomis',
@@ -39,27 +40,61 @@ const mockDefaultOrder = {
     issp: 'YES',
     hdc: 'NO',
     prarr: 'UNKNOWN',
+    pilot: '',
     offenceType: '',
   },
 }
-const stubGetOrder = order => {
+const stubGetOrder = ({ notifyingOrg = 'PRISON' } = {}) => {
   cy.task('stubCemoGetOrder', {
     httpStatus: 200,
     id: mockOrderId,
     status: 'IN_PROGRESS',
-    order,
+    order: {
+      ...mockDefaultOrder,
+      interestedParties: {
+        notifyingOrganisation: notifyingOrg,
+        notifyingOrganisationName: '',
+        notifyingOrganisationEmail: 'notifying@organisation',
+        responsibleOrganisation: 'HOME_OFFICE',
+        responsibleOfficerPhoneNumber: '',
+        responsibleOrganisationEmail: 'responsible@organisation',
+        responsibleOrganisationRegion: '',
+        responsibleOfficerName: 'name',
+      },
+    },
   })
 }
 
 context('Monitoring conditions', () => {
   context('Installation appointment', () => {
+    context('Viewing a draft order for a Home Office order', () => {
+      beforeEach(() => {
+        cy.task('reset')
+        cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+        stubGetOrder({ notifyingOrg: 'HOME_OFFICE' })
+        cy.signIn()
+      })
+
+      it('Should display Home Office specific appointment time question text', () => {
+        Page.visit(InstallationAppointmentPage, {
+          orderId: mockOrderId,
+        })
+        cy.get('.form-time legend').should(
+          'contains.text',
+          'What is the preferred time for installation to take place?',
+        )
+        cy.get('.form-time .govuk-hint').should(
+          'contains.text',
+          "If the installation can't be done at this time, it will happen during standard hours. Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm",
+        )
+      })
+    })
+
     context('Viewing a draft order with no installation appointment', () => {
       beforeEach(() => {
         cy.task('reset')
         cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
-        stubGetOrder({
-          mockDefaultOrder,
-        })
+        stubGetOrder()
         cy.signIn()
       })
 
@@ -76,6 +111,11 @@ context('Monitoring conditions', () => {
         page.errorSummary.shouldNotExist()
         page.backToSummaryButton.should('not.exist')
         page.checkIsAccessible()
+        cy.get('.form-time legend').should('contains.text', 'What time will installation take place?')
+        cy.get('.form-time .govuk-hint').should(
+          'contains.text',
+          'Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm',
+        )
       })
     })
   })

--- a/server/controllers/monitoringConditions/installationAppointmentController.ts
+++ b/server/controllers/monitoringConditions/installationAppointmentController.ts
@@ -19,10 +19,13 @@ export default class InstallationAppointmentController {
     const isHomeOffice =
       req.order!.interestedParties?.notifyingOrganisation === 'HOME_OFFICE' &&
       (location === 'PRIMARY' || location === 'INSTALLATION')
+    const { questions } = res.locals.content!.pages.installationAppointment
+    const timeQuestion = isHomeOffice ? questions.appointmentTimeHomeOffice : questions.appointmentTime
     const viewModel = installationAppointmenttViewModel.construct(
       req.order!.installationAppointment,
       formData[0] as never,
-      isHomeOffice,
+      timeQuestion.text,
+      timeQuestion.hint as string,
       errors as never,
     )
     res.render('pages/order/monitoring-conditions/installation-appointment', viewModel)

--- a/server/controllers/monitoringConditions/installationAppointmentController.ts
+++ b/server/controllers/monitoringConditions/installationAppointmentController.ts
@@ -15,9 +15,11 @@ export default class InstallationAppointmentController {
   view: RequestHandler = async (req: Request, res: Response) => {
     const errors = req.flash('validationErrors')
     const formData = req.flash('formData')
+    const isHomeOffice = req.order!.interestedParties?.notifyingOrganisation === 'HOME_OFFICE'
     const viewModel = installationAppointmenttViewModel.construct(
       req.order!.installationAppointment,
       formData[0] as never,
+      isHomeOffice,
       errors as never,
     )
     res.render('pages/order/monitoring-conditions/installation-appointment', viewModel)

--- a/server/controllers/monitoringConditions/installationAppointmentController.ts
+++ b/server/controllers/monitoringConditions/installationAppointmentController.ts
@@ -15,7 +15,10 @@ export default class InstallationAppointmentController {
   view: RequestHandler = async (req: Request, res: Response) => {
     const errors = req.flash('validationErrors')
     const formData = req.flash('formData')
-    const isHomeOffice = req.order!.interestedParties?.notifyingOrganisation === 'HOME_OFFICE'
+    const location = req.order!.installationLocation?.location
+    const isHomeOffice =
+      req.order!.interestedParties?.notifyingOrganisation === 'HOME_OFFICE' &&
+      (location === 'PRIMARY' || location === 'INSTALLATION')
     const viewModel = installationAppointmenttViewModel.construct(
       req.order!.installationAppointment,
       formData[0] as never,

--- a/server/controllers/monitoringConditions/installationAppointmentController.ts
+++ b/server/controllers/monitoringConditions/installationAppointmentController.ts
@@ -20,7 +20,7 @@ export default class InstallationAppointmentController {
       req.order!.interestedParties?.notifyingOrganisation === 'HOME_OFFICE' &&
       (location === 'PRIMARY' || location === 'INSTALLATION')
     const { questions } = res.locals.content!.pages.installationAppointment
-    const timeQuestion = isHomeOffice ? questions.appointmentTimeHomeOffice : questions.appointmentTime
+    const timeQuestion = isHomeOffice ? questions.preferredAppointmentTime : questions.appointmentTime
     const viewModel = installationAppointmenttViewModel.construct(
       req.order!.installationAppointment,
       formData[0] as never,

--- a/server/i18n/en/pages/installationAppointment.ts
+++ b/server/i18n/en/pages/installationAppointment.ts
@@ -18,7 +18,7 @@ const installationAppointmentPageContent: InstallationAppointmentPageContent = {
       text: 'What time will installation take place?',
       hint: 'Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm',
     },
-    appointmentTimeHomeOffice: {
+    preferredAppointmentTime: {
       text: 'What is the preferred time for installation to take place?',
       hint: "If the installation can't be done at this time, it will happen during standard hours. Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm",
     },

--- a/server/i18n/en/pages/installationAppointment.ts
+++ b/server/i18n/en/pages/installationAppointment.ts
@@ -18,6 +18,10 @@ const installationAppointmentPageContent: InstallationAppointmentPageContent = {
       text: 'What time will installation take place?',
       hint: 'Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm',
     },
+    appointmentTimeHomeOffice: {
+      text: 'What is the preferred time for installation to take place?',
+      hint: "If the installation can't be done at this time, it will happen during standard hours. Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm",
+    },
   },
 }
 

--- a/server/models/view-models/installationAppointment.ts
+++ b/server/models/view-models/installationAppointment.ts
@@ -7,10 +7,12 @@ import { createGovukErrorSummary } from '../../utils/errors'
 
 type InstallationAppointmentViewModel = ViewModel<Pick<InstallationAppointment, 'placeName'>> & {
   appointmentDate: DateTimeField
+  isHomeOffice: boolean
 }
 
 const constructFromEntity = (
   appointment: InstallationAppointment | undefined | null,
+  isHomeOffice: boolean,
 ): InstallationAppointmentViewModel => {
   return {
     placeName: {
@@ -19,12 +21,14 @@ const constructFromEntity = (
     appointmentDate: {
       value: deserialiseDateTime(appointment?.appointmentDate),
     },
+    isHomeOffice,
     errorSummary: null,
   }
 }
 
 const constructFromFormData = (
   formData: InstallationAppointmentFormData,
+  isHomeOffice: boolean,
   validationErrors: ValidationResult,
 ): InstallationAppointmentViewModel => {
   return {
@@ -43,18 +47,21 @@ const constructFromFormData = (
       timeError: getError(validationErrors, 'appointmentDate-hours'),
       dateError: getError(validationErrors, 'appointmentDate'),
     },
+    isHomeOffice,
     errorSummary: createGovukErrorSummary(validationErrors),
   }
 }
+
 const construct = (
   appointment: InstallationAppointment | undefined | null,
   formData: InstallationAppointmentFormData,
+  isHomeOffice: boolean,
   validationErrors: ValidationResult,
 ): InstallationAppointmentViewModel => {
   if (validationErrors.length > 0 && formData) {
-    return constructFromFormData(formData, validationErrors)
+    return constructFromFormData(formData, isHomeOffice, validationErrors)
   }
-  return constructFromEntity(appointment)
+  return constructFromEntity(appointment, isHomeOffice)
 }
 
 export default {

--- a/server/models/view-models/installationAppointment.ts
+++ b/server/models/view-models/installationAppointment.ts
@@ -7,12 +7,14 @@ import { createGovukErrorSummary } from '../../utils/errors'
 
 type InstallationAppointmentViewModel = ViewModel<Pick<InstallationAppointment, 'placeName'>> & {
   appointmentDate: DateTimeField
-  isHomeOffice: boolean
+  appointmentTimeLabel: string
+  appointmentTimeHint: string
 }
 
 const constructFromEntity = (
   appointment: InstallationAppointment | undefined | null,
-  isHomeOffice: boolean,
+  appointmentTimeLabel: string,
+  appointmentTimeHint: string,
 ): InstallationAppointmentViewModel => {
   return {
     placeName: {
@@ -21,14 +23,16 @@ const constructFromEntity = (
     appointmentDate: {
       value: deserialiseDateTime(appointment?.appointmentDate),
     },
-    isHomeOffice,
+    appointmentTimeLabel,
+    appointmentTimeHint,
     errorSummary: null,
   }
 }
 
 const constructFromFormData = (
   formData: InstallationAppointmentFormData,
-  isHomeOffice: boolean,
+  appointmentTimeLabel: string,
+  appointmentTimeHint: string,
   validationErrors: ValidationResult,
 ): InstallationAppointmentViewModel => {
   return {
@@ -47,7 +51,8 @@ const constructFromFormData = (
       timeError: getError(validationErrors, 'appointmentDate-hours'),
       dateError: getError(validationErrors, 'appointmentDate'),
     },
-    isHomeOffice,
+    appointmentTimeLabel,
+    appointmentTimeHint,
     errorSummary: createGovukErrorSummary(validationErrors),
   }
 }
@@ -55,13 +60,14 @@ const constructFromFormData = (
 const construct = (
   appointment: InstallationAppointment | undefined | null,
   formData: InstallationAppointmentFormData,
-  isHomeOffice: boolean,
+  appointmentTimeLabel: string,
+  appointmentTimeHint: string,
   validationErrors: ValidationResult,
 ): InstallationAppointmentViewModel => {
   if (validationErrors.length > 0 && formData) {
-    return constructFromFormData(formData, isHomeOffice, validationErrors)
+    return constructFromFormData(formData, appointmentTimeLabel, appointmentTimeHint, validationErrors)
   }
-  return constructFromEntity(appointment, isHomeOffice)
+  return constructFromEntity(appointment, appointmentTimeLabel, appointmentTimeHint)
 }
 
 export default {

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -499,7 +499,7 @@ const createInstallationAppointmentAnswer = (order: Order, content: I18n, answer
 
   const appointmentTimeText =
     isHomeOffice && (location === 'PRIMARY' || location === 'INSTALLATION')
-      ? 'What is the preferred time for installation to take place?'
+      ? questions.appointmentTimeHomeOffice.text
       : questions.appointmentTime.text
 
   return [

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -499,7 +499,7 @@ const createInstallationAppointmentAnswer = (order: Order, content: I18n, answer
 
   const appointmentTimeText =
     isHomeOffice && (location === 'PRIMARY' || location === 'INSTALLATION')
-      ? questions.appointmentTimeHomeOffice.text
+      ? questions.preferredAppointmentTime.text
       : questions.appointmentTime.text
 
   return [

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -490,13 +490,20 @@ const createInstallationAppointmentAnswer = (order: Order, content: I18n, answer
 
   const { questions } = content.pages.installationAppointment
 
-  if (!order.installationAppointment || order.installationLocation?.location === 'PRIMARY') {
+  const isHomeOffice = order.interestedParties?.notifyingOrganisation === 'HOME_OFFICE'
+
+  if (!order.installationAppointment || (order.installationLocation?.location === 'PRIMARY' && !isHomeOffice)) {
     return []
   }
+
+  const appointmentTimeText = isHomeOffice
+    ? 'What is the preferred time for installation to take place?'
+    : questions.appointmentTime.text
+
   return [
     createAnswer(questions.placeName.text, order.installationAppointment?.placeName, uri, answerOpts),
     createDateAnswer(questions.appointmentDate.text, order.installationAppointment?.appointmentDate, uri, answerOpts),
-    createTimeAnswer(questions.appointmentTime.text, order.installationAppointment?.appointmentDate, uri, answerOpts),
+    createTimeAnswer(appointmentTimeText, order.installationAppointment?.appointmentDate, uri, answerOpts),
   ]
 }
 

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -491,14 +491,16 @@ const createInstallationAppointmentAnswer = (order: Order, content: I18n, answer
   const { questions } = content.pages.installationAppointment
 
   const isHomeOffice = order.interestedParties?.notifyingOrganisation === 'HOME_OFFICE'
+  const location = order.installationLocation?.location
 
-  if (!order.installationAppointment || (order.installationLocation?.location === 'PRIMARY' && !isHomeOffice)) {
+  if (!order.installationAppointment || (location === 'PRIMARY' && !isHomeOffice)) {
     return []
   }
 
-  const appointmentTimeText = isHomeOffice
-    ? 'What is the preferred time for installation to take place?'
-    : questions.appointmentTime.text
+  const appointmentTimeText =
+    isHomeOffice && (location === 'PRIMARY' || location === 'INSTALLATION')
+      ? 'What is the preferred time for installation to take place?'
+      : questions.appointmentTime.text
 
   return [
     createAnswer(questions.placeName.text, order.installationAppointment?.placeName, uri, answerOpts),

--- a/server/types/i18n/pages/installationAppointment.ts
+++ b/server/types/i18n/pages/installationAppointment.ts
@@ -1,7 +1,7 @@
 import QuestionPageContent from './questionPage'
 
 type InstallationAppointmentPageContent = QuestionPageContent<
-  'placeName' | 'appointmentDate' | 'appointmentTime' | 'appointmentTimeHomeOffice'
+  'placeName' | 'appointmentDate' | 'appointmentTime' | 'preferredAppointmentTime'
 >
 
 export default InstallationAppointmentPageContent

--- a/server/types/i18n/pages/installationAppointment.ts
+++ b/server/types/i18n/pages/installationAppointment.ts
@@ -1,5 +1,7 @@
 import QuestionPageContent from './questionPage'
 
-type InstallationAppointmentPageContent = QuestionPageContent<'placeName' | 'appointmentDate' | 'appointmentTime'>
+type InstallationAppointmentPageContent = QuestionPageContent<
+  'placeName' | 'appointmentDate' | 'appointmentTime' | 'appointmentTimeHomeOffice'
+>
 
 export default InstallationAppointmentPageContent

--- a/server/views/pages/order/monitoring-conditions/installation-appointment.njk
+++ b/server/views/pages/order/monitoring-conditions/installation-appointment.njk
@@ -6,6 +6,9 @@
 {% set legend = content.pages.installationAppointment.legend %}
 {% set helpText = content.pages.installationAppointment.helpText %}
 {% set questions = content.pages.installationAppointment.questions %}
+{% set appointmentTimeLabel = "What is the preferred time for installation to take place?" if isHomeOffice else questions.appointmentTime.text %}
+{% set appointmentTimeHint = "If the installation can't be done at this time, it will happen during standard hours. Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm" if isHomeOffice else questions.appointmentTime.hint %}
+{% set questions = content.pages.installationAppointment.questions %}
 {% block formInputs %}
 
 {{ govukInput({
@@ -30,8 +33,8 @@
       date: appointmentDate.value,
       dateLabel:  questions.appointmentDate.text,
       dateHint: questions.appointmentDate.hint,
-      timeLabel: questions.appointmentTime.text,
-      timeHint: questions.appointmentTime.hint,
+      timeLabel: appointmentTimeLabel,
+      timeHint: appointmentTimeHint,
       errorMessages: {
         date: appointmentDate.dateError,
         time: appointmentDate.timeError

--- a/server/views/pages/order/monitoring-conditions/installation-appointment.njk
+++ b/server/views/pages/order/monitoring-conditions/installation-appointment.njk
@@ -6,8 +6,6 @@
 {% set legend = content.pages.installationAppointment.legend %}
 {% set helpText = content.pages.installationAppointment.helpText %}
 {% set questions = content.pages.installationAppointment.questions %}
-{% set appointmentTimeLabel = "What is the preferred time for installation to take place?" if isHomeOffice else questions.appointmentTime.text %}
-{% set appointmentTimeHint = "If the installation can't be done at this time, it will happen during standard hours. Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm" if isHomeOffice else questions.appointmentTime.hint %}
 {% block formInputs %}
 
 {{ govukInput({

--- a/server/views/pages/order/monitoring-conditions/installation-appointment.njk
+++ b/server/views/pages/order/monitoring-conditions/installation-appointment.njk
@@ -8,7 +8,6 @@
 {% set questions = content.pages.installationAppointment.questions %}
 {% set appointmentTimeLabel = "What is the preferred time for installation to take place?" if isHomeOffice else questions.appointmentTime.text %}
 {% set appointmentTimeHint = "If the installation can't be done at this time, it will happen during standard hours. Enter time using a 24 hour clock. For example, enter 14:30 instead of 2:30pm" if isHomeOffice else questions.appointmentTime.hint %}
-{% set questions = content.pages.installationAppointment.questions %}
 {% block formInputs %}
 
 {{ govukInput({


### PR DESCRIPTION
### Context

Ticket: [https://dsdmoj.atlassian.net/browse/ELM-4824](https://dsdmoj.atlassian.net/browse/ELM-4824)

Add preferred time of installation for Home Office users.

### Changes proposed in this pull request

1.) Change the time question and hint on installation appointment page for HO - should only display for **primary** and **at another address** options, default text with others

2.) Fix bug where installation appointment section hidden on CYA page for HO

<img width="786" height="656" alt="image" src="https://github.com/user-attachments/assets/9951bdfb-bcb3-4e11-b81a-5878c47b294a" />

<img width="814" height="828" alt="image" src="https://github.com/user-attachments/assets/21337566-7795-403a-b309-8d1585844460" />