### PR TITLE
ELM-5005: Sentencing act page improvements

### DIFF
--- a/integration_tests/e2e/order/contact-information/probation-delivery-unit.submission.cy.ts
+++ b/integration_tests/e2e/order/contact-information/probation-delivery-unit.submission.cy.ts
@@ -22,6 +22,7 @@ context('Contact information', () => {
           status: 'IN_PROGRESS',
           order: {
             dataDictionaryVersion: 'DDV5',
+            isSentencingAct: false,
             interestedParties: {
               notifyingOrganisation: 'PRISON',
               notifyingOrganisationName: 'FELTHAM_YOUNG_OFFENDER_INSTITUTION',

--- a/integration_tests/e2e/order/interested-parties/check-your-answers/submission.cy.ts
+++ b/integration_tests/e2e/order/interested-parties/check-your-answers/submission.cy.ts
@@ -25,6 +25,7 @@ context('interested parties check answers page', () => {
         status: 'IN_PROGRESS',
         order: {
           dataDictionaryVersion: 'DDV5',
+          isSentencingAct: false,
           interestedParties: {
             notifyingOrganisation: 'PRISON',
             notifyingOrganisationName: 'ALTCOURSE_PRISON',
@@ -66,6 +67,7 @@ context('interested parties check answers page', () => {
         status: 'SUBMITTED',
         order: {
           dataDictionaryVersion: 'DDV5',
+          isSentencingAct: false,
           interestedParties: {
             notifyingOrganisation: 'PRISON',
             notifyingOrganisationName: 'ALTCOURSE_PRISON',

--- a/integration_tests/e2e/order/interested-parties/sentencing-act/sentencingActFormComponent.ts
+++ b/integration_tests/e2e/order/interested-parties/sentencing-act/sentencingActFormComponent.ts
@@ -3,7 +3,7 @@ import FormRadiosComponent from '../../../../pages/components/formRadiosComponen
 
 export default class SentencingActFormComponent extends FormComponent {
   get isSentencingActChangeField(): FormRadiosComponent {
-    const label = 'Is the device wearer being released on or after 2 September 2026?'
+    const label = 'Is the device wearer being released on or after 1 October 2026?'
     return new FormRadiosComponent(this.form, label, ['Yes', 'No'])
   }
 

--- a/integration_tests/e2e/order/interested-parties/sentencing-act/sentencingActPage.ts
+++ b/integration_tests/e2e/order/interested-parties/sentencing-act/sentencingActPage.ts
@@ -8,7 +8,7 @@ export default class SentencingActPage extends AppFormPage {
 
   constructor() {
     super(
-      'Is the device wearer being released on or after 2 September 2026?',
+      'Is the device wearer being released on or after 1 October 2026?',
       paths.INTEREST_PARTIES.SENTENCING_ACT_SELECTION,
     )
   }

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/hdc-pause/draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/hdc-pause/draft.cy.ts
@@ -25,7 +25,7 @@ context('orderType', () => {
 
     page.header.userName().should('contain.text', 'J. Smith')
     page.header.phaseBanner().should('contain.text', 'dev')
-    cy.get('p').contains('Device wearers must not be released on HDC on or after 2 September 2026.').should('exist')
+    cy.get('p').contains('Device wearers must not be released on HDC on or after 1 October 2026.').should('exist')
     cy.get('p')
       .contains('They can ony be re-released on HDC on after this date if all of the following conditions are met:')
       .should('exist')
@@ -33,7 +33,7 @@ context('orderType', () => {
     cy.get('ul')
       .children()
       .get('li')
-      .contains('They were recalled during their HDC period on or after 2 September 2026.')
+      .contains('They were recalled during their HDC period on or after 1 October 2026.')
       .should('exist')
     cy.get('ul')
       .children()

--- a/integration_tests/e2e/order/summary.cy.ts
+++ b/integration_tests/e2e/order/summary.cy.ts
@@ -780,10 +780,10 @@ context('Order Summary', () => {
         httpStatus: 200,
         id: mockOrderId,
         status: 'IN_PROGRESS',
-        isSentencingAct: false,
         order: {
           id: mockOrderId,
           status: 'IN_PROGRESS',
+          isSentencingAct: false,
           deviceWearer: {
             nomisId: '',
             pncId: null,
@@ -1000,10 +1000,10 @@ context('Order Summary', () => {
         httpStatus: 200,
         id: mockOrderId,
         status: 'SUBMITTED',
-        isSentencingAct: false,
         order: {
           id: mockOrderId,
           status: 'IN_PROGRESS',
+          isSentencingAct: false,
           deviceWearer: {
             nomisId: '',
             pncId: null,

--- a/integration_tests/e2e/order/summary.cy.ts
+++ b/integration_tests/e2e/order/summary.cy.ts
@@ -30,6 +30,7 @@ context('Order Summary', () => {
         status: 'IN_PROGRESS',
         order: {
           dataDictionaryVersion: 'DDV6',
+          isSentencingAct: false,
           interestedParties: {
             notifyingOrganisation: 'PRISON',
             notifyingOrganisationName: 'ALTCOURSE_PRISON',
@@ -232,6 +233,7 @@ context('Order Summary', () => {
         status: 'IN_PROGRESS',
         order: {
           type: 'VARIATION',
+          isSentencingAct: false,
           interestedParties: {
             notifyingOrganisation: 'PRISON',
             notifyingOrganisationName: 'ALTCOURSE_PRISON',
@@ -289,6 +291,7 @@ context('Order Summary', () => {
         status: 'IN_PROGRESS',
         order: {
           type: 'VARIATION',
+          isSentencingAct: false,
           interestedParties: {
             notifyingOrganisation: 'PRISON',
             notifyingOrganisationName: 'ALTCOURSE_PRISON',
@@ -317,6 +320,7 @@ context('Order Summary', () => {
         status: 'IN_PROGRESS',
         order: {
           type: 'REVOCATION',
+          isSentencingAct: false,
           interestedParties: {
             notifyingOrganisation: 'PRISON',
             notifyingOrganisationName: 'ALTCOURSE_PRISON',
@@ -345,6 +349,7 @@ context('Order Summary', () => {
         status: 'IN_PROGRESS',
         order: {
           type: 'END_MONITORING',
+          isSentencingAct: false,
           interestedParties: {
             notifyingOrganisation: 'PRISON',
             notifyingOrganisationName: 'ALTCOURSE_PRISON',
@@ -373,6 +378,7 @@ context('Order Summary', () => {
         status: 'IN_PROGRESS',
         order: {
           type: 'REINSTALL_DEVICE',
+          isSentencingAct: false,
           interestedParties: {
             notifyingOrganisation: 'PRISON',
             notifyingOrganisationName: 'ALTCOURSE_PRISON',
@@ -401,6 +407,7 @@ context('Order Summary', () => {
         status: 'IN_PROGRESS',
         order: {
           type: 'REINSTALL_AT_DIFFERENT_ADDRESS',
+          isSentencingAct: false,
           interestedParties: {
             notifyingOrganisation: 'PRISON',
             notifyingOrganisationName: 'ALTCOURSE_PRISON',
@@ -470,6 +477,7 @@ context('Order Summary', () => {
         order: {
           id: mockOrderId,
           status: 'IN_PROGRESS',
+          isSentencingAct: false,
           deviceWearer: {
             nomisId: '',
             pncId: null,
@@ -772,6 +780,7 @@ context('Order Summary', () => {
         httpStatus: 200,
         id: mockOrderId,
         status: 'IN_PROGRESS',
+        isSentencingAct: false,
         order: {
           id: mockOrderId,
           status: 'IN_PROGRESS',
@@ -991,6 +1000,7 @@ context('Order Summary', () => {
         httpStatus: 200,
         id: mockOrderId,
         status: 'SUBMITTED',
+        isSentencingAct: false,
         order: {
           id: mockOrderId,
           status: 'IN_PROGRESS',
@@ -2175,6 +2185,7 @@ context('Order Summary', () => {
           status: 'SUBMITTED',
           submittedBy: 'John Smith',
           fmsResultDate: new Date(2025, 0, 1, 10, 30, 0, 0),
+          isSentencingAct: false,
           deviceWearer: {
             nomisId: '',
             pncId: null,

--- a/integration_tests/scenarios/all-condition-default-start-and-end-times.cy.ts
+++ b/integration_tests/scenarios/all-condition-default-start-and-end-times.cy.ts
@@ -262,6 +262,11 @@ context('The kitchen sink', () => {
                 start_date: formatAsFmsDateTime(primaryEnforcementZoneDetails.startDate, 0, 0),
                 end_date: formatAsFmsDateTime(primaryEnforcementZoneDetails.endDate, 23, 59),
               },
+              {
+                condition: 'Restriction Zone',
+                start_date: formatAsFmsDateTime(primaryEnforcementZoneDetails.startDate, 0, 0),
+                end_date: formatAsFmsDateTime(primaryEnforcementZoneDetails.endDate, 23, 59),
+              },
             ],
             exclusion_allday: '',
             interim_court_date: '',
@@ -356,6 +361,14 @@ context('The kitchen sink', () => {
               },
             ],
             inclusion_zones: [],
+            restriction_zones: [
+              {
+                description: primaryRestrictionZoneDetails.description,
+                duration: primaryRestrictionZoneDetails.duration,
+                start: formatAsFmsDate(primaryRestrictionZoneDetails.startDate),
+                end: formatAsFmsDate(primaryRestrictionZoneDetails.endDate),
+              },
+            ],
             abstinence: '',
             schedule: '',
             checkin_schedule: [],

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -466,7 +466,7 @@ const validationErrors: ValidationErrors = {
     isAddressChangeRequired: 'Select Yes if the device wearer’s primary address has changed',
   },
   sentencingActSelection: {
-    required: 'Select Yes if the device wearer is being released on or after October 1st 2026',
+    required: 'Select Yes if the device wearer is being released on or after 1 October 2026',
   },
 }
 

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -466,7 +466,7 @@ const validationErrors: ValidationErrors = {
     isAddressChangeRequired: 'Select Yes if the device wearer’s primary address has changed',
   },
   sentencingActSelection: {
-    required: 'Select Yes if the device wearer is being released on or after September 2026',
+    required: 'Select Yes if the device wearer is being released on or after October 1st 2026',
   },
 }
 

--- a/server/controllers/orderController.test.ts
+++ b/server/controllers/orderController.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto'
-import { getMockOrder } from '../../test/mocks/mockOrder'
+import { createInterestedParties, getMockOrder } from '../../test/mocks/mockOrder'
 import { createMockRequest, createMockResponse } from '../../test/mocks/mockExpress'
 import HmppsAuditClient from '../data/hmppsAuditClient'
 import RestClient from '../data/restClient'
@@ -63,6 +63,19 @@ describe('OrderController', () => {
           order: mockOrder,
         }),
       )
+    })
+
+    it('should redirect to sentencing act page when not set and user is prison instead of summary', async () => {
+      const mockOrder = getMockOrder({
+        interestedParties: createInterestedParties({ notifyingOrganisation: 'PRISON' }),
+      })
+      const req = createMockRequest({ order: mockOrder, flash: jest.fn() })
+      const res = createMockResponse()
+      const next = jest.fn()
+      req.flash = jest.fn().mockReturnValue([])
+
+      await orderController.summary(req, res, next)
+      expect(res.redirect).toHaveBeenCalledWith(`/order/${mockOrder.id}/interest-parties/sentencing-act-selection`)
     })
   })
 

--- a/server/controllers/orderController.ts
+++ b/server/controllers/orderController.ts
@@ -8,6 +8,7 @@ import isVariationType from '../utils/isVariationType'
 import TimelineModel from '../models/view-models/timelineModel'
 import { Order } from '../models/Order'
 import SectionService from '../services/sectionsService'
+import { isNullOrUndefined } from '../utils/utils'
 
 export default class OrderController {
   constructor(
@@ -63,9 +64,21 @@ export default class OrderController {
 
   summary: RequestHandler = async (req: Request, res: Response) => {
     const order = req.order!
-
     const versionId = req.params.versionId as string
     const createNewOrderVersionEnabled = FeatureFlags.getInstance().get('CREATE_NEW_ORDER_VERSION_ENABLED')
+
+    // guarding against forcing SA question on read only
+    const isEditable = order.status !== 'SUBMITTED' && order.status !== 'ERROR' && order.isOwner
+    if (
+      !versionId &&
+      isEditable &&
+      order.interestedParties?.notifyingOrganisation === 'PRISON' &&
+      isNullOrUndefined(order.isSentencingAct)
+    ) {
+      res.redirect(paths.INTEREST_PARTIES.SENTENCING_ACT_SELECTION.replace(':orderId', order.id))
+      return
+    }
+
     const error = req.flash('submissionError')
 
     const [sections, completedOrderVersions] = await Promise.all([

--- a/server/i18n/en/pages/setSentencingAct.ts
+++ b/server/i18n/en/pages/setSentencingAct.ts
@@ -5,7 +5,7 @@ const setSentencingActSelectionPageContent: SetSentencingActPageContent = {
   legend: '',
   questions: {
     isSentencingAct: {
-      text: 'Is the device wearer being released on or after 2 September 2026?',
+      text: 'Is the device wearer being released on or after 1 October 2026?',
     },
   },
   section: '',

--- a/server/routes/baseControllers/yes-no-question-page/controller.ts
+++ b/server/routes/baseControllers/yes-no-question-page/controller.ts
@@ -12,7 +12,7 @@ export default abstract class YesNoQuestionPageController {
     question: string,
     pageTitle: string,
     value: string | undefined = undefined,
-    hideBack: boolean = false
+    hideBack: boolean = false,
   ) {
     const errors = req.flash('validationErrors') as unknown as ValidationResult
     res.render('pages/shared-pages/yes-no-question-page', constructModel(value, errors, question, pageTitle, hideBack))

--- a/server/routes/baseControllers/yes-no-question-page/controller.ts
+++ b/server/routes/baseControllers/yes-no-question-page/controller.ts
@@ -13,9 +13,13 @@ export default abstract class YesNoQuestionPageController {
     pageTitle: string,
     value: string | undefined = undefined,
     hideBack: boolean = false,
+    hideCancelButton: boolean = false,
   ) {
     const errors = req.flash('validationErrors') as unknown as ValidationResult
-    res.render('pages/shared-pages/yes-no-question-page', constructModel(value, errors, question, pageTitle, hideBack))
+    res.render('pages/shared-pages/yes-no-question-page', {
+      ...constructModel(value, errors, question, pageTitle, hideBack),
+      hideCancelButton,
+    })
   }
 
   protected tryGetValidFormData(

--- a/server/routes/baseControllers/yes-no-question-page/controller.ts
+++ b/server/routes/baseControllers/yes-no-question-page/controller.ts
@@ -12,9 +12,10 @@ export default abstract class YesNoQuestionPageController {
     question: string,
     pageTitle: string,
     value: string | undefined = undefined,
+    hideBack: boolean = false
   ) {
     const errors = req.flash('validationErrors') as unknown as ValidationResult
-    res.render('pages/shared-pages/yes-no-question-page', constructModel(value, errors, question, pageTitle))
+    res.render('pages/shared-pages/yes-no-question-page', constructModel(value, errors, question, pageTitle, hideBack))
   }
 
   protected tryGetValidFormData(

--- a/server/routes/baseControllers/yes-no-question-page/viewModel.ts
+++ b/server/routes/baseControllers/yes-no-question-page/viewModel.ts
@@ -7,6 +7,7 @@ import { YesNoQuestionFormData } from './formModel'
 export type YesNoQuestionPageViewModel = ViewModel<YesNoQuestionFormData> & {
   question: string
   questionTitle: string
+  hideBack: boolean
 }
 
 const constructModel = (
@@ -14,14 +15,16 @@ const constructModel = (
   errors: ValidationResult,
   question: string,
   questionTitle: string,
+  hideBack: boolean = false
 ): YesNoQuestionPageViewModel => {
   const model: YesNoQuestionPageViewModel = {
     answer: { value: data || '' },
     errorSummary: null,
     question,
     questionTitle,
+    hideBack
   }
-
+  
   if (errors && errors.length) {
     model.answer!.error = getError(errors, 'answer')
     model.errorSummary = createGovukErrorSummary(errors)

--- a/server/routes/baseControllers/yes-no-question-page/viewModel.ts
+++ b/server/routes/baseControllers/yes-no-question-page/viewModel.ts
@@ -15,16 +15,16 @@ const constructModel = (
   errors: ValidationResult,
   question: string,
   questionTitle: string,
-  hideBack: boolean = false
+  hideBack: boolean = false,
 ): YesNoQuestionPageViewModel => {
   const model: YesNoQuestionPageViewModel = {
     answer: { value: data || '' },
     errorSummary: null,
     question,
     questionTitle,
-    hideBack
+    hideBack,
   }
-  
+
   if (errors && errors.length) {
     model.answer!.error = getError(errors, 'answer')
     model.errorSummary = createGovukErrorSummary(errors)

--- a/server/routes/sentencing-act-selection/controller.ts
+++ b/server/routes/sentencing-act-selection/controller.ts
@@ -29,7 +29,7 @@ export default class SentencingActSelection extends YesNoQuestionPageController 
       res.locals.content!.pages.setSentencingAct.questions.isSentencingAct.text,
       res.locals.content!.pages.setSentencingAct.title,
       value,
-      hideBack
+      hideBack,
     )
   }
 

--- a/server/routes/sentencing-act-selection/controller.ts
+++ b/server/routes/sentencing-act-selection/controller.ts
@@ -12,6 +12,8 @@ export default class SentencingActSelection extends YesNoQuestionPageController 
   }
 
   view: RequestHandler = async (req: Request, res: Response) => {
+    // Hiding the back button on this page as a temp fix against disrupting order flow
+    const hideBack = true
     const current = req.order!.isSentencingAct
     let value
     if (isNullOrUndefined(value)) {
@@ -27,6 +29,7 @@ export default class SentencingActSelection extends YesNoQuestionPageController 
       res.locals.content!.pages.setSentencingAct.questions.isSentencingAct.text,
       res.locals.content!.pages.setSentencingAct.title,
       value,
+      hideBack
     )
   }
 

--- a/server/routes/sentencing-act-selection/controller.ts
+++ b/server/routes/sentencing-act-selection/controller.ts
@@ -13,7 +13,7 @@ export default class SentencingActSelection extends YesNoQuestionPageController 
 
   view: RequestHandler = async (req: Request, res: Response) => {
     // Hiding the back button on this page as a temp fix against disrupting order flow
-    const hideBack = true
+    const hideBackAndCancel = true
     const current = req.order!.isSentencingAct
     let value
     if (isNullOrUndefined(value)) {
@@ -29,7 +29,8 @@ export default class SentencingActSelection extends YesNoQuestionPageController 
       res.locals.content!.pages.setSentencingAct.questions.isSentencingAct.text,
       res.locals.content!.pages.setSentencingAct.title,
       value,
-      hideBack,
+      hideBackAndCancel,
+      hideBackAndCancel,
     )
   }
 

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -690,6 +690,7 @@ describe('TaskListService', () => {
         contactDetails: createContactDetails(),
         installationAndRisk: createInstallationAndRisk(),
         interestedParties: createInterestedParties({ notifyingOrganisation: 'PRISON' }),
+        isSentencingAct: true,
         enforcementZoneConditions: [createEnforcementZoneCondition()],
         addresses: [
           createAddress({ addressType: 'PRIMARY' }),
@@ -788,6 +789,7 @@ describe('TaskListService', () => {
           placeName: 'primary',
           appointmentDate: 'date',
         },
+        isSentencingAct: true,
         additionalDocuments: [createAttatchment(), createAttatchment({ fileType: AttachmentType.PHOTO_ID })],
         orderParameters: { havePhoto: true },
       })
@@ -1155,6 +1157,7 @@ describe('TaskListService', () => {
       it('should navigate to CYA when notifying and responsible organisations are to check', async () => {
         const order = getMockOrder({
           interestedParties: createInterestedParties({ responsibleOfficerFirstName: 'mockUser' }),
+          isSentencingAct: true,
         })
         const taskListService = new TaskListService(mockOrderChecklistService)
 
@@ -1177,6 +1180,7 @@ describe('TaskListService', () => {
           interestedParties: createInterestedParties({
             responsibleOfficerFirstName: 'mockUser',
           }),
+          isSentencingAct: false,
         })
         mockOrderChecklistService.getChecklist.mockResolvedValueOnce({
           ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS: true,
@@ -1394,6 +1398,43 @@ describe('TaskListService', () => {
       expect(riskInformationSection?.completed).toBe(true)
 
       jest.restoreAllMocks()
+    })
+
+    it('should not route to the sentencing act page if a prison user has already answered', async () => {
+      const order = getMockOrder({
+        interestedParties: createInterestedParties({
+          responsibleOfficerFirstName: 'mockUser',
+          notifyingOrganisation: 'PRISON',
+        }),
+        isSentencingAct: true,
+      })
+      const taskListService = new TaskListService(mockOrderChecklistService)
+      const sections = await taskListService.getSections(order)
+      const interestedParties = sections.find(
+        section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
+      )
+      expect(interestedParties!.path).not.toBe(
+        paths.INTEREST_PARTIES.SENTENCING_ACT_SELECTION.replace(':orderId', order.id),
+      )
+    })
+
+    it('should route to the sentencing act page if a prison user has not answered', async () => {
+      const order = getMockOrder({
+        interestedParties: createInterestedParties({
+          responsibleOfficerFirstName: 'mockUser',
+          notifyingOrganisation: 'PRISON',
+        }),
+        isSentencingAct: null,
+      })
+      const taskListService = new TaskListService(mockOrderChecklistService)
+      const sections = await taskListService.getSections(order)
+      const interestedParties = sections.find(
+        section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
+      )
+      expect(interestedParties?.completed).toBe(false)
+      expect(interestedParties!.path).toBe(
+        paths.INTEREST_PARTIES.SENTENCING_ACT_SELECTION.replace(':orderId', order.id),
+      )
     })
   })
   describe('getNextCheckYourAnswersPage', () => {

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -67,6 +67,7 @@ const PAGES = {
   installationAppointment: 'INSTALLATION_APPOINTMENT',
   responsibleOrganisation: 'RESPONSIBLE_ORGANISATION',
   responsibleOfficer: 'RESPONSIBLE_OFFICER',
+  sentencingAct: 'SENTENCING_ACT',
 } as const
 
 type Page = (typeof PAGES)[keyof typeof PAGES]
@@ -156,6 +157,17 @@ export default class TaskListService {
       path: paths.VARIATION.VARIATION_DETAILS,
       state: isVariationType(order.type) ? STATES.required : STATES.disabled,
       completed: isNotNullOrUndefined(order.variationDetails),
+    })
+
+    tasks.push({
+      section: SECTIONS.interestedParties,
+      name: PAGES.sentencingAct,
+      path: paths.INTEREST_PARTIES.SENTENCING_ACT_SELECTION,
+      state:
+        order.interestedParties?.notifyingOrganisation === 'PRISON' && isNullOrUndefined(order.isSentencingAct)
+          ? STATES.required
+          : STATES.disabled,
+      completed: isNotNullOrUndefined(order.isSentencingAct),
     })
 
     if (

--- a/server/views/pages/order/monitoring-conditions/order-type-description/hdc-pause.njk
+++ b/server/views/pages/order/monitoring-conditions/order-type-description/hdc-pause.njk
@@ -5,7 +5,7 @@
 {% set singleQuestionPage = true %}
 {% block formInputs %}
 
-      <p class="govuk-body">Device wearers must not be released on HDC on or after 2 September 2026.</p>
+      <p class="govuk-body">Device wearers must not be released on HDC on or after 1 October 2026.</p>
 
       <p class="govuk-body">
         They can ony be re-released on HDC on after this date if all of the following conditions are met:
@@ -13,7 +13,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
           <li>They were on HDC in the community.</li>
-          <li>They were recalled during their HDC period on or after 2 September 2026.</li>
+          <li>They were recalled during their HDC period on or after 1 October 2026.</li>
           <li>The recall was under Section 255(1)(b) (inability to monitor).</li>
           <li>They are being re-released following the recall.</li>
           <li>They meet HDC policy, eligibility criteria, and pass the risk assessment.</li>

--- a/server/views/pages/shared-pages/yes-no-question-page.njk
+++ b/server/views/pages/shared-pages/yes-no-question-page.njk
@@ -6,10 +6,12 @@
 {% set questions = content.pages.isAddressChange.questions %}
 {% set questionName = questionTitle%}
 {% block beforeContent %}
+  {% if not hideBack %}
     {{ govukBackLink({
-    text: "Back",
-    href: "/order/" + order.id + "/edit"
-  }) }}
+      text: "Back",
+      href: "/order/" + order.id + "/edit"
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% set isOrderEditable = true %}

--- a/server/views/partials/form-layout.njk
+++ b/server/views/partials/form-layout.njk
@@ -111,13 +111,14 @@
                 name: "action",
                 value: "continue"
             }) }}
-
+            {% if not hideCancelButton %}
             {{ govukButton({
                 text: "Save as draft" if not backButtonText else backButtonText,
                 classes: "govuk-button--secondary",
                 name: "action",
                 value: "back"
             }) }}
+            {% endif %}
           {% else %}
             <a id="backToSummary" class="govuk-link" href="{{ orderSummaryUri }}">
                 Return back to form section menu


### PR DESCRIPTION
### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-5005

[Why are we making this change?]

1. On submitting an answer in the ISR flow (Is the device wearer being released on or after 2 September 2026?), it is not possible to go back and change the answer, however, that may have been intentional (check).

Spoke with @Lisa.Rae2 , as its a temp page at the start of a new order flow, user can just create a fresh order, or create a variation of an order - variation of order re-asks the question
Opting to remove the back button on this page to not redirect to an non existent order


Updated sentencing act date

### Changes proposed in this pull request

[What has been changed?]
