### PR TITLE
remove variation type question

### DIFF
--- a/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.page.draft.cy.ts
@@ -35,13 +35,10 @@ context('Variation', () => {
         page.form.variationDetailsAvailableField.set('Yes')
         page.form.variationDetailsField.element.should('exist')
 
-        cy.get('form').find('legend').contains('What have you changed in the form?').should('exist')
-
         page.form.saveAndReturnButton.should('exist')
         page.form.shouldNotBeDisabled()
         page.errorSummary.shouldNotExist()
         page.backButton.should('exist')
-        page.form.shouldHaveAllOptions()
         page.checkIsAccessible()
       })
 
@@ -50,63 +47,6 @@ context('Variation', () => {
         Page.visit(VariationDetailsPage, { orderId: mockOrderId })
         Page.verifyOnPage(VariationDetailsPage)
         cy.get('form').find('legend').contains('What have you changed in the form?').should('not.exist')
-      })
-      context('DDv5', () => {
-        beforeEach(() => {
-          stubOrder()
-        })
-
-        it('Should have DDv5 options only', () => {
-          Page.visit(VariationDetailsPage, { orderId: mockOrderId })
-          const page = Page.verifyOnPage(VariationDetailsPage)
-          page.form.variationTypeField.shouldHaveOption('The device wearer’s address')
-          page.form.variationTypeField.shouldHaveOption('The device wearer’s personal details')
-          page.form.variationTypeField.shouldHaveOption('Change to add an exclusion zone(s)')
-          page.form.variationTypeField.shouldHaveOption('Change to an existing exclusion zone(s)')
-          page.form.variationTypeField.shouldHaveOption('The curfew hours')
-          page.form.variationTypeField.shouldHaveOption('Change of device type (fitted/non fitted)')
-          page.form.variationTypeField.shouldHaveOption(
-            'Temporary suspension of monitoring (attend a funeral or go on holiday)',
-          )
-          page.form.variationTypeField.shouldHaveOption('Change to an enforceable condition')
-          page.form.variationTypeField.shouldHaveOption('I have changed something due to an administration error')
-          page.form.variationTypeField.shouldHaveOption('I have changed something else in the form')
-
-          page.form.variationTypeField.shouldNotHaveOption('Change of curfew hours')
-          page.form.variationTypeField.shouldNotHaveOption('Change of address')
-          page.form.variationTypeField.shouldNotHaveOption('Change to add an Exclusion Zone(s)')
-          page.form.variationTypeField.shouldNotHaveOption('Change to an existing Exclusion Zone(s).')
-        })
-      })
-
-      context('DDv4', () => {
-        beforeEach(() => {
-          stubOrder('VARIATION', 'DDV4')
-        })
-
-        it('Should have DDv4 options only', () => {
-          Page.visit(VariationDetailsPage, { orderId: mockOrderId })
-          const page = Page.verifyOnPage(VariationDetailsPage)
-
-          page.form.variationTypeField.shouldHaveOption('Change of curfew hours')
-          page.form.variationTypeField.shouldHaveOption('Change of address')
-          page.form.variationTypeField.shouldHaveOption('Change to add an Exclusion Zone(s)')
-          page.form.variationTypeField.shouldHaveOption('Change to an existing Exclusion Zone(s).')
-          page.form.variationTypeField.shouldHaveOption('Order Suspension')
-
-          page.form.variationTypeField.shouldNotHaveOption('The device wearer’s address')
-          page.form.variationTypeField.shouldNotHaveOption('The device wearer’s personal details')
-          page.form.variationTypeField.shouldNotHaveOption('Change to add an exclusion zone(s)')
-          page.form.variationTypeField.shouldNotHaveOption('Change to an existing exclusion zone(s)')
-          page.form.variationTypeField.shouldNotHaveOption('The curfew hours')
-          page.form.variationTypeField.shouldNotHaveOption('Change to a device type')
-          page.form.variationTypeField.shouldNotHaveOption('Change to an enforceable condition')
-          page.form.variationTypeField.shouldNotHaveOption(
-            'Temporary suspension of monitoring (attend a funeral or go on holiday)',
-          )
-          page.form.variationTypeField.shouldNotHaveOption('I have changed something due to an administration error')
-          page.form.variationTypeField.shouldNotHaveOption('I have changed something else in the form')
-        })
       })
     })
     context('viewing an previous version', () => {

--- a/integration_tests/e2e/order/variation/variation-details.submission.cy.ts
+++ b/integration_tests/e2e/order/variation/variation-details.submission.cy.ts
@@ -8,7 +8,6 @@ const mockOrderId = uuidv4()
 const apiPath = '/variation'
 const sampleFormData = {
   variationDate: new Date(2024, 0, 1),
-  variationType: 'Change of curfew hours',
   variationDetails: 'Change to curfew hours',
 }
 
@@ -31,7 +30,6 @@ context('Variation', () => {
           id: mockOrderId,
           subPath: apiPath,
           response: {
-            variationType: 'CURFEW_HOURS',
             variationDate: '2024-01-01T00:00:00.000Z',
             variationDetails: 'Change to curfew hours',
           },
@@ -49,7 +47,6 @@ context('Variation', () => {
         cy.task('stubCemoVerifyRequestReceived', {
           uri: `/orders/${mockOrderId}${apiPath}`,
           body: {
-            variationType: 'CURFEW_HOURS',
             variationDate: '2024-01-01T00:00:00.000Z',
             variationDetails: 'Change to curfew hours',
           },
@@ -93,7 +90,6 @@ context('Variation', () => {
           id: mockOrderId,
           subPath: apiPath,
           response: {
-            variationType: 'CHANGE_TO_DEVICE_TYPE',
             variationDate: '2024-01-01T00:00:00.000Z',
             variationDetails: 'Change to device type',
           },
@@ -107,7 +103,6 @@ context('Variation', () => {
 
         page.form.fillInWith({
           variationDate: new Date(2024, 0, 1),
-          variationType: 'Change of device type (fitted/non fitted)',
           variationDetails: 'Change to device type',
         })
 
@@ -116,7 +111,6 @@ context('Variation', () => {
         cy.task('stubCemoVerifyRequestReceived', {
           uri: `/orders/${mockOrderId}${apiPath}`,
           body: {
-            variationType: 'CHANGE_TO_DEVICE_TYPE',
             variationDate: '2024-01-01T00:00:00.000Z',
             variationDetails: 'Change to device type',
           },
@@ -143,7 +137,6 @@ context('Variation', () => {
           id: mockOrderId,
           subPath: apiPath,
           response: {
-            variationType: 'CHANGE_TO_DEVICE_TYPE',
             variationDate: '2024-01-01T00:00:00.000Z',
             variationDetails: 'Change to device type',
           },
@@ -157,7 +150,6 @@ context('Variation', () => {
 
         page.form.fillInWith({
           variationDate: new Date(2024, 0, 1),
-          variationType: 'Change of device type (fitted/non fitted)',
           variationDetails: 'Change to device type',
         })
 
@@ -166,7 +158,6 @@ context('Variation', () => {
         cy.task('stubCemoVerifyRequestReceived', {
           uri: `/orders/${mockOrderId}${apiPath}`,
           body: {
-            variationType: 'CHANGE_TO_DEVICE_TYPE',
             variationDate: '2024-01-01T00:00:00.000Z',
             variationDetails: 'Change to device type',
           },
@@ -180,7 +171,6 @@ context('Variation', () => {
 
         page.form.fillInWith({
           variationDate: new Date(2024, 0, 1),
-          variationType: 'Change of device type (fitted/non fitted)',
         })
         page.form.variationDetailsAvailableField.set('No')
 
@@ -189,7 +179,6 @@ context('Variation', () => {
         cy.task('stubCemoVerifyRequestReceived', {
           uri: `/orders/${mockOrderId}${apiPath}`,
           body: {
-            variationType: 'CHANGE_TO_DEVICE_TYPE',
             variationDate: '2024-01-01T00:00:00.000Z',
             variationDetails: '',
           },

--- a/integration_tests/pages/components/forms/variation/variationDetails.ts
+++ b/integration_tests/pages/components/forms/variation/variationDetails.ts
@@ -4,18 +4,12 @@ import FormInputComponent from '../../formInputComponent'
 import FormRadiosComponent from '../../formRadiosComponent'
 
 export type VariationDetailsFormData = {
-  variationType?: string
   variationDate?: Date
   variationDetails?: string
 }
 
 export default class VariationDetailsFormComponent extends FormComponent {
   // FIELDS
-
-  get variationTypeField(): FormRadiosComponent {
-    const label = 'What have you changed in the form?'
-    return new FormRadiosComponent(this.form, label, [])
-  }
 
   get variationDateField(): FormDateComponent {
     const label = 'What is the date you want the changes to take effect?'
@@ -38,10 +32,6 @@ export default class VariationDetailsFormComponent extends FormComponent {
       this.variationDateField.set(profile.variationDate)
     }
 
-    if (profile.variationType) {
-      this.variationTypeField.set(profile.variationType)
-    }
-
     if (profile.variationDetails) {
       this.variationDetailsAvailableField.set('Yes')
       this.variationDetailsField.set(profile.variationDetails)
@@ -49,24 +39,17 @@ export default class VariationDetailsFormComponent extends FormComponent {
   }
 
   shouldBeValid(): void {
-    this.variationTypeField.shouldNotHaveValidationMessage()
     this.variationDateField.shouldNotHaveValidationMessage()
     this.variationDetailsField.shouldNotHaveValidationMessage()
   }
 
   shouldBeDisabled(): void {
     this.variationDateField.shouldBeDisabled()
-    this.variationTypeField.shouldBeDisabled()
     this.variationDetailsField.shouldBeDisabled()
   }
 
   shouldNotBeDisabled(): void {
     this.variationDateField.shouldNotBeDisabled()
-    this.variationTypeField.shouldNotBeDisabled()
     this.variationDetailsField.shouldNotBeDisabled()
-  }
-
-  shouldHaveAllOptions(): void {
-    this.variationTypeField.shouldHaveAllOptions()
   }
 }

--- a/server/controllers/variation/variationDetailsController.test.ts
+++ b/server/controllers/variation/variationDetailsController.test.ts
@@ -77,9 +77,6 @@ describe('VariationDetailsController', () => {
             hours: '',
           },
         },
-        variationType: {
-          value: '',
-        },
         variationDetails: {
           value: '',
         },
@@ -95,7 +92,6 @@ describe('VariationDetailsController', () => {
         order: getMockOrder({
           type: 'VARIATION',
           variationDetails: {
-            variationType: 'CURFEW_HOURS',
             variationDate: '2024-01-01T00:00:00.000Z',
             variationDetails: 'Change to curfew hours',
           },
@@ -110,9 +106,6 @@ describe('VariationDetailsController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/order/variation/variation-details', {
-        variationType: {
-          value: 'CURFEW_HOURS',
-        },
         variationDate: {
           value: {
             year: '2024',
@@ -142,13 +135,11 @@ describe('VariationDetailsController', () => {
         flash: jest
           .fn()
           .mockReturnValueOnce([
-            { error: 'Select what you have changed', field: 'variationType' },
             { error: 'Enter the date you want the changes to take effect', field: 'variationDate' },
             { error: 'Enter details of all the changes you have made', field: 'variationDetails' },
           ])
           .mockReturnValueOnce([
             {
-              variationType: '',
               variationDate: {
                 year: '',
                 month: '',
@@ -166,12 +157,6 @@ describe('VariationDetailsController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/order/variation/variation-details', {
-        variationType: {
-          value: '',
-          error: {
-            text: 'Select what you have changed',
-          },
-        },
         variationDate: {
           value: {
             year: '',
@@ -195,7 +180,6 @@ describe('VariationDetailsController', () => {
         errorSummary: {
           titleText: 'There is a problem',
           errorList: [
-            { href: '#variationType', text: 'Select what you have changed' },
             { href: '#variationDate', text: 'Enter the date you want the changes to take effect' },
             { href: '#variationDetails', text: 'Enter details of all the changes you have made' },
           ],
@@ -212,7 +196,6 @@ describe('VariationDetailsController', () => {
         order,
         body: {
           action: 'continue',
-          variationType: 'CURFEW_HOURS',
           variationDate: {
             year: '2024',
             month: '01',
@@ -229,7 +212,6 @@ describe('VariationDetailsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       restClient.put.mockResolvedValue({
-        variationType: 'CURFEW_HOURS',
         variationDate: '2024-01-01T00:00:00.000Z',
         variationDetails: 'Change to curfew hours',
       })
@@ -244,7 +226,6 @@ describe('VariationDetailsController', () => {
       expect(restClient.put).toHaveBeenCalledWith({
         path: `/api/orders/${order.id}/variation`,
         data: {
-          variationType: 'CURFEW_HOURS',
           variationDate: '2024-01-01T00:00:00.000Z',
           variationDetails: 'Change to curfew hours',
         },
@@ -259,7 +240,6 @@ describe('VariationDetailsController', () => {
         order,
         body: {
           action: 'continue',
-          variationType: 'CURFEW_HOURS',
           variationDate: {
             year: '2024',
             month: '01',
@@ -276,7 +256,6 @@ describe('VariationDetailsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       restClient.put.mockResolvedValue({
-        variationType: 'CURFEW_HOURS',
         variationDate: '2024-01-01T00:00:00.000Z',
         variationDetails: 'Change to curfew hours',
       })
@@ -298,7 +277,6 @@ describe('VariationDetailsController', () => {
         order,
         body: {
           action: 'continue',
-          variationType: '',
           variationDate: {
             year: '',
             month: '',
@@ -320,7 +298,6 @@ describe('VariationDetailsController', () => {
       // Then
       expect(req.flash).toHaveBeenCalledTimes(2)
       expect(req.flash).toHaveBeenNthCalledWith(1, 'formData', {
-        variationType: '',
         variationDate: {
           year: '',
           month: '',
@@ -335,7 +312,6 @@ describe('VariationDetailsController', () => {
           field: 'variationDate',
           focusTarget: 'variationDate-day',
         },
-        { error: 'Select what you have changed', field: 'variationType' },
         { error: 'Select Yes if there is any other information to be aware of', field: 'variationDetailsAvailable' },
       ])
       expect(taskListService.getNextPage).not.toHaveBeenCalled()

--- a/server/i18n/en/pages/variationDetails.ts
+++ b/server/i18n/en/pages/variationDetails.ts
@@ -8,9 +8,6 @@ const variationDetailsPageContent: VariationDetailsPageContent = {
       text: 'What is the date you want the changes to take effect?',
       hint: 'For example, 21 05 2025',
     },
-    variationType: {
-      text: 'What have you changed in the form?',
-    },
     variationDetails: {
       text: 'Provide additional information about the changes',
       hint: '',

--- a/server/models/VariationDetails.ts
+++ b/server/models/VariationDetails.ts
@@ -1,27 +1,6 @@
 import { z } from 'zod'
 
-const VariationTypeEnum = z.enum([
-  // DDv4 Variation types
-  'CURFEW_HOURS',
-  'ADDRESS',
-  'ENFORCEMENT_ADD',
-  'ENFORCEMENT_UPDATE',
-  'SUSPENSION',
-  // DDv5 Variation types
-  'CHANGE_TO_ADDRESS',
-  'CHANGE_TO_PERSONAL_DETAILS',
-  'CHANGE_TO_ADD_AN_EXCLUSION_ZONES',
-  'CHANGE_TO_AN_EXISTING_EXCLUSION',
-  'CHANGE_TO_CURFEW_HOURS',
-  'ORDER_SUSPENSION',
-  'CHANGE_TO_DEVICE_TYPE',
-  'CHANGE_TO_ENFORCEABLE_CONDITION',
-  'ADMIN_ERROR',
-  'OTHER',
-])
-
 const VariationDetailsModel = z.object({
-  variationType: VariationTypeEnum.optional().nullable(),
   variationDate: z.string().datetime(),
   variationDetails: z.string(),
 })

--- a/server/models/form-data/variationDetails.ts
+++ b/server/models/form-data/variationDetails.ts
@@ -8,19 +8,14 @@ const VariationDetailsFormDataParser = FormDataModel.extend({
     month: z.string(),
     year: z.string(),
   }),
-  variationType: z.string().default(''),
   variationDetails: z.string().optional(),
   variationDetailsAvailable: z.string().optional(),
   orderType: z.string().optional(),
 })
 const validateVariationDetailsFormData = (formData: VariationDetailsFormData) => {
-  const { orderType } = formData
   return z
     .object({
       variationDate: DateInputModel(validationErrors.variationDetails.variationDate),
-      variationType: z.string().refine(val => val.length > 1 || orderType !== 'VARIATION', {
-        message: validationErrors.variationDetails.variationTypeRequired,
-      }),
       variationDetailsAvailable: z.string({
         message: validationErrors.variationDetails.variationDetailsAvailableRequired,
       }),

--- a/server/models/view-models/variationDetails.ts
+++ b/server/models/view-models/variationDetails.ts
@@ -18,10 +18,6 @@ const createViewModelFromFormData = (
   order: Order,
 ): VariationDetailsViewModel => {
   return {
-    variationType: {
-      value: formData.variationType,
-      error: getError(validationErrors, 'variationType'),
-    },
     variationDate: {
       value: formData.variationDate,
       error: getError(validationErrors, 'variationDate'),
@@ -41,9 +37,6 @@ const createViewModelFromFormData = (
 
 const createViewModelFromEntity = (order: Order): VariationDetailsViewModel => {
   return {
-    variationType: {
-      value: order.variationDetails?.variationType ?? '',
-    },
     variationDate: {
       value: deserialiseDateTime(order.variationDetails?.variationDate ?? null),
     },

--- a/server/types/i18n/pages/variationDetails.ts
+++ b/server/types/i18n/pages/variationDetails.ts
@@ -1,7 +1,7 @@
 import QuestionPageContent from './questionPage'
 
 type VariationDetailsPageContent = QuestionPageContent<
-  'variationDate' | 'variationType' | 'variationDetails' | 'variationDetailsAvailable'
+  'variationDate' | 'variationDetails' | 'variationDetailsAvailable'
 >
 
 export default VariationDetailsPageContent

--- a/server/views/pages/order/variation/variation-details.njk
+++ b/server/views/pages/order/variation/variation-details.njk
@@ -55,21 +55,6 @@
     ],
     errorMessage: variationDate.error
   }) }}
-{% if type === 'VARIATION' %}
-  {{ govukRadios({
-    name: "variationType",
-    fieldset: {
-      legend: {
-        text: content.pages.variationDetails.questions.variationType.text,
-        isPageHeading: false,
-        classes: "govuk-fieldset__legend--s"
-      }
-    },
-    value: variationType.value,
-    errorMessage: variationType.error,
-    items: content.reference.variationTypes | toOptions(not isOrderEditable)
-  }) }}
-{% endif %}
 
 {% set variationDetailsHTML %}
   {{ govukCharacterCount({


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-4872

Users have always hated the Order Variation Type (OVT) list and:

Struggled to know what to select as the list is not a complete list of changes they can make.

See it as an additional unnecessary question ‘I’ve already told you what I am changing (SR codes) and made the change, why do I have to tell you again?’

### Changes proposed in this pull request

Removing the question as the variation type is now programatically inferred
