### PR TITLE
Elm 4796 what have you changed field

### DIFF
--- a/integration_tests/e2e/order/receipt.cy.ts
+++ b/integration_tests/e2e/order/receipt.cy.ts
@@ -442,7 +442,7 @@ context('Receipt', () => {
       page.variationDetailsSection.shouldExist()
       page.variationDetailsSection.shouldHaveItems([
         { key: 'What is the date you want the changes to take effect?', value: '01/01/2025' },
-        { key: 'Enter details of all the changes you have made', value: 'some variation details' },
+        { key: 'Provide additional information about the changes', value: 'some variation details' },
       ])
     })
 

--- a/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
@@ -31,8 +31,8 @@ context('Variation', () => {
         page.header.userName().should('contain.text', 'J. Smith')
         page.header.phaseBanner().should('contain.text', 'dev')
 
-        page.form.variationDetailsNeededField.element.should('exist')
-        page.form.variationDetailsNeededField.set('Yes')
+        page.form.variationDetailsAvailable.element.should('exist')
+        page.form.variationDetailsAvailable.set('Yes')
         page.form.variationDetailsField.element.should('exist')
 
         cy.get('form').find('legend').contains('What have you changed in the form?').should('exist')

--- a/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
@@ -28,19 +28,20 @@ context('Variation', () => {
       it('Should allow the user to update the variation details', () => {
         const page = Page.visit(VariationDetailsPage, { orderId: mockOrderId })
 
-        // Verify page layout is present
         page.header.userName().should('contain.text', 'J. Smith')
         page.header.phaseBanner().should('contain.text', 'dev')
 
-        // Verify form elements present and editable
+        page.form.variationDetailsNeededField.element.should('exist')
+        page.form.variationDetailsNeededField.set('Yes')
         page.form.variationDetailsField.element.should('exist')
+
         cy.get('form').find('legend').contains('What have you changed in the form?').should('exist')
+
         page.form.saveAndReturnButton.should('exist')
         page.form.shouldNotBeDisabled()
         page.errorSummary.shouldNotExist()
         page.backButton.should('exist')
         page.form.shouldHaveAllOptions()
-        // A11y
         page.checkIsAccessible()
       })
 

--- a/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
@@ -31,8 +31,8 @@ context('Variation', () => {
         page.header.userName().should('contain.text', 'J. Smith')
         page.header.phaseBanner().should('contain.text', 'dev')
 
-        page.form.variationDetailsAvailable.element.should('exist')
-        page.form.variationDetailsAvailable.set('Yes')
+        page.form.variationDetailsAvailableField.element.should('exist')
+        page.form.variationDetailsAvailableField.set('Yes')
         page.form.variationDetailsField.element.should('exist')
 
         cy.get('form').find('legend').contains('What have you changed in the form?').should('exist')

--- a/integration_tests/e2e/order/variation/variation-details.page.submitted.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.page.submitted.cy.ts
@@ -43,6 +43,7 @@ context('Variation', () => {
         // Hide variation type question based on ticket https://dsdmoj.atlassian.net/browse/ELM-3923
         // page.form.variationTypeField.shouldHaveValue('The device wearer’s address')
         page.form.variationDateField.shouldHaveValue(new Date('2025-01-01T00:00:00Z'))
+        page.form.variationDetailsAvailableField.shouldHaveValue('Yes')
         page.form.variationDetailsField.shouldHaveValue('Change to address')
 
         // Should have the correct buttons

--- a/integration_tests/e2e/order/variation/variation-details.submission.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.submission.cy.ts
@@ -125,5 +125,78 @@ context('Variation', () => {
         Page.verifyOnPage(OrderSummaryPage)
       })
     })
+    context('Submitting valid data', () => {
+      beforeEach(() => {
+        cy.task('reset')
+        cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+
+        cy.task('stubCemoGetOrder', {
+          httpStatus: 200,
+          id: mockOrderId,
+          status: 'IN_PROGRESS',
+          type: 'VARIATION',
+          order: { dataDictionaryVersion: 'DDV5' },
+        })
+
+        cy.task('stubCemoSubmitOrder', {
+          httpStatus: 200,
+          id: mockOrderId,
+          subPath: apiPath,
+          response: {
+            variationType: 'CHANGE_TO_DEVICE_TYPE',
+            variationDate: '2024-01-01T00:00:00.000Z',
+            variationDetails: 'Change to device type',
+          },
+        })
+
+        cy.signIn()
+      })
+
+      it('with details', () => {
+        const page = Page.visit(VariationDetailsPage, { orderId: mockOrderId })
+
+        page.form.fillInWith({
+          variationDate: new Date(2024, 0, 1),
+          variationType: 'Change of device type (fitted/non fitted)',
+          variationDetails: 'Change to device type',
+        })
+
+        page.form.saveAndReturnButton.click()
+
+        cy.task('stubCemoVerifyRequestReceived', {
+          uri: `/orders/${mockOrderId}${apiPath}`,
+          body: {
+            variationType: 'CHANGE_TO_DEVICE_TYPE',
+            variationDate: '2024-01-01T00:00:00.000Z',
+            variationDetails: 'Change to device type',
+          },
+        }).should('be.true')
+
+        Page.verifyOnPage(OrderSummaryPage)
+      })
+
+      it('without details', () => {
+        const page = Page.visit(VariationDetailsPage, { orderId: mockOrderId })
+
+        page.form.fillInWith({
+          variationDate: new Date(2024, 0, 1),
+          variationType: 'Change of device type (fitted/non fitted)',
+        })
+        page.form.variationDetailsAvailableField.set('No')
+
+        page.form.saveAndReturnButton.click()
+
+        cy.task('stubCemoVerifyRequestReceived', {
+          uri: `/orders/${mockOrderId}${apiPath}`,
+          body: {
+            variationType: 'CHANGE_TO_DEVICE_TYPE',
+            variationDate: '2024-01-01T00:00:00.000Z',
+            variationDetails: '',
+          },
+        }).should('be.true')
+
+        Page.verifyOnPage(OrderSummaryPage)
+      })
+    })
   })
 })

--- a/integration_tests/e2e/order/variation/variation-details.validation.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.validation.cy.ts
@@ -46,7 +46,7 @@ context('Variation', () => {
         Page.verifyOnPage(VariationDetailsPage)
 
         page.form.variationDateField.shouldHaveValidationMessage(expectedValidationErrors.variationDate.required)
-        page.form.variationDetailsAvailable.shouldHaveValidationMessage(
+        page.form.variationDetailsAvailableField.shouldHaveValidationMessage(
           expectedValidationErrors.variationDetailsAvailable.required,
         )
         page.errorSummary.shouldExist()
@@ -58,7 +58,7 @@ context('Variation', () => {
         const page = Page.visit(VariationDetailsPage, { orderId: mockOrderId })
 
         page.form.variationDateField.set(new Date())
-        page.form.variationDetailsAvailable.set('Yes')
+        page.form.variationDetailsAvailableField.set('Yes')
 
         page.form.saveAndReturnButton.click()
 

--- a/integration_tests/e2e/order/variation/variation-details.validation.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.validation.cy.ts
@@ -18,6 +18,9 @@ const expectedValidationErrors = {
   variationDetails: {
     required: 'Enter details of all the changes you have made',
   },
+  variationDetailsAvailable: {
+    required: 'Select Yes if there is any other information to be aware of',
+  },
 }
 
 context('Variation', () => {
@@ -43,9 +46,26 @@ context('Variation', () => {
         Page.verifyOnPage(VariationDetailsPage)
 
         page.form.variationDateField.shouldHaveValidationMessage(expectedValidationErrors.variationDate.required)
-        page.form.variationDetailsField.shouldHaveValidationMessage(expectedValidationErrors.variationDetails.required)
+        page.form.variationDetailsAvailable.shouldHaveValidationMessage(
+          expectedValidationErrors.variationDetailsAvailable.required,
+        )
         page.errorSummary.shouldExist()
         page.errorSummary.shouldHaveError(expectedValidationErrors.variationDate.required)
+        page.errorSummary.shouldHaveError(expectedValidationErrors.variationDetailsAvailable.required)
+      })
+
+      it('Should display details validation message when selected "Yes"', () => {
+        const page = Page.visit(VariationDetailsPage, { orderId: mockOrderId })
+
+        page.form.variationDateField.set(new Date())
+        page.form.variationDetailsAvailable.set('Yes')
+
+        page.form.saveAndReturnButton.click()
+
+        Page.verifyOnPage(VariationDetailsPage)
+
+        page.form.variationDetailsField.shouldHaveValidationMessage(expectedValidationErrors.variationDetails.required)
+        page.errorSummary.shouldExist()
         page.errorSummary.shouldHaveError(expectedValidationErrors.variationDetails.required)
       })
 
@@ -64,22 +84,6 @@ context('Variation', () => {
         page.form.variationDateField.shouldHaveValidationMessage(expectedValidationErrors.variationDate.mustBeRealDate)
         page.errorSummary.shouldExist()
         page.errorSummary.shouldHaveError(expectedValidationErrors.variationDate.mustBeRealDate)
-      })
-
-      it('Should display description validation error message when the form description has not been filled in', () => {
-        const page = Page.visit(VariationDetailsPage, { orderId: mockOrderId })
-
-        page.form.fillInWith({
-          variationDate: new Date(2024, 1, 1),
-        })
-
-        page.form.saveAndReturnButton.click()
-
-        Page.verifyOnPage(VariationDetailsPage)
-
-        page.form.variationDetailsField.shouldHaveValidationMessage(expectedValidationErrors.variationDetails.required)
-        page.errorSummary.shouldExist()
-        page.errorSummary.shouldHaveError(expectedValidationErrors.variationDetails.required)
       })
 
       it('Should display description validation error message when the form description is longer than 200 characters', () => {

--- a/integration_tests/pages/components/forms/variation/variationDetails.ts
+++ b/integration_tests/pages/components/forms/variation/variationDetails.ts
@@ -1,7 +1,7 @@
 import FormComponent from '../../formComponent'
 import FormDateComponent from '../../formDateComponent'
+import FormInputComponent from '../../formInputComponent'
 import FormRadiosComponent from '../../formRadiosComponent'
-import FormTextareaComponent from '../../formTextareaComponent'
 
 export type VariationDetailsFormData = {
   variationType?: string
@@ -22,9 +22,13 @@ export default class VariationDetailsFormComponent extends FormComponent {
     return new FormDateComponent(this.form, label)
   }
 
-  get variationDetailsField(): FormTextareaComponent {
-    const label = 'Enter details of all the changes you have made'
-    return new FormTextareaComponent(this.form, label)
+  get variationDetailsNeededField(): FormRadiosComponent {
+    const label = 'Is there any other information to be aware of about the changes?'
+    return new FormRadiosComponent(this.form, label, ['Yes', 'No'])
+  }
+
+  get variationDetailsField(): FormInputComponent {
+    return new FormInputComponent(this.form, 'Provide additional information about the changes')
   }
 
   // FORM HELPERS

--- a/integration_tests/pages/components/forms/variation/variationDetails.ts
+++ b/integration_tests/pages/components/forms/variation/variationDetails.ts
@@ -22,7 +22,7 @@ export default class VariationDetailsFormComponent extends FormComponent {
     return new FormDateComponent(this.form, label)
   }
 
-  get variationDetailsAvailable(): FormRadiosComponent {
+  get variationDetailsAvailableField(): FormRadiosComponent {
     const label = 'Is there any other information to be aware of about the changes?'
     return new FormRadiosComponent(this.form, label, ['Yes', 'No'])
   }
@@ -43,7 +43,7 @@ export default class VariationDetailsFormComponent extends FormComponent {
     }
 
     if (profile.variationDetails) {
-      this.variationDetailsAvailable.set('Yes')
+      this.variationDetailsAvailableField.set('Yes')
       this.variationDetailsField.set(profile.variationDetails)
     }
   }

--- a/integration_tests/pages/components/forms/variation/variationDetails.ts
+++ b/integration_tests/pages/components/forms/variation/variationDetails.ts
@@ -22,7 +22,7 @@ export default class VariationDetailsFormComponent extends FormComponent {
     return new FormDateComponent(this.form, label)
   }
 
-  get variationDetailsNeededField(): FormRadiosComponent {
+  get variationDetailsAvailable(): FormRadiosComponent {
     const label = 'Is there any other information to be aware of about the changes?'
     return new FormRadiosComponent(this.form, label, ['Yes', 'No'])
   }
@@ -43,6 +43,7 @@ export default class VariationDetailsFormComponent extends FormComponent {
     }
 
     if (profile.variationDetails) {
+      this.variationDetailsAvailable.set('Yes')
       this.variationDetailsField.set(profile.variationDetails)
     }
   }

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -100,6 +100,7 @@ interface ValidationErrors {
     variationTypeRequired: string
     variationDetailsRequired: string
     variationDetailsTooLong: string
+    variationDetailsAvailableRequired: string
   }
   installationLocation: {
     locationRequired: string
@@ -353,6 +354,7 @@ const validationErrors: ValidationErrors = {
     variationTypeRequired: 'Select what you have changed',
     variationDetailsRequired: 'Enter details of all the changes you have made',
     variationDetailsTooLong: 'Information on what you have changed must be 200 characters or less',
+    variationDetailsAvailableRequired: 'Select Yes if there is any other information to be aware of',
   },
   installationLocation: {
     locationRequired: 'Select where will installation of the electronic monitoring device take place',

--- a/server/controllers/variation/variationDetailsController.test.ts
+++ b/server/controllers/variation/variationDetailsController.test.ts
@@ -219,7 +219,7 @@ describe('VariationDetailsController', () => {
             day: '01',
           },
           variationDetails: 'Change to curfew hours',
-          variationDetailsAvailable: 'Yes',
+          variationDetailsAvailable: 'true',
         },
         params: {
           orderId: order.id,

--- a/server/controllers/variation/variationDetailsController.test.ts
+++ b/server/controllers/variation/variationDetailsController.test.ts
@@ -126,7 +126,7 @@ describe('VariationDetailsController', () => {
           value: 'Change to curfew hours',
         },
         variationDetailsAvailable: {
-          value: 'Yes',
+          value: 'true',
         },
         type: 'VARIATION',
         errorSummary: null,

--- a/server/controllers/variation/variationDetailsController.test.ts
+++ b/server/controllers/variation/variationDetailsController.test.ts
@@ -83,6 +83,9 @@ describe('VariationDetailsController', () => {
         variationDetails: {
           value: '',
         },
+        variationDetailsAvailable: {
+          value: '',
+        },
       })
     })
 
@@ -121,6 +124,9 @@ describe('VariationDetailsController', () => {
         },
         variationDetails: {
           value: 'Change to curfew hours',
+        },
+        variationDetailsAvailable: {
+          value: 'Yes',
         },
         type: 'VARIATION',
         errorSummary: null,
@@ -182,6 +188,9 @@ describe('VariationDetailsController', () => {
             text: 'Enter details of all the changes you have made',
           },
         },
+        variationDetailsAvailable: {
+          value: '',
+        },
         type: 'VARIATION',
         errorSummary: {
           titleText: 'There is a problem',
@@ -210,6 +219,7 @@ describe('VariationDetailsController', () => {
             day: '01',
           },
           variationDetails: 'Change to curfew hours',
+          variationDetailsAvailable: 'Yes',
         },
         params: {
           orderId: order.id,
@@ -256,6 +266,7 @@ describe('VariationDetailsController', () => {
             day: '01',
           },
           variationDetails: 'Change to curfew hours',
+          variationDetailsAvailable: 'Yes',
         },
         params: {
           orderId: order.id,
@@ -325,7 +336,7 @@ describe('VariationDetailsController', () => {
           focusTarget: 'variationDate-day',
         },
         { error: 'Select what you have changed', field: 'variationType' },
-        { error: 'Enter details of all the changes you have made', field: 'variationDetails' },
+        { error: 'Select Yes if there is any other information to be aware of', field: 'variationDetailsAvailable' },
       ])
       expect(taskListService.getNextPage).not.toHaveBeenCalled()
       expect(res.redirect).toHaveBeenCalledWith(paths.VARIATION.VARIATION_DETAILS.replace(':orderId', order.id))

--- a/server/i18n/en/pages/variationDetails.ts
+++ b/server/i18n/en/pages/variationDetails.ts
@@ -12,8 +12,12 @@ const variationDetailsPageContent: VariationDetailsPageContent = {
       text: 'What have you changed in the form?',
     },
     variationDetails: {
-      text: 'Enter details of all the changes you have made',
-      hint: 'This text will be sent with your changes to help the installer quickly understand what has changed and what they need to do.',
+      text: 'Provide additional information about the changes',
+      hint: '',
+    },
+    variationDetailsAvailable: {
+      text: 'Is there any other information to be aware of about the changes?',
+      hint: '',
     },
   },
   section: 'About the changes in this version of the form',

--- a/server/models/form-data/variationDetails.ts
+++ b/server/models/form-data/variationDetails.ts
@@ -9,7 +9,8 @@ const VariationDetailsFormDataParser = FormDataModel.extend({
     year: z.string(),
   }),
   variationType: z.string().default(''),
-  variationDetails: z.string().default(''),
+  variationDetails: z.string().optional(),
+  variationDetailsAvailable: z.string().optional(),
   orderType: z.string().optional(),
 })
 const validateVariationDetailsFormData = (formData: VariationDetailsFormData) => {
@@ -20,11 +21,33 @@ const validateVariationDetailsFormData = (formData: VariationDetailsFormData) =>
       variationType: z.string().refine(val => val.length > 1 || orderType !== 'VARIATION', {
         message: validationErrors.variationDetails.variationTypeRequired,
       }),
-      variationDetails: z
-        .string()
-        .min(1, validationErrors.variationDetails.variationDetailsRequired)
-        .max(200, validationErrors.variationDetails.variationDetailsTooLong),
+      variationDetailsAvailable: z.string({
+        message: validationErrors.variationDetails.variationDetailsAvailableRequired,
+      }),
+      variationDetails: z.string(),
     })
+    .superRefine((data, ctx) => {
+      if (data.variationDetailsAvailable === 'true') {
+        if (data.variationDetails.length === 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['variationDetails'],
+            message: validationErrors.variationDetails.variationDetailsRequired,
+          })
+        }
+        if (data.variationDetails.length > 200) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['variationDetails'],
+            message: validationErrors.variationDetails.variationDetailsTooLong,
+          })
+        }
+      }
+    })
+    .transform(data => ({
+      ...data,
+      variationDetailsAvailable: undefined,
+    }))
     .parse(formData)
 }
 

--- a/server/models/view-models/variationDetails.ts
+++ b/server/models/view-models/variationDetails.ts
@@ -2,12 +2,13 @@ import { deserialiseDateTime, getError } from '../../utils/utils'
 import { VariationDetails } from '../VariationDetails'
 import { VariationDetailsFormData } from '../form-data/variationDetails'
 import { ValidationResult } from '../Validation'
-import { DateField, ViewModel } from './utils'
+import { DateField, TextField, ViewModel } from './utils'
 import { createGovukErrorSummary } from '../../utils/errors'
 import { Order } from '../Order'
 
 type VariationDetailsViewModel = ViewModel<Omit<VariationDetails, 'variationDate'>> & {
   variationDate: DateField
+  variationDetailsAvailable: TextField
   type: string
 }
 
@@ -26,8 +27,12 @@ const createViewModelFromFormData = (
       error: getError(validationErrors, 'variationDate'),
     },
     variationDetails: {
-      value: formData.variationDetails,
+      value: formData.variationDetails || '',
       error: getError(validationErrors, 'variationDetails'),
+    },
+    variationDetailsAvailable: {
+      value: formData.variationDetailsAvailable || '',
+      error: getError(validationErrors, 'variationDetailsAvailable'),
     },
     type: order.type,
     errorSummary: createGovukErrorSummary(validationErrors),
@@ -44,6 +49,9 @@ const createViewModelFromEntity = (order: Order): VariationDetailsViewModel => {
     },
     variationDetails: {
       value: order.variationDetails?.variationDetails ?? '',
+    },
+    variationDetailsAvailable: {
+      value: order.variationDetails?.variationDetails ? 'Yes' : '',
     },
     type: order.type,
     errorSummary: null,

--- a/server/models/view-models/variationDetails.ts
+++ b/server/models/view-models/variationDetails.ts
@@ -51,7 +51,7 @@ const createViewModelFromEntity = (order: Order): VariationDetailsViewModel => {
       value: order.variationDetails?.variationDetails ?? '',
     },
     variationDetailsAvailable: {
-      value: order.variationDetails?.variationDetails ? 'Yes' : '',
+      value: order.variationDetails?.variationDetails ? 'true' : '',
     },
     type: order.type,
     errorSummary: null,

--- a/server/types/i18n/pages/variationDetails.ts
+++ b/server/types/i18n/pages/variationDetails.ts
@@ -1,5 +1,7 @@
 import QuestionPageContent from './questionPage'
 
-type VariationDetailsPageContent = QuestionPageContent<'variationDate' | 'variationType' | 'variationDetails'>
+type VariationDetailsPageContent = QuestionPageContent<
+  'variationDate' | 'variationType' | 'variationDetails' | 'variationDetailsAvailable'
+>
 
 export default VariationDetailsPageContent

--- a/server/views/pages/order/variation/variation-details.njk
+++ b/server/views/pages/order/variation/variation-details.njk
@@ -71,21 +71,50 @@
   }) }}
 {% endif %}
 
+{% set variationDetailsHTML %}
   {{ govukCharacterCount({
     name: "variationDetails",
     id: "variationDetails",
     maxlength: 200,
     label: {
       text: content.pages.variationDetails.questions.variationDetails.text,
-      classes: "govuk-label--s",
       isPageHeading: false
-    },
-    hint: {
-      text: content.pages.variationDetails.questions.variationDetails.hint
     },
     value: variationDetails.value,
     errorMessage: variationDetails.error,
     attributes: isDisabled
   }) }}
+{% endset %}
+
+ {{ govukRadios({
+      name: "variationDetailsAvailable",
+      fieldset:{
+        legend: {
+          text: content.pages.variationDetails.questions.variationDetailsAvailable.text,
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: [
+        {
+          value: "true",
+          text: "Yes",
+          hint: {
+            html: visuallyHiddenHint
+          },
+          conditional: {
+            html: variationDetailsHTML
+          },
+          disabled: not isOrderEditable
+        },
+        {
+          value: "false",
+          text: "No",
+          disabled: not isOrderEditable
+        }
+      ],
+      value: variationDetailsAvailable.value,
+      errorMessage: variationDetailsAvailable.error,
+      disabled: not isOrderEditable
+    }) }}
 
 {% endblock %}


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4796

We are programatically inferring what has changed in a form.

This means it is less important the user puts what has changed in the box.

We want to keep it as users have said its useful. For example, ‘He never answers the front door so I can put go round the back’.

### Changes proposed in this pull request

Make the variation details section optional with radio buttons so you can select if you have details or not
