### PR TITLE
ELM-4998: Bugs in ISR epic

### DIFF
--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/draft.cy.ts
@@ -474,7 +474,7 @@ context('new ISR monitoring types', () => {
     monitoringTypePage.form.message.contains('Alcohol monitoring is not allowed because the device wearer is a youth.')
   })
 
-  it('youth, SDS, HDC no, EMAC', () => {
+  it('youth, SDS, HDC no, GPS', () => {
     stubGetOrder({
       notifyingOrg: 'PROBATION',
       deviceWearer: createDeviceWearer(false),

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/draft.cy.ts
@@ -377,24 +377,6 @@ context('new ISR monitoring types', () => {
     )
   })
 
-  it('youth, no fixed address', () => {
-    stubGetOrder({
-      notifyingOrg: 'PROBATION',
-      deviceWearer: createDeviceWearer(false),
-      addresses: createAddresses(true),
-    })
-    const monitoringTypePage = Page.visit(MonitoringTypePage, { orderId: mockOrderId })
-
-    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Curfew')
-    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Exclusion zone monitoring')
-    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Trail')
-    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Mandatory attendance monitoring')
-
-    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Alcohol')
-    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Restriction zone monitoring')
-    monitoringTypePage.form.message.contains('Alcohol monitoring is not allowed because the device wearer is a youth.')
-  })
-
   it('home office, no fixed address', () => {
     stubGetOrder({ notifyingOrg: 'HOME_OFFICE', addresses: createAddresses(true) })
     const monitoringTypePage = Page.visit(MonitoringTypePage, { orderId: mockOrderId })
@@ -408,6 +390,25 @@ context('new ISR monitoring types', () => {
     monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Restriction zone monitoring')
     monitoringTypePage.form.message.contains(
       'The device wearer has no fixed address so only Trail monitoring and Exclusion zone monitoring is allowed.',
+    )
+  })
+
+  it('youth, no fixed address', () => {
+    stubGetOrder({
+      notifyingOrg: 'PROBATION',
+      deviceWearer: createDeviceWearer(false),
+      addresses: createAddresses(true),
+    })
+    const monitoringTypePage = Page.visit(MonitoringTypePage, { orderId: mockOrderId })
+
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Curfew')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Exclusion zone monitoring')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Trail')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Mandatory attendance monitoring')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Alcohol')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Restriction zone monitoring')
+    monitoringTypePage.form.message.contains(
+      'The device wearer has no fixed address and is a youth so no monitoring is allowed.',
     )
   })
 
@@ -437,6 +438,50 @@ context('new ISR monitoring types', () => {
       deviceWearer: createDeviceWearer(false),
       monitoringConditions: createMonitoringConditions({
         sentenceType: 'SECTION_91',
+      }),
+    })
+    const monitoringTypePage = Page.visit(MonitoringTypePage, { orderId: mockOrderId })
+
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Curfew')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Exclusion zone monitoring')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Trail')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Mandatory attendance monitoring')
+
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Alcohol')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Restriction zone monitoring')
+    monitoringTypePage.form.message.contains('Alcohol monitoring is not allowed because the device wearer is a youth.')
+  })
+
+  it('youth, SDS, HDC no, pilot unknown', () => {
+    stubGetOrder({
+      notifyingOrg: 'PROBATION',
+      deviceWearer: createDeviceWearer(false),
+      monitoringConditions: createMonitoringConditions({
+        sentenceType: 'STANDARD_DETERMINATE_SENTENCE',
+        hdc: 'NO',
+        pilot: 'UNKNOWN',
+      }),
+    })
+    const monitoringTypePage = Page.visit(MonitoringTypePage, { orderId: mockOrderId })
+
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Curfew')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Exclusion zone monitoring')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Trail')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Mandatory attendance monitoring')
+
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Alcohol')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Restriction zone monitoring')
+    monitoringTypePage.form.message.contains('Alcohol monitoring is not allowed because the device wearer is a youth.')
+  })
+
+  it('youth, SDS, HDC no, EMAC', () => {
+    stubGetOrder({
+      notifyingOrg: 'PROBATION',
+      deviceWearer: createDeviceWearer(false),
+      monitoringConditions: createMonitoringConditions({
+        sentenceType: 'STANDARD_DETERMINATE_SENTENCE',
+        hdc: 'NO',
+        pilot: 'GPS_ACQUISITIVE_CRIME_PAROLE',
       }),
     })
     const monitoringTypePage = Page.visit(MonitoringTypePage, { orderId: mockOrderId })
@@ -490,7 +535,7 @@ context('new ISR monitoring types', () => {
     monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Alcohol')
   })
 
-  it('no fixed address, sds, hdc no, pilot GPS', () => {
+  it('no fixed address, hdc no, pilot GPS', () => {
     stubGetOrder({
       notifyingOrg: 'PROBATION',
       addresses: createAddresses(true),
@@ -502,14 +547,39 @@ context('new ISR monitoring types', () => {
     })
     const monitoringTypePage = Page.visit(MonitoringTypePage, { orderId: mockOrderId })
 
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Alcohol')
+
     monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Curfew')
     monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Exclusion zone monitoring')
     monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Trail')
     monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Mandatory attendance monitoring')
-    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Alcohol')
     monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Restriction zone monitoring')
     monitoringTypePage.form.message.contains(
-      'No monitoring types can be selected because the device wearer is not on a Home Detention Curfew (HDC) and has no fixed address.',
+      'The device wearer has no fixed address so only Alcohol monitoring is allowed.',
+    )
+  })
+
+  it('no fixed address, hdc no, pilot unknown', () => {
+    stubGetOrder({
+      notifyingOrg: 'PROBATION',
+      addresses: createAddresses(true),
+      monitoringConditions: createMonitoringConditions({
+        sentenceType: 'STANDARD_DETERMINATE_SENTENCE',
+        hdc: 'NO',
+        pilot: 'UNKNOWN',
+      }),
+    })
+    const monitoringTypePage = Page.visit(MonitoringTypePage, { orderId: mockOrderId })
+
+    monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Alcohol')
+
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Curfew')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Exclusion zone monitoring')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Trail')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Mandatory attendance monitoring')
+    monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Restriction zone monitoring')
+    monitoringTypePage.form.message.contains(
+      'The device wearer has no fixed address so only Alcohol monitoring is allowed.',
     )
   })
 

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/draft.cy.ts
@@ -646,13 +646,45 @@ context('new ISR monitoring types', () => {
   })
 
   context('No condition available', () => {
-    it('should disable continue button', () => {
+    it('should disable continue button, no more options pilot unknown', () => {
       stubGetOrder({
         addresses: createAddresses(true),
         monitoringConditions: createMonitoringConditions({
           alcohol: true,
           hdc: 'YES',
           pilot: 'UNKNOWN',
+        }),
+        monitoringConditionsAlcohol: {
+          endDate: null,
+          installationLocation: null,
+          monitoringType: null,
+          prisonName: null,
+          probationOfficeName: null,
+          startDate: null,
+        },
+      })
+
+      const page = Page.visit(MonitoringTypePage, { orderId: mockOrderId })
+
+      page.form.monitoringTypesField.shouldHaveDisabledOption('Alcohol')
+      page.form.monitoringTypesField.shouldHaveDisabledOption('Trail')
+      page.form.monitoringTypesField.shouldHaveDisabledOption('Exclusion zone monitoring')
+      page.form.monitoringTypesField.shouldHaveDisabledOption('Curfew')
+      page.form.monitoringTypesField.shouldHaveDisabledOption('Mandatory attendance monitoring')
+      page.form.monitoringTypesField.shouldHaveDisabledOption('Restriction zone monitoring')
+      page.form.ReturnToMonitoringListPageButton.should('exist')
+      page.form.continueButton.should('be.disabled')
+
+      page.form.message.contains('There are no additional eligible monitoring types available to add')
+    })
+
+    it('should disable continue button, no more options pilot GPS', () => {
+      stubGetOrder({
+        addresses: createAddresses(true),
+        monitoringConditions: createMonitoringConditions({
+          alcohol: true,
+          hdc: 'YES',
+          pilot: 'GPS_ACQUISITIVE_CRIME_PAROLE',
         }),
         monitoringConditionsAlcohol: {
           endDate: null,

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/validation.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/validation.cy.ts
@@ -10,6 +10,38 @@ context('monitoringTypes', () => {
     cy.task('stubCemoGetOrder', {
       httpStatus: 200,
       id: mockOrderId,
+      order: {
+        deviceWearer: {
+          nomisId: 'nomis',
+          pncId: 'pnc',
+          deliusId: 'delius',
+          prisonNumber: 'prison',
+          homeOfficeReferenceNumber: '',
+          complianceAndEnforcementPersonReference: 'cepr',
+          courtCaseReferenceNumber: 'ccrn',
+          firstName: 'Eoforhild',
+          lastName: 'Coello',
+          alias: '',
+          dateOfBirth: '2000-01-01T00:00:00Z',
+          adultAtTimeOfInstallation: true,
+          sex: 'FEMALE',
+          gender: 'FEMALE',
+          disabilities: 'MENTAL_HEALTH',
+          otherDisability: null,
+          noFixedAbode: false,
+          interpreterRequired: false,
+        },
+        addresses: [
+          {
+            addressType: 'PRIMARY',
+            addressLine1: '5 The Avenue',
+            addressLine2: '',
+            addressLine3: 'London',
+            addressLine4: 'England',
+            postcode: 'SW21 2DX',
+          },
+        ],
+      },
     })
 
     cy.signIn()

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/draft.cy.ts
@@ -182,8 +182,8 @@ context('pilot', () => {
 
     const hintText =
       'To be eligible for tagging the device wearer must either be part of a pilot or have Alcohol Monitoring on Licence (AML) as a licence condition.'
-    pilotPage.form.pilotField.element.contains(hintText).should('be.hidden')
-    pilotPage.form.fillInWith('They are not part of any of these pilots')
-    pilotPage.form.pilotField.element.contains(hintText)
+    pilotPage.form.pilotField.element.contains(hintText).should('not.exist')
+
+    cy.contains(hintText).should('not.exist')
   })
 })

--- a/server/routes/monitoring-conditions/monitoring-type/monitoringTypeEligibilityService.ts
+++ b/server/routes/monitoring-conditions/monitoring-type/monitoringTypeEligibilityService.ts
@@ -30,6 +30,7 @@ export const eligibilityMessagesISR = {
   noFixedAddressHomeOffice:
     'The device wearer has no fixed address so only Trail monitoring and Exclusion zone monitoring is allowed.',
   youthAlcoholExcluded: 'Alcohol monitoring is not allowed because the device wearer is a youth.',
+  youthNoFixedAddress: 'The device wearer has no fixed address and is a youth so no monitoring is allowed.',
 }
 
 const hasFixedAddress = (order: Order): boolean => {
@@ -93,24 +94,43 @@ export class ISRMonitoringEligibilityService {
   getEnabled(order: Order): MonitoringTypeEligibility {
     const notifyingOrganisation = order.interestedParties?.notifyingOrganisation
 
-    if (order.monitoringConditions.hdc === 'NO') {
-      if (order.monitoringConditions.pilot === 'UNKNOWN') {
+    if (isYouth(order)) {
+      if (!hasFixedAddress(order)) {
         return {
-          options: ['curfew', 'exclusionZone', 'trail', 'mandatoryAttendance', 'alcohol', 'restrictionZone'],
+          options: [],
+          message: eligibilityMessagesISR.youthNoFixedAddress,
+          exception: true,
         }
       }
+      return {
+        options: ['curfew', 'exclusionZone', 'trail', 'mandatoryAttendance'],
+        message: eligibilityMessagesISR.youthAlcoholExcluded,
+      }
+    }
 
-      if (order.monitoringConditions.pilot === 'GPS_ACQUISITIVE_CRIME_PAROLE') {
-        if (!hasFixedAddress(order)) {
-          return {
-            options: [],
-            message: eligibilityMessages.hdcNoPilotGPSNoFixedAddress,
-            exception: true,
-          }
-        }
+    if (order.monitoringConditions.pilot === 'UNKNOWN') {
+      if (!hasFixedAddress(order)) {
         return {
-          options: ['curfew', 'exclusionZone', 'trail', 'mandatoryAttendance', 'alcohol', 'restrictionZone'],
+          options: ['alcohol'],
+          message: eligibilityMessagesISR.noFixedAddress,
+          exception: true,
         }
+      }
+      return {
+        options: ['curfew', 'exclusionZone', 'trail', 'mandatoryAttendance', 'alcohol', 'restrictionZone'],
+      }
+    }
+
+    if (order.monitoringConditions.pilot === 'GPS_ACQUISITIVE_CRIME_PAROLE') {
+      if (!hasFixedAddress(order)) {
+        return {
+          options: ['alcohol'],
+          message: eligibilityMessagesISR.noFixedAddress,
+          exception: true,
+        }
+      }
+      return {
+        options: ['curfew', 'exclusionZone', 'trail', 'mandatoryAttendance', 'alcohol', 'restrictionZone'],
       }
     }
 
@@ -125,13 +145,6 @@ export class ISRMonitoringEligibilityService {
       return {
         options: ['alcohol'],
         message: eligibilityMessagesISR.noFixedAddress,
-      }
-    }
-
-    if (isYouth(order)) {
-      return {
-        options: ['curfew', 'exclusionZone', 'trail', 'mandatoryAttendance'],
-        message: eligibilityMessagesISR.youthAlcoholExcluded,
       }
     }
 

--- a/server/routes/monitoring-conditions/monitoring-type/monitoringTypeEligibilityService.ts
+++ b/server/routes/monitoring-conditions/monitoring-type/monitoringTypeEligibilityService.ts
@@ -113,7 +113,6 @@ export class ISRMonitoringEligibilityService {
         return {
           options: ['alcohol'],
           message: eligibilityMessagesISR.noFixedAddress,
-          exception: true,
         }
       }
       return {
@@ -126,7 +125,6 @@ export class ISRMonitoringEligibilityService {
         return {
           options: ['alcohol'],
           message: eligibilityMessagesISR.noFixedAddress,
-          exception: true,
         }
       }
       return {

--- a/server/routes/monitoring-conditions/pilot/controller.test.ts
+++ b/server/routes/monitoring-conditions/pilot/controller.test.ts
@@ -139,9 +139,6 @@ describe('pilot controller', () => {
             {
               text: 'They are not part of any of these pilots',
               value: 'UNKNOWN',
-              conditional: {
-                html: 'To be eligible for tagging the device wearer must either be part of a pilot or have Alcohol Monitoring on Licence (AML) as a licence condition.',
-              },
             },
           ],
         }),

--- a/server/routes/monitoring-conditions/pilot/viewModel.ts
+++ b/server/routes/monitoring-conditions/pilot/viewModel.ts
@@ -55,9 +55,6 @@ const getItems = (isResponsibleOrgProbation: boolean, hdc?: string | null): Item
       {
         text: 'They are not part of any of these pilots',
         value: 'UNKNOWN',
-        conditional: {
-          html: 'To be eligible for tagging the device wearer must either be part of a pilot or have Alcohol Monitoring on Licence (AML) as a licence condition.',
-        },
       },
     ]
   } else {


### PR DESCRIPTION
### Context

Ticket: [https://dsdmoj.atlassian.net/browse/ELM-4998](https://dsdmoj.atlassian.net/browse/ELM-4998)

To fix the bugs in the ISR epic (such as monitoring type eligibility for different flows).

### Changes proposed in this pull request

The main change is to remove logic based on the answer to HDC. So the eligibility types do not depend on the HDC yes/no answer and instead rely on the notifying organisation, has fixed address and is youth.