### PR TITLE
ELM-5006: Rebrand 'pilot' as 'pathfinder or programme'

### DIFF
--- a/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/check-your-answers.cy.ts
@@ -97,7 +97,7 @@ context('Check your answers', () => {
 
       page.monitoringConditionsSection.shouldExist()
       page.monitoringConditionsSection.shouldHaveItem(
-        'What pilot project is the device wearer part of?',
+        'What pathfinder or programme is the device wearer part of?',
         'GPS acquisitive crime (EMAC)',
       )
       page.installationAddressSection().shouldExist()
@@ -1095,7 +1095,7 @@ context('Check your answers', () => {
 
       page.monitoringConditionsSection.shouldExist()
       page.monitoringConditionsSection.shouldHaveItem(
-        'What pilot project is the device wearer part of?',
+        'What pathfinder or programme is the device wearer part of?',
         'GPS acquisitive crime (EMAC)',
       )
     })

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/hard-stop/HardStopPage.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/hard-stop/HardStopPage.ts
@@ -4,7 +4,7 @@ import paths from '../../../../../../server/constants/paths'
 export default class HardStopPage extends AppFormPage {
   constructor() {
     super(
-      'Device wearer is not eligible for the acquisitive crime pilot',
+      'Device wearer is not eligible for the acquisitive crime pathfinder or programme',
       paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.HARD_STOP,
     )
   }

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/hard-stop/hard-stop.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/hard-stop/hard-stop.cy.ts
@@ -34,9 +34,9 @@ context('hard stop page', () => {
     page.form.continueButton.click()
 
     Page.verifyOnPage(HardStopPage)
-    cy.contains('Device wearer is not eligible for the acquisitive crime pilot').should('exist')
+    cy.contains('Device wearer is not eligible for the acquisitive crime pathfinder or programme').should('exist')
     cy.contains(
-      'To be eligible for the acquisitive crime pilot the device wearer must have committed an acquisitive offence',
+      'To be eligible for the acquisitive crime pathfinder or programme the device wearer must have committed an acquisitive offence',
     ).should('exist')
   })
 
@@ -47,9 +47,9 @@ context('hard stop page', () => {
     page.form.continueButton.click()
 
     Page.verifyOnPage(HardStopPage)
-    cy.contains('Device wearer is not eligible for the acquisitive crime pilot').should('exist')
+    cy.contains('Device wearer is not eligible for the acquisitive crime pathfinder or programme').should('exist')
     cy.contains(
-      "To be eligible for the acquisitive crime pilot the device wearer's release address must be in an in-scope police force area.",
+      "To be eligible for the acquisitive crime pathfinder or programme the device wearer's release address must be in an in-scope police force area.",
     ).should('exist')
   })
 })

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/monitoring-type/draft.cy.ts
@@ -146,7 +146,7 @@ context('monitoring types', () => {
     monitoringTypePage.form.monitoringTypesField.shouldHaveDisabledOption('Mandatory attendance monitoring')
     monitoringTypePage.form.monitoringTypesField.shouldHaveEnabledOption('Alcohol')
     monitoringTypePage.form.message.contains(
-      "Some monitoring types can't be selected because the device wearer is not on a Home Detention Curfew (HDC) or part of any pilots.",
+      "Some monitoring types can't be selected because the device wearer is not on a Home Detention Curfew (HDC) or part of any pathfinders or programmes.",
     )
   })
 

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/offence-type/draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/offence-type/draft.cy.ts
@@ -51,7 +51,8 @@ context('offence type', () => {
     page.form.offenceTypeField.shouldHaveOption('They did not commit one of these offences')
 
     const hintText = 'The acquisitive crime offence needs to be their longest or equal longest sentence.'
-    const redundantCOMText = 'Any queries around pilot eligibility need to be raised with the appropriate COM.'
+    const redundantCOMText =
+      'Any queries around pathfinder or programme eligibility need to be raised with the appropriate COM.'
     page.form.offenceTypeField.element.contains(hintText)
     page.form.offenceTypeField.element.contains(redundantCOMText).should('not.exist')
   })

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/PilotComponent.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/PilotComponent.ts
@@ -4,7 +4,7 @@ import { PageElement } from '../../../../../pages/page'
 
 export default class PilotComponent extends SingleQuestionFormComponent {
   get pilotField(): FormRadiosComponent {
-    const label = 'What pilot project is the device wearer part of?'
+    const label = 'What pathfinder or programme is the device wearer part of?'
     return new FormRadiosComponent(this.form, label, [])
   }
 

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/PilotPage.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/PilotPage.ts
@@ -6,6 +6,9 @@ export default class PilotPage extends AppFormPage {
   public form = new PilotComponent()
 
   constructor() {
-    super('What pilot project is the device wearer part of?', paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PILOT)
+    super(
+      'What pathfinder or programme is the device wearer part of?',
+      paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PATHFINDER_PROGRAMME,
+    )
   }
 }

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/draft.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/draft.cy.ts
@@ -86,7 +86,7 @@ context('pilot', () => {
     page.form.continueButton.should('exist')
   })
 
-  it('Should disable DAPOL option and display message stating why if probation region not in pilot', () => {
+  it('Should disable DAPOL option and display message stating why if probation region not in pathfinder or programme', () => {
     cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
     mockDefaultOrder.monitoringConditions.hdc = 'YES'
     stubGetOrder({
@@ -110,7 +110,7 @@ context('pilot', () => {
     )
 
     cy.get('.govuk-inset-text').contains(
-      'The device wearer is being managed by the Yorkshire and the Humber probation region. To be eligible for the DAPOL pilot they must be managed by an in-scope region. Any queries around pilot eligibility need to be raised with the appropriate COM.',
+      'The device wearer is being managed by the Yorkshire and the Humber probation region. To be eligible for the DAPOL pathfinder or programme they must be managed by an in-scope region. Any queries around pathfinder or programme eligibility need to be raised with the appropriate COM.',
     )
   })
 
@@ -184,7 +184,7 @@ context('pilot', () => {
     cy.get('input[type="radio"][value="LICENCE_VARIATION_PROJECT"]').should('be.disabled')
 
     cy.get('.govuk-inset-text').contains(
-      'The device wearer is being managed by the London probation region. To be eligible for the Licence Variation pilot they must be managed by an in-scope region.',
+      'The device wearer is being managed by the London probation region. To be eligible for the Licence Variation pathfinder or programme they must be managed by an in-scope region.',
     )
   })
 
@@ -221,9 +221,9 @@ context('pilot', () => {
 
     pilotPage.form.pilotField.shouldHaveOption('Domestic Abuse Perpetrator on Licence (DAPOL)')
     pilotPage.form.pilotField.shouldHaveOption('GPS acquisitive crime (EMAC)')
-    pilotPage.form.pilotField.shouldHaveOption('They are not part of any of these pilots')
+    pilotPage.form.pilotField.shouldHaveOption('They are not part of any of these pathfinders or programmes')
 
-    pilotPage.form.fillInWith('They are not part of any of these pilots')
+    pilotPage.form.fillInWith('They are not part of any of these pathfinders or programmes')
   })
 
   it('hdc no', () => {
@@ -236,12 +236,12 @@ context('pilot', () => {
 
     pilotPage.form.pilotField.shouldHaveOption('Domestic Abuse Perpetrator on Licence (DAPOL)')
     pilotPage.form.pilotField.shouldHaveOption('GPS acquisitive crime (EMAC)')
-    pilotPage.form.pilotField.shouldHaveOption('They are not part of any of these pilots')
+    pilotPage.form.pilotField.shouldHaveOption('They are not part of any of these pathfinders or programmes')
 
     const hintText =
-      'To be eligible for tagging the device wearer must either be part of a pilot or have Alcohol Monitoring on Licence (AML) as a licence condition.'
+      'To be eligible for tagging the device wearer must either be part of a pathfinder or programme or have Alcohol Monitoring on Licence (AML) as a licence condition.'
     pilotPage.form.pilotField.element.contains(hintText).should('be.hidden')
-    pilotPage.form.fillInWith('They are not part of any of these pilots')
+    pilotPage.form.fillInWith('They are not part of any of these pathfinders or programmes')
     pilotPage.form.pilotField.element.contains(hintText)
   })
 })

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/submission.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/submission.cy.ts
@@ -44,7 +44,7 @@ context('pilot', () => {
 
     page.form.fillInWith('Licence Variation Project')
     const hintText =
-      'The pilot is only for probation practitioners varying a licence in response to an escalation of risk or as an alternative to recall.'
+      'The pathfinder or programme is only for probation practitioners varying a licence in response to an escalation of risk or as an alternative to recall.'
     page.form.pilotField.element.contains(hintText)
     page.form.continueButton.click()
 

--- a/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/validation.cy.ts
+++ b/integration_tests/e2e/order/monitoring-conditions/order-type-description/pilot/validation.cy.ts
@@ -19,12 +19,14 @@ context('order type', () => {
     cy.signIn()
   })
 
-  it('Should show errors when I do not select pilot', () => {
+  it('Should show errors when I do not select pathfinder or programme', () => {
     const page = Page.visit(PilotPage, { orderId: mockOrderId })
 
     page.form.continueButton.click()
 
     page.errorSummary.shouldExist()
-    page.form.pilotField.validationMessage.contains('Select the type of pilot the device wearer is part of')
+    page.form.pilotField.validationMessage.contains(
+      'Select the type of pathfinder or programme the device wearer is part of',
+    )
   })
 })

--- a/integration_tests/e2e/screenshots.cy.ts
+++ b/integration_tests/e2e/screenshots.cy.ts
@@ -61,7 +61,7 @@ context('Screenshots', () => {
     cy.visit(paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.HDC.replace(':orderId', mockOrderId))
     cy.screenshot('HdcPage', { overwrite: true })
 
-    cy.visit(paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PILOT.replace(':orderId', mockOrderId))
+    cy.visit(paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PATHFINDER_PROGRAMME.replace(':orderId', mockOrderId))
     cy.screenshot('PilotPage', { overwrite: true })
 
     cy.visit(paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.OFFENCE_TYPE.replace(':orderId', mockOrderId))

--- a/integration_tests/scenarios/order/monitoring-conditions/order-type-description.cy.ts
+++ b/integration_tests/scenarios/order/monitoring-conditions/order-type-description.cy.ts
@@ -97,7 +97,7 @@ context('Order type descriptions', () => {
 
     verifyValueInCheckYourAnswerPage(
       page,
-      'What pilot project is the device wearer part of?',
+      'What pathfinder or programme is the device wearer part of?',
       monitoringOrderTypeDescription.pilot,
     )
 

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -107,6 +107,7 @@ const paths = {
       PRARR: '/order/:orderId/monitoring-conditions/order-type-description/prarr',
       POLICE_AREA: '/order/:orderId/monitoring-conditions/order-type-description/police-area',
       PILOT: '/order/:orderId/monitoring-conditions/order-type-description/pilot',
+      PATHFINDER_PROGRAMME: '/order/:orderId/monitoring-conditions/order-type-description/pathfinder-programme',
       DAPOL_MISSED_IN_ERROR: '/order/:orderId/monitoring-conditions/order-type-description/dapol-missed-in-error',
       MONITORING_TYPE: '/order/:orderId/monitoring-conditions/order-type-description/monitoring-type',
       TYPES_OF_MONITORING_NEEDED:

--- a/server/constants/validationErrors.ts
+++ b/server/constants/validationErrors.ts
@@ -279,8 +279,8 @@ const validationErrors: ValidationErrors = {
   monitoringConditions: {
     conditionTypeRequired: 'Select order type condition',
     monitoringTypeRequired: 'Select monitoring required',
-    orderTypeDescriptionRequired: 'Select the type of pilot the device wearer is part of',
-    pilotRequired: 'Select the type of pilot the device wearer is part of',
+    orderTypeDescriptionRequired: 'Select the type of pathfinder or programme the device wearer is part of',
+    pilotRequired: 'Select the type of pathfinder or programme the device wearer is part of',
     dapolMissedRequired: 'Select Yes if DAPOL was missed in error at the point of release',
     orderTypeRequired: 'Select the order type',
     sentenceTypeRequired: 'Select the type of sentence the device wearer has been given',

--- a/server/controllers/monitoringConditions/checkAnswersController.test.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.test.ts
@@ -446,7 +446,7 @@ describe('MonitoringConditionsCheckAnswersController', () => {
           },
           {
             key: {
-              text: 'What pilot project is the device wearer part of?',
+              text: 'What pathfinder or programme is the device wearer part of?',
             },
             value: {
               text: 'GPS acquisitive crime (EMAC)',
@@ -454,9 +454,12 @@ describe('MonitoringConditionsCheckAnswersController', () => {
             actions: {
               items: [
                 {
-                  href: paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PILOT.replace(':orderId', order.id),
+                  href: paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PATHFINDER_PROGRAMME.replace(
+                    ':orderId',
+                    order.id,
+                  ),
                   text: 'Change',
-                  visuallyHiddenText: 'what pilot project is the device wearer part of?',
+                  visuallyHiddenText: 'what pathfinder or programme is the device wearer part of?',
                 },
               ],
             },

--- a/server/i18n/en/pages/monitoringConditions.ts
+++ b/server/i18n/en/pages/monitoringConditions.ts
@@ -27,11 +27,11 @@ const monitoringConditionsPageContent: MonitoringConditionsPageContent = {
       text: 'What is the order type?',
     },
     orderTypeDescription: {
-      text: 'What pilot project is the device wearer part of?',
+      text: 'What pathfinder or programme is the device wearer part of?',
       hint: 'This is on Create and Vary a Licence (CVL) on the page you print the licence',
     },
     pilot: {
-      text: 'What pilot project is the device wearer part of?',
+      text: 'What pathfinder or programme is the device wearer part of?',
       hint: 'This is on Create and Vary a Licence (CVL) on the page you print the licence',
     },
     prarr: {

--- a/server/i18n/en/reference/ddv5/pilots.ts
+++ b/server/i18n/en/reference/ddv5/pilots.ts
@@ -10,7 +10,7 @@ const pilots: Pilots = {
   GPS_ACQUISITIVE_CRIME_PAROLE: 'GPS Acquisitive Crime',
   ACQUISITIVE_CRIME_PROJECT: 'Acquisitive Crime Project',
   LICENCE_VARIATION_PROJECT: 'Licence Variation Project',
-  UNKNOWN: 'They are not part of any of these pilots',
+  UNKNOWN: 'They are not part of any of these pathfinders or programmes',
 }
 
 export default pilots

--- a/server/i18n/en/reference/orderTypeDescriptions.ts
+++ b/server/i18n/en/reference/orderTypeDescriptions.ts
@@ -5,7 +5,7 @@ const orderTypeDescriptions: OrderTypeDescriptions = {
   DAPOL_HDC: 'Domestic Abuse Perpetrator on Licence Home Detention Curfew (DAPOL HDC)',
   GPS_ACQUISITIVE_CRIME_HDC: 'GPS Acquisitive Crime Home Detention Curfew',
   GPS_ACQUISITIVE_CRIME_PAROLE: 'GPS Acquisitive Crime',
-  UNKNOWN: 'They are not part of any of these pilots',
+  UNKNOWN: 'They are not part of any of these pathfinders or programmes',
 }
 
 export default orderTypeDescriptions

--- a/server/i18n/en/reference/pilots.ts
+++ b/server/i18n/en/reference/pilots.ts
@@ -10,7 +10,7 @@ const pilots: Pilots = {
   GPS_ACQUISITIVE_CRIME_PAROLE: 'GPS Acquisitive Crime',
   ACQUISITIVE_CRIME_PROJECT: 'Acquisitive Crime Project',
   LICENCE_VARIATION_PROJECT: 'Licence Variation Project',
-  UNKNOWN: 'They are not part of any of these pilots',
+  UNKNOWN: 'They are not part of any of these pathfinders or programmes',
 }
 
 export default pilots

--- a/server/models/view-models/monitoringConditionsCheckAnswers.ts
+++ b/server/models/view-models/monitoringConditionsCheckAnswers.ts
@@ -86,7 +86,7 @@ const createMonitoringOrderTypeDescriptionAnswers = (order: Order, content: I18n
 
   if (data.pilot !== undefined && data.pilot !== null && data.pilot !== 'DOMESTIC_ABUSE_PROTECTION_ORDER') {
     let text = lookup(content.reference.pilots, data.pilot)
-    const pilotPath = paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PILOT
+    const pilotPath = paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PATHFINDER_PROGRAMME
     if (data.pilot === 'GPS_ACQUISITIVE_CRIME_HOME_DETENTION_CURFEW' || data.pilot === 'GPS_ACQUISITIVE_CRIME_PAROLE') {
       text = 'GPS acquisitive crime (EMAC)'
     }

--- a/server/routes/monitoring-conditions/hard-stop/viewModel.ts
+++ b/server/routes/monitoring-conditions/hard-stop/viewModel.ts
@@ -10,10 +10,10 @@ export type HardStopModel = {
 
 const getHardStopText = (data: MonitoringConditions) => {
   if (data.offenceType === 'They did not commit one of these offences') {
-    return 'To be eligible for the acquisitive crime pilot the device wearer must have committed an acquisitive offence.'
+    return 'To be eligible for the acquisitive crime pathfinder or programme the device wearer must have committed an acquisitive offence.'
   }
   if (data.policeArea === 'DIFFERENT_POLICE_AREA') {
-    return "To be eligible for the acquisitive crime pilot the device wearer's release address must be in an in-scope police force area."
+    return "To be eligible for the acquisitive crime pathfinder or programme the device wearer's release address must be in an in-scope police force area."
   }
   return ''
 }

--- a/server/routes/monitoring-conditions/hdc/controller.ts
+++ b/server/routes/monitoring-conditions/hdc/controller.ts
@@ -33,7 +33,9 @@ export default class HdcController {
       res.redirect(paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.HDC.replace(':orderId', order.id))
     } else {
       await this.montoringConditionsStoreService.updateField(order, 'hdc', formData.hdc)
-      res.redirect(paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PILOT.replace(':orderId', order.id))
+      res.redirect(
+        paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PATHFINDER_PROGRAMME.replace(':orderId', order.id),
+      )
     }
   }
 }

--- a/server/routes/monitoring-conditions/monitoring-type/viewModel.ts
+++ b/server/routes/monitoring-conditions/monitoring-type/viewModel.ts
@@ -76,7 +76,7 @@ const getEnabled = (order: Order): { options: (keyof MonitoringTypes)[]; message
       return {
         options: ['alcohol'],
         message:
-          "Some monitoring types can't be selected because the device wearer is not on a Home Detention Curfew (HDC) or part of any pilots.",
+          "Some monitoring types can't be selected because the device wearer is not on a Home Detention Curfew (HDC) or part of any pathfinders or programmes.",
       }
     }
     if (order.monitoringConditions.pilot === 'GPS_ACQUISITIVE_CRIME_PAROLE') {

--- a/server/routes/monitoring-conditions/pilot/controller.test.ts
+++ b/server/routes/monitoring-conditions/pilot/controller.test.ts
@@ -106,21 +106,21 @@ describe('pilot controller', () => {
               text: 'Licence Variation Project',
               value: 'LICENCE_VARIATION_PROJECT',
               conditional: {
-                html: 'The pilot is only for probation practitioners varying a licence in response to an escalation of risk or as an alternative to recall.',
+                html: 'The pathfinder or programme is only for probation practitioners varying a licence in response to an escalation of risk or as an alternative to recall.',
               },
             },
             {
               divider: 'or',
             },
             {
-              text: 'They are not part of any of these pilots',
+              text: 'They are not part of any of these pathfinders or programmes',
               value: 'UNKNOWN',
             },
           ],
           dapolMessage:
-            'The device wearer is being managed by the Greater Manchester probation region. To be eligible for the DAPOL pilot they must be managed by an in-scope region. Any queries around pilot eligibility need to be raised with the appropriate COM.',
+            'The device wearer is being managed by the Greater Manchester probation region. To be eligible for the DAPOL pathfinder or programme they must be managed by an in-scope region. Any queries around pathfinder or programme eligibility need to be raised with the appropriate COM.',
           licenceMessage:
-            'The device wearer is being managed by the Greater Manchester probation region. To be eligible for the Licence Variation pilot they must be managed by an in-scope region.',
+            'The device wearer is being managed by the Greater Manchester probation region. To be eligible for the Licence Variation pathfinder or programme they must be managed by an in-scope region.',
         }),
       )
     })
@@ -150,24 +150,24 @@ describe('pilot controller', () => {
               text: 'Licence Variation Project',
               value: 'LICENCE_VARIATION_PROJECT',
               conditional: {
-                html: 'The pilot is only for probation practitioners varying a licence in response to an escalation of risk or as an alternative to recall.',
+                html: 'The pathfinder or programme is only for probation practitioners varying a licence in response to an escalation of risk or as an alternative to recall.',
               },
             },
             {
               divider: 'or',
             },
             {
-              text: 'They are not part of any of these pilots',
+              text: 'They are not part of any of these pathfinders or programmes',
               value: 'UNKNOWN',
               conditional: {
-                html: 'To be eligible for tagging the device wearer must either be part of a pilot or have Alcohol Monitoring on Licence (AML) as a licence condition.',
+                html: 'To be eligible for tagging the device wearer must either be part of a pathfinder or programme or have Alcohol Monitoring on Licence (AML) as a licence condition.',
               },
             },
           ],
           dapolMessage:
-            'The device wearer is being managed by the Greater Manchester probation region. To be eligible for the DAPOL pilot they must be managed by an in-scope region. Any queries around pilot eligibility need to be raised with the appropriate COM.',
+            'The device wearer is being managed by the Greater Manchester probation region. To be eligible for the DAPOL pathfinder or programme they must be managed by an in-scope region. Any queries around pathfinder or programme eligibility need to be raised with the appropriate COM.',
           licenceMessage:
-            'The device wearer is being managed by the Greater Manchester probation region. To be eligible for the Licence Variation pilot they must be managed by an in-scope region.',
+            'The device wearer is being managed by the Greater Manchester probation region. To be eligible for the Licence Variation pathfinder or programme they must be managed by an in-scope region.',
         }),
       )
     })
@@ -175,7 +175,7 @@ describe('pilot controller', () => {
     it('validation errors', async () => {
       req.flash = jest.fn().mockReturnValueOnce([
         {
-          error: 'Select the type of pilot the device wearer is part of',
+          error: 'Select the type of pathfinder or programme the device wearer is part of',
           field: 'pilot',
         },
       ])
@@ -185,9 +185,14 @@ describe('pilot controller', () => {
       expect(res.render).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          pilot: { value: '', error: { text: 'Select the type of pilot the device wearer is part of' } },
+          pilot: {
+            value: '',
+            error: { text: 'Select the type of pathfinder or programme the device wearer is part of' },
+          },
           errorSummary: {
-            errorList: [{ href: '#pilot', text: 'Select the type of pilot the device wearer is part of' }],
+            errorList: [
+              { href: '#pilot', text: 'Select the type of pathfinder or programme the device wearer is part of' },
+            ],
             titleText: 'There is a problem',
           },
         }),
@@ -203,11 +208,11 @@ describe('pilot controller', () => {
       await controller.update(req, res, next)
 
       expect(req.flash).toHaveBeenCalledWith('validationErrors', [
-        { error: 'Select the type of pilot the device wearer is part of', field: 'pilot' },
+        { error: 'Select the type of pathfinder or programme the device wearer is part of', field: 'pilot' },
       ])
 
       expect(res.redirect).toHaveBeenCalledWith(
-        paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PILOT.replace(':orderId', req.order!.id),
+        paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PATHFINDER_PROGRAMME.replace(':orderId', req.order!.id),
       )
     })
 

--- a/server/routes/monitoring-conditions/pilot/controller.ts
+++ b/server/routes/monitoring-conditions/pilot/controller.ts
@@ -27,7 +27,9 @@ export default class PilotController {
 
     if (formData.pilot === null || formData.pilot === undefined) {
       req.flash('validationErrors', [{ error: validationErrors.monitoringConditions.pilotRequired, field: 'pilot' }])
-      res.redirect(paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PILOT.replace(':orderId', order.id))
+      res.redirect(
+        paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.PATHFINDER_PROGRAMME.replace(':orderId', order.id),
+      )
       return
     }
 

--- a/server/routes/monitoring-conditions/pilot/viewModel.ts
+++ b/server/routes/monitoring-conditions/pilot/viewModel.ts
@@ -44,7 +44,7 @@ const getDapolMessage = (order: Order): string => {
     if (isDapolPilotProbationRegion) {
       return ''
     }
-    return `The device wearer is being managed by the ${probationRegions[order.interestedParties?.responsibleOrganisationRegion as keyof typeof probationRegions]} probation region. To be eligible for the DAPOL pilot they must be managed by an in-scope region. Any queries around pilot eligibility need to be raised with the appropriate COM.`
+    return `The device wearer is being managed by the ${probationRegions[order.interestedParties?.responsibleOrganisationRegion as keyof typeof probationRegions]} probation region. To be eligible for the DAPOL pathfinder or programme they must be managed by an in-scope region. Any queries around pathfinder or programme eligibility need to be raised with the appropriate COM.`
   }
   return ''
 }
@@ -73,7 +73,7 @@ const getLicenceMessage = (order: Order): string => {
     if (isLicencePilotProbationRegion) {
       return ''
     }
-    return `The device wearer is being managed by the ${probationRegions[order.interestedParties?.responsibleOrganisationRegion as keyof typeof probationRegions]} probation region. To be eligible for the Licence Variation pilot they must be managed by an in-scope region.`
+    return `The device wearer is being managed by the ${probationRegions[order.interestedParties?.responsibleOrganisationRegion as keyof typeof probationRegions]} probation region. To be eligible for the Licence Variation pathfinder or programme they must be managed by an in-scope region.`
   }
   return ''
 }
@@ -119,10 +119,10 @@ const getItems = (
       { text: 'GPS acquisitive crime (EMAC)', value: 'GPS_ACQUISITIVE_CRIME_PAROLE' },
       { divider: 'or' },
       {
-        text: 'They are not part of any of these pilots',
+        text: 'They are not part of any of these pathfinders or programmes',
         value: 'UNKNOWN',
         conditional: {
-          html: 'To be eligible for tagging the device wearer must either be part of a pilot or have Alcohol Monitoring on Licence (AML) as a licence condition.',
+          html: 'To be eligible for tagging the device wearer must either be part of a pathfinder or programme or have Alcohol Monitoring on Licence (AML) as a licence condition.',
         },
       },
     ]
@@ -136,7 +136,7 @@ const getItems = (
       { text: 'GPS acquisitive crime (EMAC)', value: 'GPS_ACQUISITIVE_CRIME_HOME_DETENTION_CURFEW' },
       { divider: 'or' },
       {
-        text: 'They are not part of any of these pilots',
+        text: 'They are not part of any of these pathfinders or programmes',
         value: 'UNKNOWN',
       },
     ]
@@ -147,7 +147,7 @@ const getItems = (
       text: 'Licence Variation Project',
       value: 'LICENCE_VARIATION_PROJECT',
       conditional: {
-        html: 'The pilot is only for probation practitioners varying a licence in response to an escalation of risk or as an alternative to recall.',
+        html: 'The pathfinder or programme is only for probation practitioners varying a licence in response to an escalation of risk or as an alternative to recall.',
       },
       disabled: !isLicencePilotProbationRegion,
     })

--- a/server/routes/monitoring-conditions/router.ts
+++ b/server/routes/monitoring-conditions/router.ts
@@ -66,6 +66,9 @@ const createOrderTypeDescriptionRouter = (
   router.get('/pilot', asyncMiddleware(pilotController.view))
   router.post('/pilot', asyncMiddleware(pilotController.update))
 
+  router.get('/pathfinder-programme', asyncMiddleware(pilotController.view))
+  router.post('/pathfinder-programme', asyncMiddleware(pilotController.update))
+
   router.get('/dapol-missed-in-error', asyncMiddleware(dapolMissedInErrorController.view))
   router.post('/dapol-missed-in-error', asyncMiddleware(dapolMissedInErrorController.update))
 

--- a/server/routes/monitoring-conditions/router.ts
+++ b/server/routes/monitoring-conditions/router.ts
@@ -63,6 +63,7 @@ const createOrderTypeDescriptionRouter = (
   router.get('/hdc', asyncMiddleware(hdcController.view))
   router.post('/hdc', asyncMiddleware(hdcController.update))
 
+  // pilot to be phased out, replacement is pathfinder-programme
   router.get('/pilot', asyncMiddleware(pilotController.view))
   router.post('/pilot', asyncMiddleware(pilotController.update))
 

--- a/server/views/pages/order/monitoring-conditions/order-type-description/hard-stop.njk
+++ b/server/views/pages/order/monitoring-conditions/order-type-description/hard-stop.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% set section = "Electronic monitoring required" %}
-{% set heading = "Device wearer is not eligible for the acquisitive crime pilot" %}
+{% set heading = "Device wearer is not eligible for the acquisitive crime pathfinder or programme" %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/server/views/pages/order/monitoring-conditions/order-type-description/pilot.njk
+++ b/server/views/pages/order/monitoring-conditions/order-type-description/pilot.njk
@@ -5,7 +5,7 @@
 {% set section = "Electronic monitoring required" %}
 {% set singleQuestionPage = true %}
 {% set questions = content.pages.monitoringConditions.questions %}
-{% set questionName = "Pilot"%}
+{% set questionName = "Pathfinder or programme"%}
 {% block formInputs %}
     {% set hint %}
         {% if dapolMessage %}


### PR DESCRIPTION
### Context

Ticket: [https://dsdmoj.atlassian.net/browse/ELM-5006](https://dsdmoj.atlassian.net/browse/ELM-5006)

DAPOL and EMAC will no longer be pilots so the term used for them should be changed. The change is for the pilots page and acquisitive crime instances. The change will not apply to install at source, which remains a pilot.

### Changes proposed in this pull request

Change:

pilot - pathfinder or programme
pilots - pathfinders or programmes

<img width="785" height="622" alt="image" src="https://github.com/user-attachments/assets/80149568-8c98-4ff8-a0c9-2f0b8e5f13c8" />