### PR TITLE
ELM-5021: Add device wearer search results flow

### DIFF
--- a/integration_tests/e2e/order/about-the-device-wearer/device-wearer-search-results.page.draft.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/device-wearer-search-results.page.draft.cy.ts
@@ -1,0 +1,72 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import DeviceWearerSearchResultsPage from '../../../pages/order/about-the-device-wearer/device-wearer-search-results'
+
+const mockOrderId = uuidv4()
+
+const searchedIdentifier = 'A1234BC'
+
+context('About the device wearer', () => {
+  context('Device wearer search results', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+    })
+
+    it('should display matched device wearer details', () => {
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+      })
+      cy.task('stubCemoRequest', {
+        httpStatus: 200,
+        method: 'GET',
+        subPath: `orders/${mockOrderId}/device-wearer/search-results`,
+        response: {
+          fullName: 'Ermintrude Jones',
+          dateOfBirth: '1974-01-19T00:00:00Z',
+        },
+      })
+
+      cy.signIn()
+
+      const page = Page.visit(DeviceWearerSearchResultsPage, { orderId: mockOrderId }, { searchedIdentifier })
+
+      page.form.useThisDeviceWearerButton.should('be.enabled')
+      page.form.saveAsDraftButton.should('exist')
+      page.form.searchAgainLink.should('exist')
+      page.form.enterDetailsManuallyLink.should('exist')
+      cy.contains('1 device wearer found for A1234BC.')
+      cy.contains('Ermintrude Jones')
+      cy.contains('Date of birth - 19 January 1974')
+      page.checkIsAccessible()
+    })
+
+    it('should display no results content with disabled use button', () => {
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+      })
+      cy.task('stubCemoRequest', {
+        httpStatus: 200,
+        method: 'GET',
+        subPath: `orders/${mockOrderId}/device-wearer/search-results`,
+        response: {
+          fullName: null,
+          dateOfBirth: null,
+        },
+      })
+
+      cy.signIn()
+
+      const page = Page.visit(DeviceWearerSearchResultsPage, { orderId: mockOrderId }, { searchedIdentifier })
+
+      page.form.useThisDeviceWearerButton.should('not.exist')
+      page.form.saveAsDraftButton.should('not.exist')
+      cy.contains('We could not find a device wearer that matches A1234BC.')
+      page.checkIsAccessible()
+    })
+  })
+})

--- a/integration_tests/e2e/order/about-the-device-wearer/device-wearer-search-results.submission.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/device-wearer-search-results.submission.cy.ts
@@ -1,0 +1,74 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import DeviceWearerSearchResultsPage from '../../../pages/order/about-the-device-wearer/device-wearer-search-results'
+import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
+import AboutDeviceWearerPage from '../../../pages/order/about-the-device-wearer/device-wearer'
+import OrderSummaryPage from '../../../pages/order/summary'
+
+const mockOrderId = uuidv4()
+const searchedIdentifier = 'A1234BC'
+
+context('About the device wearer', () => {
+  context('Device wearer search results', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+      })
+      cy.task('stubCemoRequest', {
+        httpStatus: 200,
+        method: 'GET',
+        subPath: `orders/${mockOrderId}/device-wearer/search-results`,
+        response: {
+          fullName: 'Ermintrude Jones',
+          dateOfBirth: '1974-01-19T00:00:00Z',
+        },
+      })
+      cy.task('stubCemoRequest', {
+        httpStatus: 200,
+        method: 'POST',
+        subPath: `orders/${mockOrderId}/device-wearer/search-results/confirm`,
+        response: {},
+      })
+      cy.signIn()
+    })
+
+    it('should continue to personal details when using matched device wearer', () => {
+      const page = Page.visit(DeviceWearerSearchResultsPage, { orderId: mockOrderId }, { searchedIdentifier })
+      page.form.useThisDeviceWearerButton.click()
+
+      cy.task('stubCemoVerifyRequestReceived', {
+        uri: `/orders/${mockOrderId}/device-wearer/search-results/confirm`,
+        body: {
+          searchedIdentifier,
+        },
+      }).should('be.true')
+
+      Page.verifyOnPage(AboutDeviceWearerPage, { orderId: mockOrderId })
+    })
+
+    it('should return to identity numbers when searching again', () => {
+      const page = Page.visit(DeviceWearerSearchResultsPage, { orderId: mockOrderId }, { searchedIdentifier })
+      page.form.searchAgainLink.click()
+
+      Page.verifyOnPage(IdentityNumbersPage, { orderId: mockOrderId })
+    })
+
+    it('should continue to manual personal details when entering details manually', () => {
+      const page = Page.visit(DeviceWearerSearchResultsPage, { orderId: mockOrderId }, { searchedIdentifier })
+      page.form.enterDetailsManuallyLink.click()
+
+      Page.verifyOnPage(AboutDeviceWearerPage, { orderId: mockOrderId })
+    })
+
+    it('should return to summary when saving as draft', () => {
+      const page = Page.visit(DeviceWearerSearchResultsPage, { orderId: mockOrderId }, { searchedIdentifier })
+      page.form.saveAsDraftButton.click()
+
+      Page.verifyOnPage(OrderSummaryPage)
+    })
+  })
+})

--- a/integration_tests/e2e/order/about-the-device-wearer/device-wearer-search-results.validation.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/device-wearer-search-results.validation.cy.ts
@@ -1,0 +1,39 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../../pages/page'
+import DeviceWearerSearchResultsPage from '../../../pages/order/about-the-device-wearer/device-wearer-search-results'
+
+const mockOrderId = uuidv4()
+const searchedIdentifier = 'A1234BC'
+
+context('About the device wearer', () => {
+  context('Device wearer search results', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { name: 'john smith', roles: ['ROLE_EM_CEMO__CREATE_ORDER'] })
+      cy.task('stubCemoGetOrder', {
+        httpStatus: 200,
+        id: mockOrderId,
+        status: 'IN_PROGRESS',
+      })
+      cy.task('stubCemoRequest', {
+        httpStatus: 200,
+        method: 'GET',
+        subPath: `orders/${mockOrderId}/device-wearer/search-results`,
+        response: {
+          fullName: null,
+          dateOfBirth: null,
+        },
+      })
+
+      cy.signIn()
+    })
+
+    it("should not show 'Use this device wearer' or 'Save as draft' when no match is found", () => {
+      const page = Page.visit(DeviceWearerSearchResultsPage, { orderId: mockOrderId }, { searchedIdentifier })
+
+      page.form.useThisDeviceWearerButton.should('not.exist')
+      page.form.saveAsDraftButton.should('not.exist')
+      page.errorSummary.shouldNotExist()
+    })
+  })
+})

--- a/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.submission.cy.ts
+++ b/integration_tests/e2e/order/about-the-device-wearer/identity-numbers.submission.cy.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import Page from '../../../pages/page'
 import OrderSummaryPage from '../../../pages/order/summary'
 import IdentityNumbersPage from '../../../pages/order/about-the-device-wearer/identity-numbers'
-import AboutDeviceWearerPage from '../../../pages/order/about-the-device-wearer/device-wearer'
+import DeviceWearerSearchResultsPage from '../../../pages/order/about-the-device-wearer/device-wearer-search-results'
 
 const mockOrderId = uuidv4()
 const apiPath = '/device-wearer/identity-numbers'
@@ -37,6 +37,15 @@ context('About the device wearer', () => {
             disabilities: null,
             noFixedAbode: false,
             interpreterRequired: null,
+          },
+        })
+        cy.task('stubCemoRequest', {
+          httpStatus: 200,
+          method: 'GET',
+          subPath: `orders/${mockOrderId}/device-wearer/search-results`,
+          response: {
+            fullName: 'Ermintrude Jones',
+            dateOfBirth: '1974-01-19T00:00:00Z',
           },
         })
 
@@ -80,7 +89,7 @@ context('About the device wearer', () => {
         }).should('be.true')
       })
 
-      it('should continue to personal details page', () => {
+      it('should continue to device wearer search results page', () => {
         const page = Page.visit(IdentityNumbersPage, { orderId: mockOrderId })
 
         const validFormData = {
@@ -95,7 +104,7 @@ context('About the device wearer', () => {
         page.form.fillInWith(validFormData)
         page.form.saveAndContinueButton.click()
 
-        Page.verifyOnPage(AboutDeviceWearerPage, 'About the device wearer')
+        Page.verifyOnPage(DeviceWearerSearchResultsPage, { orderId: mockOrderId }, { searchedIdentifier: 'pnc' })
       })
 
       it('should return to the summary page', () => {

--- a/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerSearchResultsForm.ts
+++ b/integration_tests/pages/components/forms/about-the-device-wearer/deviceWearerSearchResultsForm.ts
@@ -1,0 +1,20 @@
+import FormComponent from '../../formComponent'
+import { PageElement } from '../../../page'
+
+export default class DeviceWearerSearchResultsFormComponent extends FormComponent {
+  get useThisDeviceWearerButton(): PageElement {
+    return this.form.contains('Use this device wearer')
+  }
+
+  get saveAsDraftButton(): PageElement {
+    return this.form.contains('Save as draft')
+  }
+
+  get searchAgainLink(): PageElement {
+    return this.form.contains('a', 'Search again')
+  }
+
+  get enterDetailsManuallyLink(): PageElement {
+    return this.form.contains('a', 'Enter details manually')
+  }
+}

--- a/integration_tests/pages/order/about-the-device-wearer/device-wearer-search-results.ts
+++ b/integration_tests/pages/order/about-the-device-wearer/device-wearer-search-results.ts
@@ -1,0 +1,15 @@
+import AppFormPage from '../../appFormPage'
+import paths from '../../../../server/constants/paths'
+import DeviceWearerSearchResultsFormComponent from '../../components/forms/about-the-device-wearer/deviceWearerSearchResultsForm'
+
+export default class DeviceWearerSearchResultsPage extends AppFormPage {
+  form = new DeviceWearerSearchResultsFormComponent()
+
+  constructor() {
+    super(
+      /Confirm the device wearer's details|No results found/,
+      paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER_SEARCH_RESULTS,
+      'About the device wearer',
+    )
+  }
+}

--- a/integration_tests/pages/order/summary.ts
+++ b/integration_tests/pages/order/summary.ts
@@ -3,6 +3,7 @@ import Page, { PageElement } from '../page'
 import paths from '../../../server/constants/paths'
 import Task from '../components/task'
 import AboutDeviceWearerPage from './about-the-device-wearer/device-wearer'
+import DeviceWearerSearchResultsPage from './about-the-device-wearer/device-wearer-search-results'
 import ResponsibleAdultDetailsPage from './about-the-device-wearer/responsible-adult-details'
 import ContactDetailsPage from './contact-information/contact-details'
 import NoFixedAbodePage from './contact-information/no-fixed-abode'
@@ -607,9 +608,20 @@ export default class OrderTasksPage extends AppPage {
     newDeviceWearerFlow = false,
   }): void {
     if (!newDeviceWearerFlow) {
+      const searchedIdentifier =
+        deviceWearerDetails.pncId ||
+        deviceWearerDetails.nomisId ||
+        deviceWearerDetails.prisonNumber ||
+        deviceWearerDetails.deliusId ||
+        deviceWearerDetails.complianceAndEnforcementPersonReference ||
+        deviceWearerDetails.courtCaseReferenceNumber
+
       const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
       identityNumbersPage.form.fillInWith(deviceWearerDetails)
       identityNumbersPage.form.saveAndContinueButton.click()
+
+      const deviceWearerSearchResultsPage = Page.verifyOnPage(DeviceWearerSearchResultsPage, {}, { searchedIdentifier })
+      deviceWearerSearchResultsPage.form.enterDetailsManuallyLink.click()
 
       const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
       aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)

--- a/integration_tests/scenarios/all-condition-default-start-and-end-times.cy.ts
+++ b/integration_tests/scenarios/all-condition-default-start-and-end-times.cy.ts
@@ -230,7 +230,6 @@ context('The kitchen sink', () => {
           cepr: deviceWearerDetails.complianceAndEnforcementPersonReference,
           interpreter_required: 'false',
           language: '',
-          new_order_case_id: '',
         },
       }).should('be.true')
 

--- a/integration_tests/utils/scenario-flows/about-the-device-wearer-flow.cy.ts
+++ b/integration_tests/utils/scenario-flows/about-the-device-wearer-flow.cy.ts
@@ -1,5 +1,6 @@
 import DeviceWearerCheckYourAnswersPage from '../../pages/order/about-the-device-wearer/check-your-answers'
 import AboutDeviceWearerPage from '../../pages/order/about-the-device-wearer/device-wearer'
+import DeviceWearerSearchResultsPage from '../../pages/order/about-the-device-wearer/device-wearer-search-results'
 import IdentityNumbersPage from '../../pages/order/about-the-device-wearer/identity-numbers'
 import ResponsibleAdultDetailsPage from '../../pages/order/about-the-device-wearer/responsible-adult-details'
 import ContactDetailsPage from '../../pages/order/contact-information/contact-details'
@@ -15,9 +16,20 @@ export default function fillInAboutTheDeviceWearer({
   tertiaryAddressDetails = undefined,
   section = 'About the device wearer',
 }): void {
+  const searchedIdentifier =
+    deviceWearerDetails.pncId ||
+    deviceWearerDetails.nomisId ||
+    deviceWearerDetails.prisonNumber ||
+    deviceWearerDetails.deliusId ||
+    deviceWearerDetails.complianceAndEnforcementPersonReference ||
+    deviceWearerDetails.courtCaseReferenceNumber
+
   const identityNumbersPage = Page.verifyOnPage(IdentityNumbersPage)
   identityNumbersPage.form.fillInWith(deviceWearerDetails)
   identityNumbersPage.form.saveAndContinueButton.click()
+
+  const deviceWearerSearchResultsPage = Page.verifyOnPage(DeviceWearerSearchResultsPage, {}, { searchedIdentifier })
+  deviceWearerSearchResultsPage.form.enterDetailsManuallyLink.click()
 
   const aboutDeviceWearerPage = Page.verifyOnPage(AboutDeviceWearerPage)
   aboutDeviceWearerPage.form.fillInWith(deviceWearerDetails)

--- a/server/constants/paths.ts
+++ b/server/constants/paths.ts
@@ -42,6 +42,7 @@ const paths = {
     CHECK_YOUR_ANSWERS: '/order/:orderId/about-the-device-wearer/check-your-answers',
     CHECK_YOUR_ANSWERS_VERSION: '/order/:orderId/version/:versionId/about-the-device-wearer/check-your-answers',
     DEVICE_WEARER: '/order/:orderId/about-the-device-wearer',
+    DEVICE_WEARER_SEARCH_RESULTS: '/order/:orderId/about-the-device-wearer/device-wearer-search-results',
     RESPONSIBLE_ADULT: '/order/:orderId/about-the-device-wearer/responsible-adult',
     IDENTITY_NUMBERS: '/order/:orderId/about-the-device-wearer/identity-numbers',
   },

--- a/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.test.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.test.ts
@@ -1,6 +1,4 @@
 import { createDeviceWearer, createResponsibleAdult, getMockOrder } from '../../../test/mocks/mockOrder'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
-import AuditService from '../../services/auditService'
 import DeviceWearerCheckAnswersController from './deviceWearerCheckAnswersController'
 import TaskListService from '../../services/taskListService'
 import paths from '../../constants/paths'
@@ -52,28 +50,18 @@ describe('DeviceWearerCheckAnswersController', () => {
     getNextPage: jest.fn(),
   } as unknown as jest.Mocked<TaskListService>
   let controller: DeviceWearerCheckAnswersController
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockedSectionService: jest.Mocked<SectionService>
   const mockOrderChecklistService = {
     updateChecklist: jest.fn(),
     getChecklist: jest.fn().mockResolvedValue(OrderChecklistModel.parse({})),
   } as unknown as jest.Mocked<OrderChecklistService>
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockedSectionService = {
       checkBlankVariationOrNewOrder: jest.fn().mockReturnValue(true),
       getSectionsForOrder: jest.fn(),
     } as unknown as jest.Mocked<SectionService>
 
     controller = new DeviceWearerCheckAnswersController(
-      mockAuditService,
       taskListService,
       mockOrderChecklistService,
       mockedSectionService,

--- a/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerCheckAnswersController.ts
@@ -1,6 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
 import { z } from 'zod'
-import { AuditService } from '../../services'
 import createViewModel from '../../models/view-models/deviceWearerCheckAnswers'
 import TaskListService from '../../services/taskListService'
 import OrderChecklistService from '../../services/orderChecklistService'
@@ -12,7 +11,6 @@ const CheckYourAnswersFormModel = z.object({
 
 export default class DeviceWearerCheckAnswersController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly taskListService: TaskListService,
     private readonly checklistService: OrderChecklistService,
     private readonly sectionService: SectionService,

--- a/server/controllers/about-the-device-wearer/deviceWearerController.test.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerController.test.ts
@@ -1,8 +1,6 @@
 import { getMockOrder } from '../../../test/mocks/mockOrder'
 import { createMockRequest, createMockResponse } from '../../../test/mocks/mockExpress'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
-import AuditService from '../../services/auditService'
 import DeviceWearerService from '../../services/deviceWearerService'
 import DeviceWearerController from './deviceWearerController'
 import TaskListService from '../../services/taskListService'
@@ -39,8 +37,6 @@ const mockOrder = getMockOrder({
 
 describe('DeviceWearerController', () => {
   let mockRestClient: jest.Mocked<RestClient>
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockDeviceWearerService: jest.Mocked<DeviceWearerService>
   let deviceWearerController: DeviceWearerController
   const taskListService = {
@@ -49,20 +45,13 @@ describe('DeviceWearerController', () => {
   } as unknown as jest.Mocked<TaskListService>
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockDeviceWearerService = new DeviceWearerService(mockRestClient) as jest.Mocked<DeviceWearerService>
-    deviceWearerController = new DeviceWearerController(mockAuditService, mockDeviceWearerService, taskListService)
+    deviceWearerController = new DeviceWearerController(mockDeviceWearerService, taskListService)
 
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2020-01-01'))

--- a/server/controllers/about-the-device-wearer/deviceWearerController.test.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerController.test.ts
@@ -588,7 +588,7 @@ describe('DeviceWearerController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/identity-numbers`)
     })
 
-    it('should save valid data and redirect to the personal information page', async () => {
+    it('should save valid data and redirect to the device wearer search results page', async () => {
       // Given
       const order = getMockOrder()
       const req = createMockRequest({
@@ -624,10 +624,6 @@ describe('DeviceWearerController', () => {
         pncId: null,
       })
 
-      taskListService.getNextPage = jest
-        .fn()
-        .mockReturnValue(`/order/${order.id}/about-the-device-wearer/device-wearer`)
-
       // When
       await deviceWearerController.updateIdentityNumbers(req, res, next)
 
@@ -647,7 +643,9 @@ describe('DeviceWearerController', () => {
         }),
       )
 
-      expect(res.redirect).toHaveBeenCalledWith(`/order/${order.id}/about-the-device-wearer/device-wearer`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/order/${order.id}/about-the-device-wearer/device-wearer-search-results?searchedIdentifier=nomis`,
+      )
     })
 
     it('should save and redirect to the order summary page if the user chooses back', async () => {

--- a/server/controllers/about-the-device-wearer/deviceWearerController.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerController.ts
@@ -4,13 +4,11 @@ import { isValidationResult } from '../../models/Validation'
 import { DeviceWearerFormDataParser, IdentityNumbersFormDataModel } from '../../models/form-data/deviceWearer'
 import deviceWearerViewModel from '../../models/view-models/deviceWearer'
 import identityNumbersViewModel from '../../models/view-models/identityNumbers'
-import AuditService from '../../services/auditService'
 import DeviceWearerService from '../../services/deviceWearerService'
 import TaskListService from '../../services/taskListService'
 
 export default class DeviceWearerController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly deviceWearerService: DeviceWearerService,
     private readonly taskListService: TaskListService,
   ) {}

--- a/server/controllers/about-the-device-wearer/deviceWearerController.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerController.ts
@@ -1,7 +1,11 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
-import { DeviceWearerFormDataParser, IdentityNumbersFormDataModel } from '../../models/form-data/deviceWearer'
+import {
+  DeviceWearerFormDataParser,
+  IdentityNumbersFormData,
+  IdentityNumbersFormDataModel,
+} from '../../models/form-data/deviceWearer'
 import deviceWearerViewModel from '../../models/view-models/deviceWearer'
 import identityNumbersViewModel from '../../models/view-models/identityNumbers'
 import AuditService from '../../services/auditService'
@@ -83,14 +87,24 @@ export default class DeviceWearerController {
       req.flash('validationErrors', result)
       res.redirect(paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id))
     } else if (action === 'continue') {
-      res.redirect(
-        this.taskListService.getNextPage('IDENTITY_NUMBERS', {
-          ...order,
-          deviceWearer: result,
-        }),
-      )
+      const searchedIdentifier = this.getSearchedIdentifier(formData)
+      const searchResultsPath = paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER_SEARCH_RESULTS.replace(':orderId', order.id)
+      res.redirect(`${searchResultsPath}?searchedIdentifier=${encodeURIComponent(searchedIdentifier)}`)
     } else {
       res.redirect(paths.ORDER.SUMMARY.replace(':orderId', order.id))
     }
+  }
+
+  private getSearchedIdentifier = (identityNumbers: IdentityNumbersFormData): string => {
+    return (
+      identityNumbers.pncId ||
+      identityNumbers.nomisId ||
+      identityNumbers.prisonNumber ||
+      identityNumbers.deliusId ||
+      identityNumbers.complianceAndEnforcementPersonReference ||
+      identityNumbers.courtCaseReferenceNumber ||
+      identityNumbers.homeOfficeReferenceNumber ||
+      ''
+    )
   }
 }

--- a/server/controllers/about-the-device-wearer/deviceWearerResponsibleAdultController.test.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerResponsibleAdultController.test.ts
@@ -1,6 +1,4 @@
-import AuditService from '../../services/auditService'
 import DeviceWearerResponsibleAdultService from '../../services/deviceWearerResponsibleAdultService'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import DeviceWearerResponsibleAdultController from './deviceWearerResponsibleAdultController'
 import RestClient from '../../data/restClient'
 import { createMockRequest, createMockResponse } from '../../../test/mocks/mockExpress'
@@ -25,8 +23,6 @@ const createMockOrder = (name: string) =>
 
 describe('DeviceWearerResponsibleAdultController', () => {
   let mockRestClient: jest.Mocked<RestClient>
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockDeviceWearerResponsibleAdultService: jest.Mocked<DeviceWearerResponsibleAdultService>
   let deviceWearerResponsibleAdultController: DeviceWearerResponsibleAdultController
   const taskListService = {
@@ -35,23 +31,15 @@ describe('DeviceWearerResponsibleAdultController', () => {
   } as unknown as jest.Mocked<TaskListService>
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockDeviceWearerResponsibleAdultService = new DeviceWearerResponsibleAdultService(
       mockRestClient,
     ) as jest.Mocked<DeviceWearerResponsibleAdultService>
     deviceWearerResponsibleAdultController = new DeviceWearerResponsibleAdultController(
-      mockAuditService,
       mockDeviceWearerResponsibleAdultService,
       taskListService,
     )

--- a/server/controllers/about-the-device-wearer/deviceWearerResponsibleAdultController.ts
+++ b/server/controllers/about-the-device-wearer/deviceWearerResponsibleAdultController.ts
@@ -1,5 +1,4 @@
 import { Request, RequestHandler, Response } from 'express'
-import { AuditService } from '../../services'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
 import DeviceWearerResponsibleAdultService from '../../services/deviceWearerResponsibleAdultService'
@@ -9,7 +8,6 @@ import responsibleAdultViewModel from '../../models/view-models/responsibleAdult
 
 export default class DeviceWearerResponsibleAdultController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly deviceWearerResponsibleAdultService: DeviceWearerResponsibleAdultService,
     private readonly taskListService: TaskListService,
   ) {}

--- a/server/controllers/attachments/attachmentController.test.ts
+++ b/server/controllers/attachments/attachmentController.test.ts
@@ -8,7 +8,6 @@ import AttachmentType from '../../models/AttachmentType'
 import { OrderStatusEnum } from '../../models/Order'
 import AttachmentService from '../../services/attachmentService'
 import AuditService from '../../services/auditService'
-import OrderService from '../../services/orderService'
 import AttachmentController from './attachmentController'
 import { createMockRequest } from '../../../test/mocks/mockExpress'
 import TaskListService from '../../services/taskListService'
@@ -26,7 +25,6 @@ const mockId = uuidv4()
 describe('AttachmentController', () => {
   let mockAuditClient: jest.Mocked<HmppsAuditClient>
   let mockAuditService: jest.Mocked<AuditService>
-  let mockOrderService: jest.Mocked<OrderService>
   let mockAttachmentService: jest.Mocked<AttachmentService>
   const taskListService = {
     getNextCheckYourAnswersPage: jest.fn(),
@@ -52,13 +50,11 @@ describe('AttachmentController', () => {
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockOrderService = new OrderService(mockRestClient) as jest.Mocked<OrderService>
     mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockAttachmentService = new AttachmentService(mockRestClient) as jest.Mocked<AttachmentService>
 
     controller = new AttachmentController(
       mockAuditService,
-      mockOrderService,
       mockAttachmentService,
       taskListService,
       mockOrderChecklistService,

--- a/server/controllers/attachments/attachmentController.ts
+++ b/server/controllers/attachments/attachmentController.ts
@@ -1,5 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
-import { AttachmentService, AuditService, OrderService } from '../../services'
+import { AttachmentService, AuditService } from '../../services'
 import AttachmentType from '../../models/AttachmentType'
 import paths from '../../constants/paths'
 import TaskListService, { PAGES, Page } from '../../services/taskListService'
@@ -10,7 +10,6 @@ import OrderChecklistService from '../../services/orderChecklistService'
 export default class AttachmentsController {
   constructor(
     private readonly auditService: AuditService,
-    private readonly orderService: OrderService,
     private readonly attachmentService: AttachmentService,
     private readonly taskListService: TaskListService,
     private readonly checklistService: OrderChecklistService,

--- a/server/controllers/contact-information/checkAnswersController.test.ts
+++ b/server/controllers/contact-information/checkAnswersController.test.ts
@@ -1,6 +1,4 @@
 import { createAddress, createDeviceWearer, getMockOrder } from '../../../test/mocks/mockOrder'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
-import AuditService from '../../services/auditService'
 import CheckAnswersController from './checkAnswersController'
 import TaskListService from '../../services/taskListService'
 import paths from '../../constants/paths'
@@ -23,8 +21,6 @@ describe('ContactDetailsCheckAnswersController', () => {
     getNextPage: jest.fn(),
   } as unknown as jest.Mocked<TaskListService>
   let controller: CheckAnswersController
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   const content = getContent(Locales.en, DataDictionaryVersions.DDV5)
   const { questions } = content.pages.interestedParties
   const mockOrderChecklistService = {
@@ -32,14 +28,7 @@ describe('ContactDetailsCheckAnswersController', () => {
     getChecklist: jest.fn().mockResolvedValue(OrderChecklistModel.parse({})),
   } as unknown as jest.Mocked<OrderChecklistService>
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
-    controller = new CheckAnswersController(mockAuditService, taskListService, mockOrderChecklistService)
+    controller = new CheckAnswersController(taskListService, mockOrderChecklistService)
   })
 
   afterEach(() => {

--- a/server/controllers/contact-information/checkAnswersController.ts
+++ b/server/controllers/contact-information/checkAnswersController.ts
@@ -1,6 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
 import { z } from 'zod'
-import { AuditService } from '../../services'
 import TaskListService from '../../services/taskListService'
 import createViewModel from '../../models/view-models/contactInformationCheckAnswers'
 import OrderChecklistService from '../../services/orderChecklistService'
@@ -11,7 +10,6 @@ const CheckYourAnswersFormModel = z.object({
 
 export default class CheckAnswersController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly taskListService: TaskListService,
     private readonly checklistService: OrderChecklistService,
   ) {}

--- a/server/controllers/contact-information/contactDetailsController.test.ts
+++ b/server/controllers/contact-information/contactDetailsController.test.ts
@@ -1,6 +1,4 @@
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
-import AuditService from '../../services/auditService'
 import ContactDetailsService from '../../services/contactDetailsService'
 import { createMockRequest, createMockResponse } from '../../../test/mocks/mockExpress'
 import { getMockOrder } from '../../../test/mocks/mockOrder'
@@ -15,8 +13,6 @@ jest.mock('../../data/restClient')
 
 describe('ContactDetailsController', () => {
   let mockRestClient: jest.Mocked<RestClient>
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockContactDetailsService: jest.Mocked<ContactDetailsService>
   let contactDetailsController: ContactDetailsController
   const taskListService = {
@@ -25,24 +21,13 @@ describe('ContactDetailsController', () => {
   } as unknown as jest.Mocked<TaskListService>
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockContactDetailsService = new ContactDetailsService(mockRestClient) as jest.Mocked<ContactDetailsService>
-    contactDetailsController = new ContactDetailsController(
-      mockAuditService,
-      mockContactDetailsService,
-      taskListService,
-    )
+    contactDetailsController = new ContactDetailsController(mockContactDetailsService, taskListService)
   })
 
   describe('get', () => {

--- a/server/controllers/contact-information/contactDetailsController.ts
+++ b/server/controllers/contact-information/contactDetailsController.ts
@@ -1,6 +1,6 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
-import { AuditService, ContactDetailsService } from '../../services'
+import { ContactDetailsService } from '../../services'
 import { isValidationResult } from '../../models/Validation'
 import contactDetailsViewModel from '../../models/view-models/contactDetails'
 import ContactDetailsFormDataModel from '../../models/form-data/contactDetails'
@@ -8,7 +8,6 @@ import TaskListService from '../../services/taskListService'
 
 export default class ContactDetailsController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly contactDetailsService: ContactDetailsService,
     private readonly taskListService: TaskListService,
   ) {}

--- a/server/controllers/contact-information/interestedPartiesController.test.ts
+++ b/server/controllers/contact-information/interestedPartiesController.test.ts
@@ -1,6 +1,4 @@
 import RestClient from '../../data/restClient'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
-import AuditService from '../../services/auditService'
 import TaskListService from '../../services/taskListService'
 import InterestedPartiesController from './interestedPartiesController'
 import InterestedPartiesService from '../../services/interestedPartiesService'
@@ -28,8 +26,6 @@ const createMockOrder = getMockOrder({
 
 describe('InterestedPartiesController', () => {
   let mockRestClient: jest.Mocked<RestClient>
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockInterestedPartiesService: jest.Mocked<InterestedPartiesService>
   let interestedPartiesController: InterestedPartiesController
   const taskListService = {
@@ -38,24 +34,13 @@ describe('InterestedPartiesController', () => {
   } as unknown as jest.Mocked<TaskListService>
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockInterestedPartiesService = new InterestedPartiesService(mockRestClient) as jest.Mocked<InterestedPartiesService>
-    interestedPartiesController = new InterestedPartiesController(
-      mockAuditService,
-      mockInterestedPartiesService,
-      taskListService,
-    )
+    interestedPartiesController = new InterestedPartiesController(mockInterestedPartiesService, taskListService)
 
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2020-01-01'))

--- a/server/controllers/contact-information/interestedPartiesController.ts
+++ b/server/controllers/contact-information/interestedPartiesController.ts
@@ -1,7 +1,6 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
-import { AuditService } from '../../services'
 import InterestedPartiesService from '../../services/interestedPartiesService'
 import TaskListService from '../../services/taskListService'
 import InterestedPartiesFormDataModel from '../../models/form-data/interestedParties'
@@ -9,7 +8,6 @@ import interestedPartiesViewModel from '../../models/view-models/interestedParti
 
 export default class InterestedPartiesController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly interestedPartiesService: InterestedPartiesService,
     private readonly taskListService: TaskListService,
   ) {}

--- a/server/controllers/contact-information/noFixedAbodeController.test.ts
+++ b/server/controllers/contact-information/noFixedAbodeController.test.ts
@@ -1,6 +1,4 @@
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
-import AuditService from '../../services/auditService'
 import DeviceWearerService from '../../services/deviceWearerService'
 import { createMockRequest, createMockResponse } from '../../../test/mocks/mockExpress'
 import { getMockOrder } from '../../../test/mocks/mockOrder'
@@ -39,8 +37,6 @@ const createMockOrder = (noFixedAbode: boolean | null) =>
 
 describe('NoFixedAbodeController', () => {
   let mockRestClient: jest.Mocked<RestClient>
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockDeviceWearerService: jest.Mocked<DeviceWearerService>
   let controller: NoFixedAbodeController
   const taskListService = {
@@ -49,20 +45,13 @@ describe('NoFixedAbodeController', () => {
   } as unknown as jest.Mocked<TaskListService>
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockDeviceWearerService = new DeviceWearerService(mockRestClient) as jest.Mocked<DeviceWearerService>
-    controller = new NoFixedAbodeController(mockAuditService, mockDeviceWearerService, taskListService)
+    controller = new NoFixedAbodeController(mockDeviceWearerService, taskListService)
   })
 
   describe('get', () => {

--- a/server/controllers/contact-information/noFixedAbodeController.ts
+++ b/server/controllers/contact-information/noFixedAbodeController.ts
@@ -1,6 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
-import { AuditService } from '../../services'
 import DeviceWearerService from '../../services/deviceWearerService'
 import { isValidationResult } from '../../models/Validation'
 import TaskListService from '../../services/taskListService'
@@ -9,7 +8,6 @@ import noFixedAbodeViewModel from '../../models/view-models/noFixedAbode'
 
 export default class NoFixedAbodeController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly deviceWearerService: DeviceWearerService,
     private readonly taskListService: TaskListService,
   ) {}

--- a/server/controllers/contact-information/probationDeliveryUnitController.ts
+++ b/server/controllers/contact-information/probationDeliveryUnitController.ts
@@ -1,7 +1,6 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
-import { AuditService } from '../../services'
 import ProbationDeliveryUnitFormDataModel from '../../models/form-data/probationDeliveryUnit'
 import probationDeliveryUnitViewModel from '../../models/view-models/probationDeliveryUnit'
 import TaskListService from '../../services/taskListService'
@@ -12,7 +11,6 @@ import ReferenceData from '../../types/i18n/reference/reference'
 
 export default class ProbationDeliveryUnitController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly probationDeliveryUnitService: ProbationDeliveryUnitService,
     private readonly taskListService: TaskListService,
   ) {}

--- a/server/controllers/installationAndRisk/installationAndRiskCheckAnswersController.test.ts
+++ b/server/controllers/installationAndRisk/installationAndRiskCheckAnswersController.test.ts
@@ -1,6 +1,4 @@
 import { getMockOrder } from '../../../test/mocks/mockOrder'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
-import AuditService from '../../services/auditService'
 import CheckAnswersController from './installationAndRiskCheckAnswersController'
 import TaskListService from '../../services/taskListService'
 import paths from '../../constants/paths'
@@ -25,8 +23,6 @@ describe('InstallationAndRiskCheckAnswersController', () => {
     getNextPage: jest.fn(),
   } as unknown as jest.Mocked<TaskListService>
   let controller: CheckAnswersController
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockedSectionService: jest.Mocked<SectionService>
   const { questions } = installationAndRiskPageContent
   const isMappaQuestions = isMappaPageContent.questions
@@ -36,22 +32,10 @@ describe('InstallationAndRiskCheckAnswersController', () => {
     getChecklist: jest.fn().mockResolvedValue(OrderChecklistModel.parse({})),
   } as unknown as jest.Mocked<OrderChecklistService>
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockedSectionService = {
       checkBlankVariationOrNewOrder: jest.fn().mockReturnValue(true),
     } as unknown as jest.Mocked<SectionService>
-    controller = new CheckAnswersController(
-      mockAuditService,
-      taskListService,
-      mockOrderChecklistService,
-      mockedSectionService,
-    )
+    controller = new CheckAnswersController(taskListService, mockOrderChecklistService, mockedSectionService)
   })
 
   it('should render the check answers page without any answers completed', async () => {

--- a/server/controllers/installationAndRisk/installationAndRiskCheckAnswersController.ts
+++ b/server/controllers/installationAndRisk/installationAndRiskCheckAnswersController.ts
@@ -1,6 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
 import { z } from 'zod'
-import { AuditService } from '../../services'
 import TaskListService from '../../services/taskListService'
 import paths from '../../constants/paths'
 import createViewModel from '../../models/view-models/riskInformationCheckAnswers'
@@ -13,7 +12,6 @@ const CheckYourAnswersFormModel = z.object({
 
 export default class CheckAnswersController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly taskListService: TaskListService,
     private readonly checklistService: OrderChecklistService,
     private readonly sectionService: SectionService,

--- a/server/controllers/installationAndRisk/installationAndRiskController.ts
+++ b/server/controllers/installationAndRisk/installationAndRiskController.ts
@@ -1,7 +1,6 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
-import { AuditService } from '../../services'
 import InstallationAndRiskService from '../../services/installationAndRiskService'
 import TaskListService from '../../services/taskListService'
 import InstallationAndRiskFormDataModel from '../../models/form-data/installationAndRisk'
@@ -9,7 +8,6 @@ import installationAndRiskViewModel from '../../models/view-models/installationA
 
 export default class InstallationAndRiskController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly installationAndRiskService: InstallationAndRiskService,
     private readonly taskListService: TaskListService,
   ) {}

--- a/server/controllers/monitoringConditions/CurfewReleaseDateController.test.ts
+++ b/server/controllers/monitoringConditions/CurfewReleaseDateController.test.ts
@@ -1,9 +1,7 @@
 import type { NextFunction, Request, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 import { createMonitoringConditions, getMockOrder } from '../../../test/mocks/mockOrder'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
-import AuditService from '../../services/auditService'
 import CurfewReleaseDateService from '../../services/curfewReleaseDateService'
 import CurfewReleaseDateController from './curfewReleaseDateController'
 import paths from '../../constants/paths'
@@ -16,8 +14,6 @@ jest.mock('../../data/restClient')
 const mockId = uuidv4()
 
 describe('CurfewReleaseDateController', () => {
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockCurfewReleaseDateService: jest.Mocked<CurfewReleaseDateService>
   let controller: CurfewReleaseDateController
   const taskListService = {
@@ -28,20 +24,13 @@ describe('CurfewReleaseDateController', () => {
   let next: NextFunction
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     const mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockCurfewReleaseDateService = new CurfewReleaseDateService(mockRestClient) as jest.Mocked<CurfewReleaseDateService>
-    controller = new CurfewReleaseDateController(mockAuditService, mockCurfewReleaseDateService, taskListService)
+    controller = new CurfewReleaseDateController(mockCurfewReleaseDateService)
 
     req = {
       // @ts-expect-error stubbing session

--- a/server/controllers/monitoringConditions/alcoholMonitoringController.test.ts
+++ b/server/controllers/monitoringConditions/alcoholMonitoringController.test.ts
@@ -1,11 +1,8 @@
-import AuditService from '../../services/auditService'
 import AlcoholMonitoringService from '../../services/alcoholMonitoringService'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import AlcoholMonitoringController from './alcoholMonitoringController'
 import RestClient from '../../data/restClient'
 import { createMockRequest, createMockResponse } from '../../../test/mocks/mockExpress'
 import { getMockOrder } from '../../../test/mocks/mockOrder'
-import TaskListService from '../../services/taskListService'
 
 jest.mock('../../services/auditService')
 jest.mock('../../services/orderService')
@@ -24,34 +21,17 @@ const createMockOrder = (startDate: string | null = null) =>
 
 describe('AlcoholMonitoringController', () => {
   let mockRestClient: jest.Mocked<RestClient>
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockAlcoholMonitoringService: jest.Mocked<AlcoholMonitoringService>
   let alcoholMonitoringController: AlcoholMonitoringController
-  const taskListService = {
-    getNextCheckYourAnswersPage: jest.fn(),
-    getNextPage: jest.fn(),
-  } as unknown as jest.Mocked<TaskListService>
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockAlcoholMonitoringService = new AlcoholMonitoringService(mockRestClient) as jest.Mocked<AlcoholMonitoringService>
-    alcoholMonitoringController = new AlcoholMonitoringController(
-      mockAuditService,
-      mockAlcoholMonitoringService,
-      taskListService,
-    )
+    alcoholMonitoringController = new AlcoholMonitoringController(mockAlcoholMonitoringService)
   })
 
   describe('view', () => {

--- a/server/controllers/monitoringConditions/alcoholMonitoringController.ts
+++ b/server/controllers/monitoringConditions/alcoholMonitoringController.ts
@@ -1,17 +1,12 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
-import { AlcoholMonitoringService, AuditService } from '../../services'
+import { AlcoholMonitoringService } from '../../services'
 import alcoholMonitoringViewModel from '../../models/view-models/alcoholMonitoring'
 import { AlcoholMonitoringFormDataModel } from '../../models/form-data/alcoholMonitoring'
-import TaskListService from '../../services/taskListService'
 
 export default class AlcoholMonitoringController {
-  constructor(
-    private readonly auditService: AuditService,
-    private readonly alcoholMonitoringService: AlcoholMonitoringService,
-    private readonly taskListService: TaskListService,
-  ) {}
+  constructor(private readonly alcoholMonitoringService: AlcoholMonitoringService) {}
 
   view: RequestHandler = async (req: Request, res: Response) => {
     const order = req.order!

--- a/server/controllers/monitoringConditions/attendanceMonitoringController.test.ts
+++ b/server/controllers/monitoringConditions/attendanceMonitoringController.test.ts
@@ -4,8 +4,6 @@ import AttendanceMonitoringController from './attendanceMonitoringController'
 import { createMockRequest, createMockResponse } from '../../../test/mocks/mockExpress'
 import RestClient from '../../data/restClient'
 import AttendanceMonitoringService from '../../services/attendanceMonitoringService'
-import TaskListService from '../../services/taskListService'
-import OrderChecklistService from '../../services/orderChecklistService'
 
 const mockConditionId = uuidv4()
 
@@ -19,10 +17,6 @@ describe('attendanceMonitoringController', () => {
   let mockRestClient: jest.Mocked<RestClient>
   let mockAttendanceMonitoringService: jest.Mocked<AttendanceMonitoringService>
   let attendanceMonitoringController: AttendanceMonitoringController
-  const mockOrderChecklistService = {
-    setSectionCheckStatus: jest.fn(),
-  } as unknown as jest.Mocked<OrderChecklistService>
-  const taskListService = new TaskListService(mockOrderChecklistService)
 
   beforeEach(() => {
     mockRestClient = new RestClient('cemoApi', {
@@ -35,10 +29,7 @@ describe('attendanceMonitoringController', () => {
       mockRestClient,
     ) as jest.Mocked<AttendanceMonitoringService>
 
-    attendanceMonitoringController = new AttendanceMonitoringController(
-      mockAttendanceMonitoringService,
-      taskListService,
-    )
+    attendanceMonitoringController = new AttendanceMonitoringController(mockAttendanceMonitoringService)
   })
 
   const validMock = [

--- a/server/controllers/monitoringConditions/attendanceMonitoringController.ts
+++ b/server/controllers/monitoringConditions/attendanceMonitoringController.ts
@@ -2,15 +2,11 @@ import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
 import AttendanceMonitoringService from '../../services/attendanceMonitoringService'
-import TaskListService from '../../services/taskListService'
 import { AttendanceMonitoringFormDataModel } from '../../models/form-data/attendanceMonitoring'
 import attendanceMonitoringViewModel from '../../models/view-models/attendanceMonitoring'
 
 export default class AttendanceMonitoringController {
-  constructor(
-    private readonly attendanceMonitoringService: AttendanceMonitoringService,
-    private readonly taskListService: TaskListService,
-  ) {}
+  constructor(private readonly attendanceMonitoringService: AttendanceMonitoringService) {}
 
   new: RequestHandler = async (req: Request, res: Response) => {
     const errors = req.flash('validationErrors')

--- a/server/controllers/monitoringConditions/checkAnswersController.test.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.test.ts
@@ -7,9 +7,7 @@ import {
   getMockOrder,
 } from '../../../test/mocks/mockOrder'
 import paths from '../../constants/paths'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import EnforcementZoneTypes from '../../models/EnforcementZoneTypes'
-import AuditService from '../../services/auditService'
 import TaskListService from '../../services/taskListService'
 import CheckAnswersController from './checkAnswersController'
 import OrderChecklistModel from '../../models/OrderChecklist'
@@ -25,8 +23,6 @@ describe('MonitoringConditionsCheckAnswersController', () => {
     getNextCheckYourAnswersPage: jest.fn(),
     getNextPage: jest.fn(),
   } as unknown as jest.Mocked<TaskListService>
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockedSectionService: jest.Mocked<SectionService>
   let controller: CheckAnswersController
   const mockOrderChecklistService = {
@@ -34,22 +30,10 @@ describe('MonitoringConditionsCheckAnswersController', () => {
     getChecklist: jest.fn().mockResolvedValue(OrderChecklistModel.parse({})),
   } as unknown as jest.Mocked<OrderChecklistService>
   beforeEach(async () => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockedSectionService = {
       checkBlankVariationOrNewOrder: jest.fn().mockReturnValue(true),
     } as unknown as jest.Mocked<SectionService>
-    controller = new CheckAnswersController(
-      mockAuditService,
-      taskListService,
-      mockOrderChecklistService,
-      mockedSectionService,
-    )
+    controller = new CheckAnswersController(taskListService, mockOrderChecklistService, mockedSectionService)
   })
 
   afterEach(() => {

--- a/server/controllers/monitoringConditions/checkAnswersController.ts
+++ b/server/controllers/monitoringConditions/checkAnswersController.ts
@@ -1,6 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
 import { z } from 'zod'
-import { AuditService } from '../../services'
 import TaskListService from '../../services/taskListService'
 import createViewModel from '../../models/view-models/monitoringConditionsCheckAnswers'
 import OrderChecklistService from '../../services/orderChecklistService'
@@ -12,7 +11,6 @@ const CheckYourAnswersFormModel = z.object({
 
 export default class CheckAnswersController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly taskListService: TaskListService,
     private readonly checklistService: OrderChecklistService,
     private readonly sectionService: SectionService,

--- a/server/controllers/monitoringConditions/curfewAdditionalDetailsController.test.ts
+++ b/server/controllers/monitoringConditions/curfewAdditionalDetailsController.test.ts
@@ -1,10 +1,7 @@
 import type { NextFunction, Request, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 import { createMonitoringConditions, getMockOrder } from '../../../test/mocks/mockOrder'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
-import AuditService from '../../services/auditService'
-import TaskListService from '../../services/taskListService'
 import CurfewAdditionalDetailsService from '../../services/curfewAdditionalDetailsService'
 import CurfewAdditionalDetailsController from './curfewAdditionalDetailsController'
 import { ValidationError } from '../../models/Validation'
@@ -16,42 +13,24 @@ jest.mock('../../data/restClient')
 const mockId = uuidv4()
 
 describe('CurfewConditionsController', () => {
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockCurfewAdditionalDetailsService: jest.Mocked<CurfewAdditionalDetailsService>
   let controller: CurfewAdditionalDetailsController
-  const taskListService = {
-    getNextCheckYourAnswersPage: jest.fn(),
-    getNextPage: jest.fn(),
-  } as unknown as jest.Mocked<TaskListService>
   let req: Request
   let res: Response
   let next: NextFunction
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
-
     const mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
 
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockCurfewAdditionalDetailsService = new CurfewAdditionalDetailsService(
       mockRestClient,
     ) as jest.Mocked<CurfewAdditionalDetailsService>
 
-    controller = new CurfewAdditionalDetailsController(
-      mockAuditService,
-      mockCurfewAdditionalDetailsService,
-      taskListService,
-    )
+    controller = new CurfewAdditionalDetailsController(mockCurfewAdditionalDetailsService)
 
     req = {
       // @ts-expect-error stubbing session

--- a/server/controllers/monitoringConditions/curfewAdditionalDetailsController.ts
+++ b/server/controllers/monitoringConditions/curfewAdditionalDetailsController.ts
@@ -1,18 +1,12 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
-import { AuditService } from '../../services'
 import CurfewAdditionalDetailsService from '../../services/curfewAdditionalDetailsService'
 import CurfewAdditionalDetailsViewModel from '../../models/view-models/curfewAdditionalDetails'
-import TaskListService from '../../services/taskListService'
 import { CurfewAdditionalDetailsFormDataModel } from '../../models/form-data/curfewAdditionalDetails'
 
 export default class CurfewAdditionalDetailsController {
-  constructor(
-    private readonly auditService: AuditService,
-    private readonly curfewAdditionalDetailsService: CurfewAdditionalDetailsService,
-    private readonly taskListService: TaskListService,
-  ) {}
+  constructor(private readonly curfewAdditionalDetailsService: CurfewAdditionalDetailsService) {}
 
   view: RequestHandler = async (req: Request, res: Response) => {
     const { curfewConditions: model } = req.order!

--- a/server/controllers/monitoringConditions/curfewConditionsController.test.ts
+++ b/server/controllers/monitoringConditions/curfewConditionsController.test.ts
@@ -1,13 +1,10 @@
 import type { NextFunction, Request, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 import { createMonitoringConditions, getMockOrder } from '../../../test/mocks/mockOrder'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
-import AuditService from '../../services/auditService'
 import CurfewConditionsService from '../../services/curfewConditionsService'
 import CurfewConditionsController from './curfewConditionsController'
 import paths from '../../constants/paths'
-import TaskListService from '../../services/taskListService'
 
 jest.mock('../../services/auditService')
 jest.mock('../../data/hmppsAuditClient')
@@ -16,32 +13,20 @@ jest.mock('../../data/restClient')
 const mockId = uuidv4()
 
 describe('CurfewConditionsController', () => {
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockCurfewReleaseDateService: jest.Mocked<CurfewConditionsService>
   let controller: CurfewConditionsController
-  const taskListService = {
-    getSections: jest.fn().mockReturnValue(Promise.resolve([])),
-  } as unknown as jest.Mocked<TaskListService>
   let req: Request
   let res: Response
   let next: NextFunction
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     const mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockCurfewReleaseDateService = new CurfewConditionsService(mockRestClient) as jest.Mocked<CurfewConditionsService>
-    controller = new CurfewConditionsController(mockAuditService, mockCurfewReleaseDateService, taskListService)
+    controller = new CurfewConditionsController(mockCurfewReleaseDateService)
 
     req = {
       // @ts-expect-error stubbing session

--- a/server/controllers/monitoringConditions/curfewConditionsController.ts
+++ b/server/controllers/monitoringConditions/curfewConditionsController.ts
@@ -1,18 +1,12 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
-import { AuditService } from '../../services'
 import CurfewConditionsService from '../../services/curfewConditionsService'
 import { CurfewConditionsFormDataModel } from '../../models/form-data/curfewConditions'
 import CurfewConditionsViewModel from '../../models/view-models/curfewConditions'
-import TaskListService from '../../services/taskListService'
 
 export default class CurfewConditionsController {
-  constructor(
-    private readonly auditService: AuditService,
-    private readonly curfewConditionsService: CurfewConditionsService,
-    private readonly taskListService: TaskListService,
-  ) {}
+  constructor(private readonly curfewConditionsService: CurfewConditionsService) {}
 
   view: RequestHandler = async (req: Request, res: Response) => {
     const errors = req.flash('validationErrors')

--- a/server/controllers/monitoringConditions/curfewReleaseDateController.ts
+++ b/server/controllers/monitoringConditions/curfewReleaseDateController.ts
@@ -1,18 +1,12 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
-import { AuditService } from '../../services'
 import CurfewReleaseDateService from '../../services/curfewReleaseDateService'
 import CurfewReleaseDateFormDataModel from '../../models/form-data/curfewReleaseDate'
 import curfewReleaseDateViewModel from '../../models/view-models/curfewReleaseDate'
-import TaskListService from '../../services/taskListService'
 
 export default class CurfewReleaseDateController {
-  constructor(
-    private readonly auditService: AuditService,
-    private readonly curfewReleaseDateService: CurfewReleaseDateService,
-    private readonly taskListService: TaskListService,
-  ) {}
+  constructor(private readonly curfewReleaseDateService: CurfewReleaseDateService) {}
 
   view: RequestHandler = async (req: Request, res: Response) => {
     const { curfewReleaseDateConditions: model, addresses } = req.order!

--- a/server/controllers/monitoringConditions/curfewTimetableController.test.ts
+++ b/server/controllers/monitoringConditions/curfewTimetableController.test.ts
@@ -1,13 +1,10 @@
 import type { NextFunction, Request, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 import { getMockOrder } from '../../../test/mocks/mockOrder'
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
-import AuditService from '../../services/auditService'
 import CurfewTimetableService from '../../services/curfewTimetableService'
 import CurfewTimetableController from './curfewTimetableController'
 import paths from '../../constants/paths'
-import TaskListService from '../../services/taskListService'
 
 jest.mock('../../services/auditService')
 jest.mock('../../data/hmppsAuditClient')
@@ -16,34 +13,22 @@ jest.mock('../../data/restClient')
 const mockId = uuidv4()
 
 describe('CurfewTimetableController', () => {
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockCurfewTimetableService: jest.Mocked<CurfewTimetableService>
   let controller: CurfewTimetableController
 
-  const taskListService = {
-    getSections: jest.fn().mockReturnValue(Promise.resolve([])),
-  } as unknown as jest.Mocked<TaskListService>
   let req: Request
   let res: Response
   let next: NextFunction
   const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     const mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockCurfewTimetableService = new CurfewTimetableService(mockRestClient) as jest.Mocked<CurfewTimetableService>
-    controller = new CurfewTimetableController(mockAuditService, mockCurfewTimetableService, taskListService)
+    controller = new CurfewTimetableController(mockCurfewTimetableService)
 
     req = {
       // @ts-expect-error stubbing session

--- a/server/controllers/monitoringConditions/curfewTimetableController.ts
+++ b/server/controllers/monitoringConditions/curfewTimetableController.ts
@@ -2,8 +2,7 @@ import { Request, RequestHandler, Response } from 'express'
 
 import paths from '../../constants/paths'
 import { isValidationListResult } from '../../models/Validation'
-import { AuditService, CurfewTimetableService } from '../../services'
-import TaskListService from '../../services/taskListService'
+import { CurfewTimetableService } from '../../services'
 import { CurfewTimetable } from '../../models/CurfewTimetable'
 import CurfewTimetableFormDataModel, { CurfewTimetableDataModel } from '../../models/form-data/curfewTimetable'
 import curfewTimetableViewModel from '../../models/view-models/curfewTimetable'
@@ -42,11 +41,7 @@ const parseAction = (action?: string): [verb: string | undefined, options: { day
 }
 
 export default class CurfewTimetableController {
-  constructor(
-    private readonly auditService: AuditService,
-    private readonly curfewTimetableService: CurfewTimetableService,
-    private readonly taskListService: TaskListService,
-  ) {}
+  constructor(private readonly curfewTimetableService: CurfewTimetableService) {}
 
   private addTimeToCurfewDay(
     curfewTimetable: CurfewTimetableDataModel,

--- a/server/controllers/monitoringConditions/trailMonitoringController.ts
+++ b/server/controllers/monitoringConditions/trailMonitoringController.ts
@@ -1,18 +1,12 @@
 import { Request, RequestHandler, Response } from 'express'
 import paths from '../../constants/paths'
 import { isValidationResult } from '../../models/Validation'
-import { AuditService } from '../../services'
 import TrailMonitoringService from '../../services/trailMonitoringService'
 import trailMonitoringViewModel from '../../models/view-models/trailMonitoring'
 import { TrailMonitoringFormDataModel } from '../../models/form-data/trailMonitoring'
-import TaskListService from '../../services/taskListService'
 
 export default class TrailMonitoringController {
-  constructor(
-    private readonly auditService: AuditService,
-    private readonly trailMonitoringService: TrailMonitoringService,
-    private readonly taskListService: TaskListService,
-  ) {}
+  constructor(private readonly trailMonitoringService: TrailMonitoringService) {}
 
   view: RequestHandler = async (req: Request, res: Response) => {
     const { monitoringConditionsTrail, interestedParties } = req.order!

--- a/server/controllers/orderController.test.ts
+++ b/server/controllers/orderController.test.ts
@@ -1,11 +1,9 @@
 import { randomUUID } from 'crypto'
 import { createInterestedParties, getMockOrder } from '../../test/mocks/mockOrder'
 import { createMockRequest, createMockResponse } from '../../test/mocks/mockExpress'
-import HmppsAuditClient from '../data/hmppsAuditClient'
 import RestClient from '../data/restClient'
 import { OrderStatusEnum } from '../models/Order'
 import ConfirmationPageViewModel from '../models/view-models/confirmationPage'
-import AuditService from '../services/auditService'
 import OrderService from '../services/orderService'
 import OrderController from './orderController'
 import SectionService from '../services/sectionsService'
@@ -29,31 +27,22 @@ afterEach(() => {
 
 describe('OrderController', () => {
   let mockRestClient: jest.Mocked<RestClient>
-  let mockAuditClient: jest.Mocked<HmppsAuditClient>
-  let mockAuditService: jest.Mocked<AuditService>
   let mockOrderService: jest.Mocked<OrderService>
   let orderController: OrderController
   let sectionService: jest.Mocked<SectionService>
 
   beforeEach(() => {
-    mockAuditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     mockRestClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    mockAuditService = new AuditService(mockAuditClient) as jest.Mocked<AuditService>
     mockOrderService = new OrderService(mockRestClient) as jest.Mocked<OrderService>
     mockOrderService.getVersionInformations = jest.fn().mockResolvedValue([])
     sectionService = {
       getSectionsForOrder: jest.fn().mockReturnValue(Promise.resolve([])),
     } as unknown as jest.Mocked<SectionService>
-    orderController = new OrderController(mockAuditService, mockOrderService, sectionService)
+    orderController = new OrderController(mockOrderService, sectionService)
   })
 
   describe('summary', () => {

--- a/server/controllers/orderController.ts
+++ b/server/controllers/orderController.ts
@@ -1,5 +1,5 @@
 import { Request, RequestHandler, Response } from 'express'
-import { AuditService, OrderService } from '../services'
+import { OrderService } from '../services'
 import paths from '../constants/paths'
 import { CreateOrderFormDataParser } from '../models/form-data/order'
 import ConfirmationPageViewModel from '../models/view-models/confirmationPage'
@@ -12,7 +12,6 @@ import { isNullOrUndefined } from '../utils/utils'
 
 export default class OrderController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly orderService: OrderService,
     private readonly sectionService: SectionService,
   ) {}

--- a/server/controllers/variation/variationDetailsController.test.ts
+++ b/server/controllers/variation/variationDetailsController.test.ts
@@ -1,6 +1,4 @@
-import HmppsAuditClient from '../../data/hmppsAuditClient'
 import RestClient from '../../data/restClient'
-import AuditService from '../../services/auditService'
 import TaskListService from '../../services/taskListService'
 import VariationService from '../../services/variationService'
 import VariationDetailsController from './variationDetailsController'
@@ -17,8 +15,6 @@ jest.mock('../../data/restClient')
 
 describe('VariationDetailsController', () => {
   let taskListService: TaskListService
-  let auditClient: jest.Mocked<HmppsAuditClient>
-  let auditService: jest.Mocked<AuditService>
   let restClient: jest.Mocked<RestClient>
   let variationService: VariationService
   let controller: VariationDetailsController
@@ -27,28 +23,16 @@ describe('VariationDetailsController', () => {
     updateChecklist: jest.fn(),
   } as unknown as jest.Mocked<OrderChecklistService>
   beforeEach(() => {
-    auditClient = new HmppsAuditClient({
-      queueUrl: '',
-      enabled: true,
-      region: '',
-      serviceName: '',
-    }) as jest.Mocked<HmppsAuditClient>
     restClient = new RestClient('cemoApi', {
       url: '',
       timeout: { response: 0, deadline: 0 },
       agent: { timeout: 0 },
     }) as jest.Mocked<RestClient>
-    auditService = new AuditService(auditClient) as jest.Mocked<AuditService>
     variationService = new VariationService(restClient)
 
-    taskListService = new TaskListService(mockOrderChecklistService)
+    taskListService = new TaskListService()
 
-    controller = new VariationDetailsController(
-      auditService,
-      variationService,
-      taskListService,
-      mockOrderChecklistService,
-    )
+    controller = new VariationDetailsController(variationService, taskListService, mockOrderChecklistService)
   })
 
   describe('view', () => {

--- a/server/controllers/variation/variationDetailsController.ts
+++ b/server/controllers/variation/variationDetailsController.ts
@@ -1,5 +1,4 @@
 import { RequestHandler } from 'express'
-import AuditService from '../../services/auditService'
 import TaskListService from '../../services/taskListService'
 import VariationService from '../../services/variationService'
 import { VariationDetailsFormDataParser } from '../../models/form-data/variationDetails'
@@ -10,7 +9,6 @@ import OrderChecklistService from '../../services/orderChecklistService'
 
 export default class VariationDetailsController {
   constructor(
-    private readonly auditService: AuditService,
     private readonly variationDetailsService: VariationService,
     private readonly taskListService: TaskListService,
     private readonly checklistService: OrderChecklistService,

--- a/server/i18n/en/index.ts
+++ b/server/i18n/en/index.ts
@@ -9,6 +9,7 @@ import curfewReleaseDatePageContent from './pages/curfewReleaseDate'
 import curfewTimeTablePageContent from './pages/curfewTimetable'
 import deleteConfirmPageContent from './pages/deleteConfirm'
 import deviceWearerPageContent from './pages/deviceWearer'
+import deviceWearerSearchResultsPageContent from './pages/deviceWearerSearchResults'
 import editConfirmPageContent from './pages/editConfirm'
 import exclusionZonePageContent from './pages/exclusionZone'
 import identityNumbersPageContent from './pages/identityNumbers'
@@ -80,6 +81,7 @@ const getEnglishContent = (ddVersion: DataDictionaryVersion): I18n => {
       curfewTimetable: curfewTimeTablePageContent,
       deleteConfirm: deleteConfirmPageContent,
       deviceWearer: deviceWearerPageContent,
+      deviceWearerSearchResults: deviceWearerSearchResultsPageContent,
       editConfirm: editConfirmPageContent,
       exclusionZone: exclusionZonePageContent,
       restrictionZone: restrictionZonePageContent,

--- a/server/i18n/en/pages/deviceWearerSearchResults.ts
+++ b/server/i18n/en/pages/deviceWearerSearchResults.ts
@@ -1,0 +1,21 @@
+import DeviceWearerSearchResultsPageContent from '../../../types/i18n/pages/deviceWearerSearchResults'
+
+const deviceWearerSearchResultsPageContent: DeviceWearerSearchResultsPageContent = {
+  section: 'About the device wearer',
+  titleFound: "Confirm the device wearer's details",
+  titleNoResults: 'No results found',
+  messages: {
+    oneResultFound: '1 device wearer found for <b>{identifier}</b>.',
+    noResultsFound:
+      'We could not find a device wearer that matches <b>{identifier}</b>. You can search again or enter their details manually.',
+  },
+  links: {
+    searchAgain: 'Search again',
+    enterDetailsManually: 'Enter details manually',
+  },
+  buttons: {
+    useThisDeviceWearer: 'Use this device wearer',
+  },
+}
+
+export default deviceWearerSearchResultsPageContent

--- a/server/routes/about-the-device-wearer/device-wearer-search-results/controller.test.ts
+++ b/server/routes/about-the-device-wearer/device-wearer-search-results/controller.test.ts
@@ -1,0 +1,97 @@
+import { createMockRequest, createMockResponse } from '../../../../test/mocks/mockExpress'
+import { getMockOrder } from '../../../../test/mocks/mockOrder'
+import paths from '../../../constants/paths'
+import DeviceWearerSearchResultsController from './controller'
+import DeviceWearerSearchResultsService from './service'
+
+describe('DeviceWearerSearchResultsController', () => {
+  const mockService = {
+    getSearchResult: jest.fn(),
+    confirmSearchResult: jest.fn(),
+    hasSearchMatch: jest.fn(),
+    getDisplayDateOfBirth: jest.fn(),
+  } as unknown as jest.Mocked<DeviceWearerSearchResultsService>
+
+  const controller = new DeviceWearerSearchResultsController(mockService)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('view', () => {
+    it('calls backend service with searchedIdentifier query parameter', async () => {
+      const order = getMockOrder()
+      const req = createMockRequest({
+        order,
+        query: {
+          searchedIdentifier: 'A1234BC',
+        },
+      })
+      const res = createMockResponse()
+
+      mockService.getSearchResult.mockResolvedValue({
+        fullName: 'Ermintrude Jones',
+        dateOfBirth: '1974-01-19T00:00:00Z',
+      })
+      mockService.hasSearchMatch.mockReturnValue(true)
+      mockService.getDisplayDateOfBirth.mockReturnValue('19 January 1974')
+
+      await controller.view(req, res, jest.fn())
+
+      expect(mockService.getSearchResult).toHaveBeenCalledWith({
+        accessToken: 'fakeUserToken',
+        orderId: order.id,
+        searchedIdentifier: 'A1234BC',
+      })
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/order/about-the-device-wearer/device-wearer-search-results',
+        expect.objectContaining({
+          searchedIdentifier: 'A1234BC',
+          fullName: 'Ermintrude Jones',
+        }),
+      )
+    })
+  })
+
+  describe('update', () => {
+    it('confirms selection and redirects to device wearer page on continue', async () => {
+      const order = getMockOrder()
+      const req = createMockRequest({
+        order,
+        body: {
+          action: 'continue',
+          searchedIdentifier: 'A1234BC',
+        },
+      })
+      const res = createMockResponse()
+
+      await controller.update(req, res, jest.fn())
+
+      expect(mockService.confirmSearchResult).toHaveBeenCalledWith({
+        accessToken: 'fakeUserToken',
+        orderId: order.id,
+        searchedIdentifier: 'A1234BC',
+      })
+      expect(res.redirect).toHaveBeenCalledWith(
+        paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id),
+      )
+    })
+
+    it('redirects to summary on save as draft without backend confirm', async () => {
+      const order = getMockOrder()
+      const req = createMockRequest({
+        order,
+        body: {
+          action: 'back',
+          searchedIdentifier: 'A1234BC',
+        },
+      })
+      const res = createMockResponse()
+
+      await controller.update(req, res, jest.fn())
+
+      expect(mockService.confirmSearchResult).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith(paths.ORDER.SUMMARY.replace(':orderId', order.id))
+    })
+  })
+})

--- a/server/routes/about-the-device-wearer/device-wearer-search-results/controller.ts
+++ b/server/routes/about-the-device-wearer/device-wearer-search-results/controller.ts
@@ -1,0 +1,51 @@
+import { Request, RequestHandler, Response } from 'express'
+import z from 'zod'
+import paths from '../../../constants/paths'
+import DeviceWearerSearchResultsService from './service'
+import Model from './viewModel'
+
+const SearchIdentifierModel = z.object({
+  searchedIdentifier: z.string().trim().min(1),
+})
+
+const FormModel = z.object({
+  action: z.string().default('continue'),
+  searchedIdentifier: z.string().trim().min(1),
+})
+
+export default class DeviceWearerSearchResultsController {
+  constructor(private readonly service: DeviceWearerSearchResultsService) {}
+
+  view: RequestHandler = async (req: Request, res: Response) => {
+    const order = req.order!
+    const { searchedIdentifier } = SearchIdentifierModel.parse(req.query)
+    const searchResult = await this.service.getSearchResult({
+      accessToken: res.locals.user.token,
+      orderId: order.id,
+      searchedIdentifier,
+    })
+
+    res.render(
+      'pages/order/about-the-device-wearer/device-wearer-search-results',
+      Model.construct(order.id, searchedIdentifier, searchResult, res.locals.content!, this.service),
+    )
+  }
+
+  update: RequestHandler = async (req: Request, res: Response) => {
+    const order = req.order!
+    const { action, searchedIdentifier } = FormModel.parse(req.body)
+
+    if (action === 'back') {
+      res.redirect(paths.ORDER.SUMMARY.replace(':orderId', order.id))
+      return
+    }
+
+    await this.service.confirmSearchResult({
+      accessToken: res.locals.user.token,
+      orderId: order.id,
+      searchedIdentifier,
+    })
+
+    res.redirect(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', order.id))
+  }
+}

--- a/server/routes/about-the-device-wearer/device-wearer-search-results/service.test.ts
+++ b/server/routes/about-the-device-wearer/device-wearer-search-results/service.test.ts
@@ -1,0 +1,71 @@
+import RestClient from '../../../data/restClient'
+import DeviceWearerSearchResultsService from './service'
+
+jest.mock('../../../data/restClient')
+
+describe('DeviceWearerSearchResultsService', () => {
+  const mockRestClient = new RestClient('cemoApi', {
+    url: '',
+    timeout: { response: 0, deadline: 0 },
+    agent: { timeout: 0 },
+  }) as jest.Mocked<RestClient>
+
+  const service = new DeviceWearerSearchResultsService(mockRestClient)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('gets search result by searched identifier', async () => {
+    mockRestClient.get.mockResolvedValue({
+      fullName: 'Ermintrude Jones',
+      dateOfBirth: '1974-01-19T00:00:00Z',
+    })
+
+    const result = await service.getSearchResult({
+      accessToken: 'fake-token',
+      orderId: 'order-123',
+      searchedIdentifier: 'A1234BC',
+    })
+
+    expect(mockRestClient.get).toHaveBeenCalledWith({
+      path: '/api/orders/order-123/device-wearer/search-results',
+      query: { searchedIdentifier: 'A1234BC' },
+      token: 'fake-token',
+    })
+    expect(result).toEqual({
+      fullName: 'Ermintrude Jones',
+      dateOfBirth: '1974-01-19T00:00:00Z',
+    })
+  })
+
+  it('confirms the selected search result', async () => {
+    mockRestClient.post.mockResolvedValue({})
+
+    await service.confirmSearchResult({
+      accessToken: 'fake-token',
+      orderId: 'order-123',
+      searchedIdentifier: 'A1234BC',
+    })
+
+    expect(mockRestClient.post).toHaveBeenCalledWith({
+      path: '/api/orders/order-123/device-wearer/search-results/confirm',
+      token: 'fake-token',
+      data: { searchedIdentifier: 'A1234BC' },
+    })
+  })
+
+  it('returns true when search result has a matching person', () => {
+    expect(service.hasSearchMatch({ fullName: 'Ermintrude Jones', dateOfBirth: null })).toBe(true)
+  })
+
+  it('returns false when search result has no matching person', () => {
+    expect(service.hasSearchMatch({ fullName: null, dateOfBirth: null })).toBe(false)
+  })
+
+  it('formats date of birth for display', () => {
+    expect(service.getDisplayDateOfBirth({ fullName: null, dateOfBirth: '1974-01-19T00:00:00Z' })).toBe(
+      '19 January 1974',
+    )
+  })
+})

--- a/server/routes/about-the-device-wearer/device-wearer-search-results/service.ts
+++ b/server/routes/about-the-device-wearer/device-wearer-search-results/service.ts
@@ -1,0 +1,60 @@
+import z from 'zod'
+import RestClient from '../../../data/restClient'
+import { AuthenticatedRequestInput } from '../../../interfaces/request'
+
+const DeviceWearerSearchResultResponseModel = z.object({
+  fullName: z.string().nullable().optional(),
+  dateOfBirth: z.string().datetime().nullable().optional(),
+})
+
+export type DeviceWearerSearchResultResponse = z.infer<typeof DeviceWearerSearchResultResponseModel>
+
+type GetSearchResultInput = AuthenticatedRequestInput & {
+  orderId: string
+  searchedIdentifier: string
+}
+
+type ConfirmSearchResultInput = AuthenticatedRequestInput & {
+  orderId: string
+  searchedIdentifier: string
+}
+
+export default class DeviceWearerSearchResultsService {
+  constructor(private readonly apiClient: RestClient) {}
+
+  async getSearchResult(input: GetSearchResultInput): Promise<DeviceWearerSearchResultResponse> {
+    const response = await this.apiClient.get({
+      path: `/api/orders/${input.orderId}/device-wearer/search-results`,
+      query: { searchedIdentifier: input.searchedIdentifier },
+      token: input.accessToken,
+    })
+
+    return DeviceWearerSearchResultResponseModel.parse(response)
+  }
+
+  async confirmSearchResult(input: ConfirmSearchResultInput): Promise<void> {
+    await this.apiClient.post({
+      path: `/api/orders/${input.orderId}/device-wearer/search-results/confirm`,
+      token: input.accessToken,
+      data: {
+        searchedIdentifier: input.searchedIdentifier,
+      },
+    })
+  }
+
+  hasSearchMatch(searchResult: DeviceWearerSearchResultResponse): boolean {
+    return Boolean(searchResult.fullName || searchResult.dateOfBirth)
+  }
+
+  getDisplayDateOfBirth(searchResult: DeviceWearerSearchResultResponse): string {
+    if (!searchResult.dateOfBirth) {
+      return ''
+    }
+
+    return new Date(searchResult.dateOfBirth).toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+  }
+}

--- a/server/routes/about-the-device-wearer/device-wearer-search-results/viewModel.ts
+++ b/server/routes/about-the-device-wearer/device-wearer-search-results/viewModel.ts
@@ -1,0 +1,27 @@
+import paths from '../../../constants/paths'
+import I18n from '../../../types/i18n'
+import DeviceWearerSearchResultsService, { DeviceWearerSearchResultResponse } from './service'
+
+const construct = (
+  orderId: string,
+  searchedIdentifier: string,
+  searchResult: DeviceWearerSearchResultResponse,
+  content: I18n,
+  service: DeviceWearerSearchResultsService,
+) => {
+  const hasMatch = service.hasSearchMatch(searchResult)
+
+  return {
+    hasMatch,
+    searchedIdentifier,
+    fullName: searchResult.fullName,
+    dateOfBirth: service.getDisplayDateOfBirth(searchResult),
+    heading: hasMatch
+      ? content.pages.deviceWearerSearchResults.titleFound
+      : content.pages.deviceWearerSearchResults.titleNoResults,
+    searchAgainLink: paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', orderId),
+    enterDetailsManuallyLink: paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER.replace(':orderId', orderId),
+  }
+}
+
+export default { construct }

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -41,7 +41,7 @@ const mockOrderChecklistService = {
   setSectionCheckStatus: jest.fn(),
   getChecklist: jest.fn(),
 } as unknown as jest.Mocked<OrderChecklistService>
-const taskListService = new TaskListService(mockOrderChecklistService)
+const taskListService = new TaskListService()
 const sectionService = {
   checkBlankVariationOrNewOrder: jest.fn().mockReturnValue(true),
   getSectionsForOrder: jest.fn().mockReturnValue([]),

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -14,6 +14,7 @@ import TaskListService from '../services/taskListService'
 import OrderChecklistService from '../services/orderChecklistService'
 import OrderChecklistModel from '../models/OrderChecklist'
 import SectionsService from '../services/sectionsService'
+import DeviceWearerSearchResultsService from './about-the-device-wearer/device-wearer-search-results/service'
 
 jest.mock('../services/auditService')
 jest.mock('../services/orderService')
@@ -46,6 +47,12 @@ const sectionService = {
   checkBlankVariationOrNewOrder: jest.fn().mockReturnValue(true),
   getSectionsForOrder: jest.fn().mockReturnValue([]),
 } as unknown as jest.Mocked<SectionsService>
+const deviceWearerSearchResultsService = {
+  getSearchResult: jest.fn().mockResolvedValue({ fullName: null, dateOfBirth: null }),
+  confirmSearchResult: jest.fn(),
+  hasSearchMatch: jest.fn().mockReturnValue(false),
+  getDisplayDateOfBirth: jest.fn().mockReturnValue(''),
+} as unknown as jest.Mocked<DeviceWearerSearchResultsService>
 const mockSubmittedOrder = getMockSubmittedOrder()
 const mockDraftOrder = getMockOrder()
 
@@ -76,6 +83,7 @@ describe('authorised user', () => {
         taskListService,
         sectionService,
         orderChecklistService: mockOrderChecklistService,
+        deviceWearerSearchResultsService,
       },
       userSupplier: () => user,
     })
@@ -164,6 +172,28 @@ describe('authorised user', () => {
     })
   })
 
+  describe('GET /order/:orderId/about-the-device-wearer/device-wearer-search-results', () => {
+    it('should render device wearer search results page', () => {
+      auditService.logPageView.mockResolvedValue()
+      orderService.getOrder.mockResolvedValue(mockSubmittedOrder)
+      flashProvider.mockReturnValue([])
+      deviceWearerSearchResultsService.getSearchResult.mockResolvedValue({
+        fullName: 'Ermintrude Jones',
+        dateOfBirth: '1974-01-19T00:00:00Z',
+      })
+      deviceWearerSearchResultsService.hasSearchMatch.mockReturnValue(true)
+      deviceWearerSearchResultsService.getDisplayDateOfBirth.mockReturnValue('19 January 1974')
+
+      return request(app)
+        .get(`/order/${mockSubmittedOrder.id}/about-the-device-wearer/device-wearer-search-results`)
+        .query({ searchedIdentifier: 'A1234BC' })
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('About the device wearer')
+        })
+    })
+  })
+
   describe('GET /order/:orderId/contact-information/contact-details', () => {
     it('should render contact details page', () => {
       auditService.logPageView.mockResolvedValue()
@@ -240,6 +270,7 @@ describe('Order Not Found', () => {
         deviceWearerService,
         orderSearchService,
         orderChecklistService: mockOrderChecklistService,
+        deviceWearerSearchResultsService,
       },
       userSupplier: () => user,
     })
@@ -257,6 +288,16 @@ describe('Order Not Found', () => {
     ['POST /order/:orderId/summary', 'post', `/order/${mockId}/delete`],
     ['GET /order/:orderId/about-the-device-wearer', 'get', `/order/${mockId}/about-the-device-wearer`],
     ['POST /order/:orderId/about-the-device-wearer', 'post', `/order/${mockId}/about-the-device-wearer`],
+    [
+      'GET /order/:orderId/about-the-device-wearer/device-wearer-search-results',
+      'get',
+      `/order/${mockId}/about-the-device-wearer/device-wearer-search-results`,
+    ],
+    [
+      'POST /order/:orderId/about-the-device-wearer/device-wearer-search-results',
+      'post',
+      `/order/${mockId}/about-the-device-wearer/device-wearer-search-results`,
+    ],
     [
       'GET /order/:orderId/contact-information/contact-details',
       'get',
@@ -284,6 +325,7 @@ describe('unauthorised user', () => {
         orderService,
         deviceWearerService,
         orderSearchService,
+        deviceWearerSearchResultsService,
       },
       userSupplier: () => unauthorisedUser,
     })
@@ -302,6 +344,16 @@ describe('unauthorised user', () => {
     ['POST /order/:orderId/summary', 'post', '/order/123456789/delete'],
     ['GET /order/:orderId/about-the-device-wearer', 'get', '/order/123456789/about-the-device-wearer'],
     ['POST /order/:orderId/about-the-device-wearer', 'post', '/order/123456789/about-the-device-wearer'],
+    [
+      'GET /order/:orderId/about-the-device-wearer/device-wearer-search-results',
+      'get',
+      '/order/123456789/about-the-device-wearer/device-wearer-search-results',
+    ],
+    [
+      'POST /order/:orderId/about-the-device-wearer/device-wearer-search-results',
+      'post',
+      '/order/123456789/about-the-device-wearer/device-wearer-search-results',
+    ],
     [
       'GET /order/:orderId/contact-information/contact-details',
       'get',

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -45,6 +45,7 @@ import IsAddressChangeController from './variations/is-address-change/controller
 import NoRefitsController from './variations/no-refits/controller'
 import NoChangeResponsibleOfficerController from './variations/no-change-responsible-officer/controller'
 import SentencingActSelection from './sentencing-act-selection/controller'
+import DeviceWearerSearchResultsController from './about-the-device-wearer/device-wearer-search-results/controller'
 
 export default function routes({
   alcoholMonitoringService,
@@ -88,6 +89,7 @@ export default function routes({
   postcodeService,
   sectionService,
   sentencingActService,
+  deviceWearerSearchResultsService,
 }: Services): Router {
   const router = Router()
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
@@ -214,6 +216,7 @@ export default function routes({
   const noRefitsController = new NoRefitsController()
   const noChangeResonsibleOfficer = new NoChangeResponsibleOfficerController()
   const setSentencingAct = new SentencingActSelection(sentencingActService)
+  const deviceWearerSearchResultsController = new DeviceWearerSearchResultsController(deviceWearerSearchResultsService)
   router.param('orderId', populateOrder(orderService))
 
   get('/', orderSearchController.list)
@@ -259,6 +262,10 @@ export default function routes({
   // Identity numbers
   get(paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS, deviceWearerController.viewIdentityNumbers)
   post(paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS, deviceWearerController.updateIdentityNumbers)
+
+  // Device wearer search results
+  get(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER_SEARCH_RESULTS, deviceWearerSearchResultsController.view)
+  post(paths.ABOUT_THE_DEVICE_WEARER.DEVICE_WEARER_SEARCH_RESULTS, deviceWearerSearchResultsController.update)
 
   // Responsible Adult
   get(paths.ABOUT_THE_DEVICE_WEARER.RESPONSIBLE_ADULT, responsibleAdultController.view)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -93,89 +93,55 @@ export default function routes({
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
   const post = (path: string | string[], handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
 
-  const alcoholMonitoringController = new AlcoholMonitoringController(
-    auditService,
-    alcoholMonitoringService,
-    taskListService,
-  )
+  const alcoholMonitoringController = new AlcoholMonitoringController(alcoholMonitoringService)
   const attachmentsController = new AttachmentsController(
     auditService,
-    orderService,
     attachmentService,
     taskListService,
     orderChecklistService,
   )
-  const attendanceMonitoringController = new AttendanceMonitoringController(
-    attendanceMonitoringService,
-    taskListService,
-  )
+  const attendanceMonitoringController = new AttendanceMonitoringController(attendanceMonitoringService)
   const attendanceMonitoringAddToListController = new AttendanceMonitoringAddToListController(
     attendanceMonitoringAddToListService,
   )
-  const contactDetailsController = new ContactDetailsController(auditService, contactDetailsService, taskListService)
-  const curfewReleaseDateController = new CurfewReleaseDateController(
-    auditService,
-    curfewReleaseDateService,
-    taskListService,
-  )
-  const curfewTimetableController = new CurfewTimetableController(auditService, curfewTimetableService, taskListService)
-  const curfewConditionsController = new CurfewConditionsController(
-    auditService,
-    curfewConditionsService,
-    taskListService,
-  )
-  const curfewAdditionalDetailsController = new CurfewAdditionalDetailsController(
-    auditService,
-    curfewAdditionalDetailsService,
-    taskListService,
-  )
-  const deviceWearerController = new DeviceWearerController(auditService, deviceWearerService, taskListService)
+  const contactDetailsController = new ContactDetailsController(contactDetailsService, taskListService)
+  const curfewReleaseDateController = new CurfewReleaseDateController(curfewReleaseDateService)
+  const curfewTimetableController = new CurfewTimetableController(curfewTimetableService)
+  const curfewConditionsController = new CurfewConditionsController(curfewConditionsService)
+  const curfewAdditionalDetailsController = new CurfewAdditionalDetailsController(curfewAdditionalDetailsService)
+  const deviceWearerController = new DeviceWearerController(deviceWearerService, taskListService)
   const deviceWearerCheckAnswersController = new DeviceWearerCheckAnswersController(
-    auditService,
     taskListService,
     orderChecklistService,
     sectionService,
   )
-  const installationAndRiskController = new InstallationAndRiskController(
-    auditService,
-    installationAndRiskService,
-    taskListService,
-  )
+  const installationAndRiskController = new InstallationAndRiskController(installationAndRiskService, taskListService)
   const installationAndRiskCheckAnswersController = new InstallationAndRiskCheckAnswersController(
-    auditService,
     taskListService,
     orderChecklistService,
     sectionService,
   )
   const removeMonitoringTypeController = new RemoveMonitoringTypeController(removeMonitoringTypeService)
-  const noFixedAbodeController = new NoFixedAbodeController(auditService, deviceWearerService, taskListService)
-  const interestedPartiesController = new InterestedPartiesController(
-    auditService,
-    interestedPartiesService,
-    taskListService,
-  )
+  const noFixedAbodeController = new NoFixedAbodeController(deviceWearerService, taskListService)
+  const interestedPartiesController = new InterestedPartiesController(interestedPartiesService, taskListService)
   const orderSearchController = new OrderSearchController(auditService, orderSearchService)
-  const orderController = new OrderController(auditService, orderService, sectionService)
+  const orderController = new OrderController(orderService, sectionService)
   const responsibleAdultController = new ResponsibleAdultController(
-    auditService,
     deviceWearerResponsibleAdultService,
     taskListService,
   )
-  const trailMonitoringController = new TrailMonitoringController(auditService, trailMonitoringService, taskListService)
+  const trailMonitoringController = new TrailMonitoringController(trailMonitoringService)
   const zoneControllerAddToList = new EnforcementZoneAddToListController(auditService, zoneAddToListService)
   const monitoringConditionsCheckYourAnswersController = new MonitoringConditionsCheckAnswersController(
-    auditService,
     taskListService,
     orderChecklistService,
     sectionService,
   )
   const contactInformationCheckAnswersController = new ContactInformationCheckAnswersController(
-    auditService,
     taskListService,
     orderChecklistService,
   )
   const variationDetailsController = new VariationDetailsController(
-    auditService,
     variationService,
     taskListService,
     orderChecklistService,
@@ -183,7 +149,6 @@ export default function routes({
   const receiptController = new ReceiptController(fmsRequestService)
 
   const probationDeliveryUnitController = new ProbationDeliveryUnitController(
-    auditService,
     probationDeliveryUnitService,
     taskListService,
   )

--- a/server/routes/monitoring-conditions/monitoring-type/controller.test.ts
+++ b/server/routes/monitoring-conditions/monitoring-type/controller.test.ts
@@ -3,16 +3,10 @@ import { createMockRequest, createMockResponse } from '../../../../test/mocks/mo
 import MonitoringTypeController from './controller'
 import constructModel from './viewModel'
 import paths from '../../../constants/paths'
-import TaskListService from '../../../services/taskListService'
 
 jest.mock('./viewModel')
 
 describe('monitoring type controller', () => {
-  const mockTaskListService = {
-    getNextCheckYourAnswersPage: jest.fn(),
-    getNextPage: jest.fn(),
-  } as unknown as jest.Mocked<TaskListService>
-
   let controller: MonitoringTypeController
 
   let res: Response
@@ -23,7 +17,7 @@ describe('monitoring type controller', () => {
   beforeEach(() => {
     jest.restoreAllMocks()
 
-    controller = new MonitoringTypeController(mockTaskListService)
+    controller = new MonitoringTypeController()
 
     mockConstructModel.mockReturnValue({ errorSummary: null })
 
@@ -51,9 +45,6 @@ describe('monitoring type controller', () => {
         action: 'continue',
         monitoringType: 'curfew',
       }
-      mockTaskListService.getNextPage = jest
-        .fn()
-        .mockReturnValue(paths.MONITORING_CONDITIONS.CURFEW_RELEASE_DATE.replace(':orderId', req.order!.id))
 
       await controller.update(req, res, next)
 

--- a/server/routes/monitoring-conditions/monitoring-type/controller.ts
+++ b/server/routes/monitoring-conditions/monitoring-type/controller.ts
@@ -4,10 +4,9 @@ import paths from '../../../constants/paths'
 import MonitoringTypesFormDataModel from './formModel'
 import { validationErrors } from '../../../constants/validationErrors'
 import { ValidationResult } from '../../../models/Validation'
-import TaskListService from '../../../services/taskListService'
 
 export default class MonitoringTypeController {
-  constructor(private readonly taskListService: TaskListService) {}
+  constructor() {}
 
   view: RequestHandler = async (req: Request, res: Response) => {
     const order = req.order!

--- a/server/routes/monitoring-conditions/router.ts
+++ b/server/routes/monitoring-conditions/router.ts
@@ -49,7 +49,7 @@ const createOrderTypeDescriptionRouter = (
 
   const prarrController = new PrarrController(monitoringConditionsStoreService, monitoringConditionsUpdateService)
 
-  const monitoringTypeController = new MonitoringTypeController(taskListService)
+  const monitoringTypeController = new MonitoringTypeController()
 
   const policeAreaController = new PoliceAreaController(monitoringConditionsStoreService)
 

--- a/server/routes/postcode-lookup/enter-address/controller.ts
+++ b/server/routes/postcode-lookup/enter-address/controller.ts
@@ -5,13 +5,9 @@ import { AddressType } from '../../../models/Address'
 import { isValidationResult } from '../../../models/Validation'
 import { AddressFormDataModel } from '../../../models/form-data/address'
 import AddressService from '../../../services/addressService'
-import PostcodeService from '../postcodeService'
 
 export default class EnterAddressController {
-  constructor(
-    private readonly addressService: AddressService,
-    private readonly postcodeService: PostcodeService,
-  ) {}
+  constructor(private readonly addressService: AddressService) {}
 
   view: RequestHandler = async (req: Request, res: Response) => {
     const addressType = req.params.addressType as string

--- a/server/routes/postcode-lookup/enter-address/enterAddressController.test.ts
+++ b/server/routes/postcode-lookup/enter-address/enterAddressController.test.ts
@@ -4,7 +4,6 @@ import { createDeviceWearer, getMockOrder } from '../../../../test/mocks/mockOrd
 import RestClient from '../../../data/restClient'
 import { createMockRequest, createMockResponse } from '../../../../test/mocks/mockExpress'
 import AddressService from '../../../services/addressService'
-import PostcodeService from '../postcodeService'
 import ViewModel from './viewModel'
 
 jest.mock('../../../services/orderService')
@@ -39,7 +38,6 @@ describe('EnterAddressController', () => {
   let mockRestClient: jest.Mocked<RestClient>
   let enterAddressController: EnterAddressController
   let mockAddressService: jest.Mocked<AddressService>
-  let mockPostcodeService: jest.Mocked<PostcodeService>
 
   beforeEach(() => {
     jest.restoreAllMocks()
@@ -50,10 +48,7 @@ describe('EnterAddressController', () => {
     }) as jest.Mocked<RestClient>
 
     mockAddressService = new AddressService(mockRestClient) as jest.Mocked<AddressService>
-    mockPostcodeService = {
-      buildUrl: jest.fn(),
-    } as unknown as jest.Mocked<PostcodeService>
-    enterAddressController = new EnterAddressController(mockAddressService, mockPostcodeService)
+    enterAddressController = new EnterAddressController(mockAddressService)
   })
 
   describe('getEnterAddress', () => {

--- a/server/routes/postcode-lookup/router.ts
+++ b/server/routes/postcode-lookup/router.ts
@@ -16,7 +16,7 @@ const createPostcodeLookupRouter = (
   const addressResultController = new AddressResultController(services.postcodeService, services.addressService)
   const confirmAddressController = new ConfirmAddressController(services.postcodeService, services.taskListService)
   const addressListController = new AddressListController(services.taskListService)
-  const enterAddressController = new EnterAddressController(services.addressService, services.postcodeService)
+  const enterAddressController = new EnterAddressController(services.addressService)
   router.get('/find-address/:addressType', asyncMiddleware(findAddressController.view))
   router.post('/find-address/:addressType', asyncMiddleware(findAddressController.update))
 

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -74,7 +74,7 @@ export const services = () => {
   const orderChecklistService = new OrderChecklistService(
     config.redis.enabled ? new RedisOrderChecklistStore(createRedisClient()) : new InMemoryOrderChecklistStore(),
   )
-  const taskListService = new TaskListService(orderChecklistService)
+  const taskListService = new TaskListService()
   const trailMonitoringService = new TrailMonitoringService(cemoApiClient)
   const variationService = new VariationService(cemoApiClient)
   const probationDeliveryUnitService = new ProbationDeliveryUnitService(cemoApiClient)

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -50,6 +50,7 @@ import UpdateInterestedPartiesService from '../routes/interested-parties/interes
 import PostcodeService from '../routes/postcode-lookup/postcodeService'
 import SentencingActService from '../routes/sentencing-act-selection/SentencingActService'
 import SectionService from './sectionsService'
+import DeviceWearerSearchResultsService from '../routes/about-the-device-wearer/device-wearer-search-results/service'
 
 export const services = () => {
   const { applicationInfo, hmppsAuditClient, cemoApiClient, osDataHubClient } = dataAccess()
@@ -112,6 +113,7 @@ export const services = () => {
   )
 
   const sectionService = new SectionService(taskListService, orderChecklistService)
+  const deviceWearerSearchResultsService = new DeviceWearerSearchResultsService(cemoApiClient)
 
   const fmsRequestService = new FmsRequestService(cemoApiClient)
   return {
@@ -158,6 +160,7 @@ export const services = () => {
     postcodeService,
     sectionService,
     sentencingActService,
+    deviceWearerSearchResultsService,
   }
 }
 

--- a/server/services/taskListService.test.ts
+++ b/server/services/taskListService.test.ts
@@ -1,42 +1,20 @@
 import {
-  createAddress,
-  createAttatchment,
-  createContactDetails,
-  createCurfewConditions,
-  createCurfewReleaseDateConditions,
-  createCurfewTimeTable,
   createDeviceWearer,
-  createEnforcementZoneCondition,
-  createInstallationAndRisk,
-  createInterestedParties,
   createMonitoringConditions,
-  createMonitoringConditionsAlcohol,
-  createMonitoringConditionsAttendance,
-  createMonitoringConditionsTrail,
-  createResponsibleAdult,
   getFilledMockOrder,
   getMockOrder,
 } from '../../test/mocks/mockOrder'
 import paths from '../constants/paths'
 import TaskListService, { Page, Task } from './taskListService'
 import { Order } from '../models/Order'
-import AttachmentType from '../models/AttachmentType'
-import OrderChecklistService from './orderChecklistService'
-import OrderChecklistModel from '../models/OrderChecklist'
-import FeatureFlags from '../utils/featureFlags'
 
 describe('TaskListService', () => {
-  const mockOrderChecklistService = {
-    setSectionCheckStatus: jest.fn(),
-    getChecklist: jest.fn().mockResolvedValue(OrderChecklistModel.parse({})),
-  } as unknown as jest.Mocked<OrderChecklistService>
-
   const monitoringConditionsPath = paths.MONITORING_CONDITIONS.ORDER_TYPE_DESCRIPTION.ORDER_TYPE
   describe('getNextPage', () => {
     it('should return contact details if current page is device wearer and adultAtTheTimeOfInstallation is true', () => {
       // Given
       const currentPage = 'DEVICE_WEARER'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         deviceWearer: createDeviceWearer({ adultAtTimeOfInstallation: true }),
       })
@@ -51,7 +29,7 @@ describe('TaskListService', () => {
     it('should return responsible adult if current page is device wearer and adultAtTheTimeOfInstallation is false', () => {
       // Given
       const currentPage = 'DEVICE_WEARER'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         deviceWearer: createDeviceWearer({ adultAtTimeOfInstallation: false }),
       })
@@ -66,7 +44,7 @@ describe('TaskListService', () => {
     it('should return contact details if current page is responsible adult', () => {
       // Given
       const currentPage = 'RESPONSIBLE_ADULT'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder()
 
       // When
@@ -79,7 +57,7 @@ describe('TaskListService', () => {
     it('should return device wearer page if current page is identity numbers', () => {
       // Given
       const currentPage = 'IDENTITY_NUMBERS'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder()
 
       // When
@@ -92,7 +70,7 @@ describe('TaskListService', () => {
     it('should go to installation and risk page if current page is device wearer check your answers', () => {
       // Given
       const currentPage = 'CHECK_ANSWERS_DEVICE_WEARER'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder()
 
       // When
@@ -105,7 +83,7 @@ describe('TaskListService', () => {
     it('should return no fixed abode if current page is contact details', () => {
       // Given
       const currentPage = 'CONTACT_DETAILS'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder()
 
       // When
@@ -118,7 +96,7 @@ describe('TaskListService', () => {
     it('should go to device wearer cya if current page is no fixed abode and noFixedAbode is true', () => {
       // Given
       const currentPage = 'NO_FIXED_ABODE'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         deviceWearer: createDeviceWearer({ noFixedAbode: true }),
       })
@@ -133,7 +111,7 @@ describe('TaskListService', () => {
     it('should return find address if current page is no fixed abode and noFixedAbode is false', () => {
       // Given
       const currentPage = 'NO_FIXED_ABODE'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         deviceWearer: createDeviceWearer({ noFixedAbode: false }),
       })
@@ -150,7 +128,7 @@ describe('TaskListService', () => {
     it('should return device wearer cya if current page is primary address', () => {
       // Given
       const currentPage = 'PRIMARY_ADDRESS'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         deviceWearer: createDeviceWearer({ noFixedAbode: false }),
       })
@@ -165,7 +143,7 @@ describe('TaskListService', () => {
     it('should return identity numbers if current page is interested parties cya', () => {
       // Given
       const currentPage = 'CHECK_ANSWERS_INTERESTED_PARTIES'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder()
 
       // When
@@ -178,7 +156,7 @@ describe('TaskListService', () => {
     it('should return check answers if current page is installation and risk', () => {
       // Given
       const currentPage = 'INSTALLATION_AND_RISK'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder()
 
       // When
@@ -191,7 +169,7 @@ describe('TaskListService', () => {
     it('should return monitoring conditions if current page is installation and risk check answers', () => {
       // Given
       const currentPage = 'CHECK_ANSWERS_INSTALLATION_AND_RISK'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder()
 
       // When
@@ -204,7 +182,7 @@ describe('TaskListService', () => {
     it('should return installation appointment if current page is installation location and location is PRISON', () => {
       // Given
       const currentPage = 'INSTALLATION_LOCATION'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({ installationLocation: { location: 'PRISON' } })
       order.monitoringConditions.alcohol = true
       // When
@@ -217,7 +195,7 @@ describe('TaskListService', () => {
     it('should return installation appointment if current page is installation location and location is PROBATION_OFFICE', () => {
       // Given
       const currentPage = 'INSTALLATION_LOCATION'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         installationLocation: { location: 'PROBATION_OFFICE' },
       })
@@ -232,7 +210,7 @@ describe('TaskListService', () => {
     it('should return find installation address if current page is installation appointment', () => {
       // Given
       const currentPage = 'INSTALLATION_APPOINTMENT'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({ installationLocation: { location: 'PRISON' } })
       order.monitoringConditions.alcohol = true
 
@@ -248,7 +226,7 @@ describe('TaskListService', () => {
     it('should return check your answers page if current page is installation address and alcohol was selected', () => {
       // Given
       const currentPage = 'INSTALLATION_ADDRESS'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           alcohol: true,
@@ -265,7 +243,7 @@ describe('TaskListService', () => {
     it('should return curfew timetable if current page is curfew release date', () => {
       // Given
       const currentPage = 'CURFEW_RELEASE_DATE'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           curfew: true,
@@ -282,7 +260,7 @@ describe('TaskListService', () => {
     it('should return curfew release date if current page is curfew conitions', () => {
       // Given
       const currentPage = 'CURFEW_CONDITIONS'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           curfew: true,
@@ -300,7 +278,7 @@ describe('TaskListService', () => {
     it.skip('should return curfew timetable if current page is curfew additional details', () => {
       // Given
       const currentPage = 'CURFEW_ADDITIONAL_DETAILS'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           curfew: true,
@@ -317,7 +295,7 @@ describe('TaskListService', () => {
     it('should return exclusion zone if current page is curfew timetable and exclusionZone is selected', () => {
       // Given
       const currentPage = 'CURFEW_TIMETABLE'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           curfew: true,
@@ -339,7 +317,7 @@ describe('TaskListService', () => {
     it('should return trail monitoring if current page is curfew timetable and trail is selected', () => {
       // Given
       const currentPage = 'CURFEW_TIMETABLE'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           curfew: true,
@@ -357,7 +335,7 @@ describe('TaskListService', () => {
     it('should return attendance monitoring if current page is curfew timetable and mandatoryAttendance is selected', () => {
       // Given
       const currentPage = 'CURFEW_TIMETABLE'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           curfew: true,
@@ -375,7 +353,7 @@ describe('TaskListService', () => {
     it('should return alcohol monitoring if current page is curfew timetable and alcohol is selected', () => {
       // Given
       const currentPage = 'CURFEW_TIMETABLE'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           curfew: true,
@@ -393,7 +371,7 @@ describe('TaskListService', () => {
     it('should return check your answers if current page is curfew timetable and no other monitoring is selected', () => {
       // Given
       const currentPage = 'CURFEW_TIMETABLE'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           curfew: true,
@@ -410,7 +388,7 @@ describe('TaskListService', () => {
     it('should return trail monitoring if current page is exclusion zone and trail is selected', () => {
       // Given
       const currentPage = 'ENFORCEMENT_ZONE_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           exclusionZone: true,
@@ -428,7 +406,7 @@ describe('TaskListService', () => {
     it('should return attendance monitoring if current page is exclusion zone and mandatoryAttendance is selected', () => {
       // Given
       const currentPage = 'ENFORCEMENT_ZONE_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           exclusionZone: true,
@@ -446,7 +424,7 @@ describe('TaskListService', () => {
     it('should return alcohol monitoring if current page is exclusion zone and alcohol is selected', () => {
       // Given
       const currentPage = 'ENFORCEMENT_ZONE_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           exclusionZone: true,
@@ -464,7 +442,7 @@ describe('TaskListService', () => {
     it('should return check your answers if current page is exclusion zone and no other monitoring is selected', () => {
       // Given
       const currentPage = 'ENFORCEMENT_ZONE_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           exclusionZone: true,
@@ -481,7 +459,7 @@ describe('TaskListService', () => {
     it('should return attendance monitoring if current page is trail monitoring and mandatoryAttendance is selected', () => {
       // Given
       const currentPage = 'TRAIL_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           trail: true,
@@ -499,7 +477,7 @@ describe('TaskListService', () => {
     it('should return alcohol monitoring if current page is trail monitoring and alcohol is selected', () => {
       // Given
       const currentPage = 'TRAIL_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           trail: true,
@@ -517,7 +495,7 @@ describe('TaskListService', () => {
     it('should return check your answers if current page is trail monitoring and no other monitoring is selected', () => {
       // Given
       const currentPage = 'TRAIL_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           trail: true,
@@ -534,7 +512,7 @@ describe('TaskListService', () => {
     it('should return alcohol monitoring if current page is attendance monitoring and alcohol monitoring is selected', () => {
       // Given
       const currentPage = 'ATTENDANCE_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           mandatoryAttendance: true,
@@ -552,7 +530,7 @@ describe('TaskListService', () => {
     it('should return check your answers if current page is attendance monitoring and no other monitoring is selected', () => {
       // Given
       const currentPage = 'ATTENDANCE_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           mandatoryAttendance: true,
@@ -569,7 +547,7 @@ describe('TaskListService', () => {
     it('should return check your answers if current page is alcohol monitoring and no other monitoring is selected', () => {
       // Given
       const currentPage = 'ALCOHOL_MONITORING'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder({
         monitoringConditions: createMonitoringConditions({
           alcohol: true,
@@ -586,7 +564,7 @@ describe('TaskListService', () => {
     it('should return attachments if current page is check your answers', () => {
       // Given
       const currentPage = 'CHECK_ANSWERS_MONITORING_CONDITIONS'
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
       const order = getMockOrder()
 
       // When
@@ -610,7 +588,7 @@ describe('TaskListService', () => {
       (page: string, url: string) => {
         // Given
         const currentPage = page as Page
-        const taskListService = new TaskListService(mockOrderChecklistService)
+        const taskListService = new TaskListService()
         const order = getFilledMockOrder({
           monitoringConditions: createMonitoringConditions({
             isValid: true,
@@ -626,817 +604,6 @@ describe('TaskListService', () => {
     )
   })
 
-  describe('getSections', () => {
-    it('should return all tasks grouped by section and marked as incomplete', async () => {
-      // Given
-      const order = getMockOrder()
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      expect(sections).toEqual([
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-          path: paths.INTEREST_PARTIES.RESPONSIBLE_OFFICER.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_DEVICE_WEARER',
-          path: paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'RISK_INFORMATION',
-          path: paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ELECTRONIC_MONITORING_CONDITIONS',
-          path: monitoringConditionsPath.replace(':orderId', order.id),
-          isReady: false,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ADDITIONAL_DOCUMENTS',
-          path: paths.ATTACHMENT.FILE_VIEW.replace(':orderId', order.id).replace(
-            ':fileType(photo_Id|licence|court_order)',
-            'licence',
-          ),
-          isReady: true,
-        },
-      ])
-    })
-
-    it('should return all tasks grouped by section and marked as complete', async () => {
-      // Given
-      const order = getMockOrder({
-        deviceWearer: createDeviceWearer({
-          nomisId: '',
-          firstName: '',
-          noFixedAbode: true,
-        }),
-        deviceWearerResponsibleAdult: createResponsibleAdult(),
-        contactDetails: createContactDetails(),
-        installationAndRisk: createInstallationAndRisk(),
-        interestedParties: createInterestedParties({ notifyingOrganisation: 'PRISON' }),
-        isSentencingAct: true,
-        enforcementZoneConditions: [createEnforcementZoneCondition()],
-        addresses: [
-          createAddress({ addressType: 'PRIMARY' }),
-          createAddress({ addressType: 'SECONDARY' }),
-          createAddress({ addressType: 'TERTIARY' }),
-          createAddress({ addressType: 'INSTALLATION' }),
-        ],
-        monitoringConditions: createMonitoringConditions({ isValid: true }),
-        monitoringConditionsTrail: createMonitoringConditionsTrail(),
-        monitoringConditionsAlcohol: createMonitoringConditionsAlcohol(),
-        mandatoryAttendanceConditions: [createMonitoringConditionsAttendance()],
-        curfewReleaseDateConditions: createCurfewReleaseDateConditions(),
-        curfewConditions: createCurfewConditions(),
-        curfewTimeTable: createCurfewTimeTable(),
-        installationLocation: { location: 'INSTALLATION' },
-        installationAppointment: {
-          placeName: 'primary',
-          appointmentDate: 'date',
-        },
-        additionalDocuments: [createAttatchment(), createAttatchment({ fileType: AttachmentType.PHOTO_ID })],
-        orderParameters: { havePhoto: true },
-      })
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      expect(sections).toEqual([
-        {
-          checked: false,
-          completed: true,
-          name: 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-          path: paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: true,
-          name: 'ABOUT_THE_DEVICE_WEARER',
-          path: paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: true,
-          name: 'RISK_INFORMATION',
-          path: paths.INSTALLATION_AND_RISK.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: true,
-          name: 'ELECTRONIC_MONITORING_CONDITIONS',
-          path: paths.MONITORING_CONDITIONS.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: true,
-          name: 'ADDITIONAL_DOCUMENTS',
-          path: paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id),
-          isReady: true,
-        },
-      ])
-    })
-
-    it('should return all tasks grouped by section and checked marked as true', async () => {
-      // Given
-      const order = getMockOrder({
-        deviceWearer: createDeviceWearer({
-          nomisId: '',
-          firstName: '',
-          noFixedAbode: true,
-        }),
-        deviceWearerResponsibleAdult: createResponsibleAdult(),
-        contactDetails: createContactDetails(),
-        installationAndRisk: createInstallationAndRisk(),
-        interestedParties: createInterestedParties({ notifyingOrganisation: 'PRISON' }),
-        enforcementZoneConditions: [createEnforcementZoneCondition()],
-        addresses: [
-          createAddress({ addressType: 'PRIMARY' }),
-          createAddress({ addressType: 'SECONDARY' }),
-          createAddress({ addressType: 'TERTIARY' }),
-          createAddress({ addressType: 'INSTALLATION' }),
-        ],
-        monitoringConditions: createMonitoringConditions({ isValid: true }),
-        monitoringConditionsTrail: createMonitoringConditionsTrail(),
-        monitoringConditionsAlcohol: createMonitoringConditionsAlcohol(),
-        mandatoryAttendanceConditions: [createMonitoringConditionsAttendance()],
-        curfewReleaseDateConditions: createCurfewReleaseDateConditions(),
-        curfewConditions: createCurfewConditions(),
-        curfewTimeTable: createCurfewTimeTable(),
-        installationLocation: { location: 'INSTALLATION' },
-        installationAppointment: {
-          placeName: 'primary',
-          appointmentDate: 'date',
-        },
-        isSentencingAct: true,
-        additionalDocuments: [createAttatchment(), createAttatchment({ fileType: AttachmentType.PHOTO_ID })],
-        orderParameters: { havePhoto: true },
-      })
-      mockOrderChecklistService.getChecklist.mockReturnValueOnce(
-        Promise.resolve({
-          ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS: true,
-          ABOUT_THE_CHANGES_IN_THIS_VERSION_OF_THE_FORM: true,
-          ABOUT_THE_DEVICE_WEARER: true,
-          CONTACT_INFORMATION: true,
-          RISK_INFORMATION: true,
-          ELECTRONIC_MONITORING_CONDITIONS: true,
-          ADDITIONAL_DOCUMENTS: true,
-        }),
-      )
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      expect(sections).toEqual([
-        {
-          checked: true,
-          completed: true,
-          name: 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-          path: paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: true,
-          completed: true,
-          name: 'ABOUT_THE_DEVICE_WEARER',
-          path: paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: true,
-          completed: true,
-          name: 'RISK_INFORMATION',
-          path: paths.INSTALLATION_AND_RISK.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: true,
-          completed: true,
-          name: 'ELECTRONIC_MONITORING_CONDITIONS',
-          path: paths.MONITORING_CONDITIONS.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: true,
-          completed: true,
-          name: 'ADDITIONAL_DOCUMENTS',
-          path: paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id),
-          isReady: true,
-        },
-      ])
-    })
-
-    it('should return all tasks grouped by section and ready to start', async () => {
-      // Given
-      const order = getMockOrder({
-        deviceWearer: createDeviceWearer({
-          firstName: '',
-          adultAtTimeOfInstallation: false,
-          noFixedAbode: false,
-        }),
-        monitoringConditions: createMonitoringConditions({
-          curfew: true,
-          alcohol: true,
-          exclusionZone: true,
-          trail: true,
-          mandatoryAttendance: true,
-        }),
-      })
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      expect(sections).toEqual([
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-          path: paths.INTEREST_PARTIES.RESPONSIBLE_OFFICER.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_DEVICE_WEARER',
-          path: paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'RISK_INFORMATION',
-          path: paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ELECTRONIC_MONITORING_CONDITIONS',
-          path: monitoringConditionsPath.replace(':orderId', order.id),
-          isReady: false,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ADDITIONAL_DOCUMENTS',
-          path: paths.ATTACHMENT.FILE_VIEW.replace(':orderId', order.id).replace(
-            ':fileType(photo_Id|licence|court_order)',
-            'licence',
-          ),
-          isReady: true,
-        },
-      ])
-    })
-
-    it('should return all tasks grouped by section and ready to start for a variation', async () => {
-      // Given
-      const order = getMockOrder({
-        type: 'VARIATION',
-        deviceWearer: createDeviceWearer({
-          firstName: '',
-          adultAtTimeOfInstallation: false,
-          noFixedAbode: false,
-        }),
-        interestedParties: {
-          ...createInterestedParties(),
-          notifyingOrganisation: null,
-          notifyingOrganisationName: null,
-          notifyingOrganisationEmail: null,
-        },
-        monitoringConditions: createMonitoringConditions({
-          curfew: true,
-          alcohol: true,
-          exclusionZone: true,
-          trail: true,
-          mandatoryAttendance: true,
-        }),
-      })
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      expect(sections).toEqual([
-        {
-          checked: false,
-          completed: true,
-          name: 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-          path: paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_DEVICE_WEARER',
-          path: paths.ABOUT_THE_DEVICE_WEARER.IDENTITY_NUMBERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'RISK_INFORMATION',
-          path: paths.INSTALLATION_AND_RISK.INSTALLATION_AND_RISK.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ELECTRONIC_MONITORING_CONDITIONS',
-          path: monitoringConditionsPath.replace(':orderId', order.id),
-          isReady: false,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ADDITIONAL_DOCUMENTS',
-          path: paths.ATTACHMENT.FILE_VIEW.replace(':orderId', order.id).replace(
-            ':fileType(photo_Id|licence|court_order)',
-            'licence',
-          ),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_CHANGES_IN_THIS_VERSION_OF_THE_FORM',
-          path: paths.VARIATION.VARIATION_DETAILS.replace(':orderId', order.id),
-          isReady: true,
-        },
-      ])
-    })
-    it('should return links to the check your answers pages if the order has been submitted', async () => {
-      // Given
-      const order = getMockOrder({
-        status: 'SUBMITTED',
-        deviceWearer: createDeviceWearer({
-          firstName: '',
-          adultAtTimeOfInstallation: false,
-          noFixedAbode: false,
-        }),
-        monitoringConditions: createMonitoringConditions({
-          curfew: true,
-          alcohol: true,
-          exclusionZone: true,
-          trail: true,
-          mandatoryAttendance: true,
-        }),
-      })
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      expect(sections).toEqual([
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-          path: paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_DEVICE_WEARER',
-          path: paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'RISK_INFORMATION',
-          path: paths.INSTALLATION_AND_RISK.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ELECTRONIC_MONITORING_CONDITIONS',
-          path: paths.MONITORING_CONDITIONS.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          isReady: false,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ADDITIONAL_DOCUMENTS',
-          path: paths.ATTACHMENT.ATTACHMENTS.replace(':orderId', order.id),
-          isReady: true,
-        },
-      ])
-    })
-
-    it('return links to version cya pages for old versions', async () => {
-      // Given
-      const order = getMockOrder({
-        status: 'SUBMITTED',
-        deviceWearer: createDeviceWearer({
-          firstName: '',
-          adultAtTimeOfInstallation: false,
-          noFixedAbode: false,
-        }),
-        monitoringConditions: createMonitoringConditions({
-          curfew: true,
-          alcohol: true,
-          exclusionZone: true,
-          trail: true,
-          mandatoryAttendance: true,
-        }),
-      })
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order, 'someVersionId')
-
-      expect(sections).toEqual([
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-          path: paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS_VERSION.replace(':orderId', order.id).replace(
-            ':versionId',
-            'someVersionId',
-          ),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ABOUT_THE_DEVICE_WEARER',
-          path: paths.ABOUT_THE_DEVICE_WEARER.CHECK_YOUR_ANSWERS_VERSION.replace(':orderId', order.id).replace(
-            ':versionId',
-            'someVersionId',
-          ),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'RISK_INFORMATION',
-          path: paths.INSTALLATION_AND_RISK.CHECK_YOUR_ANSWERS_VERSION.replace(':orderId', order.id).replace(
-            ':versionId',
-            'someVersionId',
-          ),
-          isReady: true,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ELECTRONIC_MONITORING_CONDITIONS',
-          path: paths.MONITORING_CONDITIONS.CHECK_YOUR_ANSWERS_VERSION.replace(':orderId', order.id).replace(
-            ':versionId',
-            'someVersionId',
-          ),
-          isReady: false,
-        },
-        {
-          checked: false,
-          completed: false,
-          name: 'ADDITIONAL_DOCUMENTS',
-          path: paths.ATTACHMENT.ATTACHMENTS_VERSION.replace(':orderId', order.id).replace(
-            ':versionId',
-            'someVersionId',
-          ),
-          isReady: true,
-        },
-      ])
-    })
-
-    it('should return interested parties section as incomplete if notifying organisation fields are null', async () => {
-      // Given
-      const order = getMockOrder({
-        deviceWearer: createDeviceWearer({ noFixedAbode: true }),
-        contactDetails: createContactDetails(),
-        interestedParties: createInterestedParties({
-          notifyingOrganisation: null,
-          notifyingOrganisationName: null,
-          notifyingOrganisationEmail: null,
-          responsibleOfficerFirstName: null,
-        }),
-      })
-
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      const interestedPartiesSection = sections.find(
-        section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-      )
-
-      expect(interestedPartiesSection?.completed).toBe(false)
-    })
-
-    describe('interested parties flow', () => {
-      it('should navigate to CYA when notifying and responsible organisations are to check', async () => {
-        const order = getMockOrder({
-          interestedParties: createInterestedParties({ responsibleOfficerFirstName: 'mockUser' }),
-          isSentencingAct: true,
-        })
-        const taskListService = new TaskListService(mockOrderChecklistService)
-
-        const sections = await taskListService.getSections(order)
-
-        const interestedPartiesSection = sections.find(
-          section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-        )
-        expect(interestedPartiesSection).toEqual(
-          expect.objectContaining({
-            checked: false,
-            completed: true,
-            path: paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-          }),
-        )
-      })
-
-      it('should navigate to CYA when notifying and responsible organisations are complete', async () => {
-        const order = getMockOrder({
-          interestedParties: createInterestedParties({
-            responsibleOfficerFirstName: 'mockUser',
-          }),
-          isSentencingAct: false,
-        })
-        mockOrderChecklistService.getChecklist.mockResolvedValueOnce({
-          ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS: true,
-          ABOUT_THE_CHANGES_IN_THIS_VERSION_OF_THE_FORM: false,
-          ABOUT_THE_DEVICE_WEARER: false,
-          CONTACT_INFORMATION: false,
-          RISK_INFORMATION: false,
-          ELECTRONIC_MONITORING_CONDITIONS: false,
-          ADDITIONAL_DOCUMENTS: false,
-        })
-        const taskListService = new TaskListService(mockOrderChecklistService)
-
-        const sections = await taskListService.getSections(order)
-
-        const interestedPartiesSection = sections.find(
-          section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-        )
-        expect(interestedPartiesSection?.path).toBe(
-          paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-        )
-      })
-
-      it('should navigate to CYA when viewing notifying and responsible organisations', async () => {
-        const order = getMockOrder({
-          status: 'SUBMITTED',
-        })
-
-        const taskListService = new TaskListService(mockOrderChecklistService)
-
-        const sections = await taskListService.getSections(order)
-
-        const interestedPartiesSection = sections.find(
-          section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-        )
-
-        expect(interestedPartiesSection?.path).toBe(
-          paths.INTEREST_PARTIES.CHECK_YOUR_ANSWERS.replace(':orderId', order.id),
-        )
-      })
-    })
-
-    it('should navigate to dapo page when offence flow is enabled and notifyingOrganisation is FAMILY_COURT', async () => {
-      const mockGet = jest.fn((flag: string) => flag === 'OFFENCE_FLOW_ENABLED')
-      const mockGetValue = jest.fn(() => '')
-      jest.spyOn(FeatureFlags, 'getInstance').mockReturnValue({
-        get: mockGet,
-        getValue: mockGetValue,
-      } as never)
-
-      const order = getMockOrder({
-        interestedParties: createInterestedParties({
-          notifyingOrganisation: 'FAMILY_COURT',
-        }),
-      })
-
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      const riskInformationSection = sections.find(section => section.name === 'RISK_INFORMATION')
-
-      expect(riskInformationSection?.path).toBe(paths.INSTALLATION_AND_RISK.DAPO.replace(':orderId', order.id))
-
-      jest.restoreAllMocks()
-    })
-
-    it('should navigate to offence page when offence flow is enabled and notifyingOrganisation is not FAMILY_COURT', async () => {
-      const mockGet = jest.fn((flag: string) => flag === 'OFFENCE_FLOW_ENABLED')
-      const mockGetValue = jest.fn(() => '')
-      jest.spyOn(FeatureFlags, 'getInstance').mockReturnValue({
-        get: mockGet,
-        getValue: mockGetValue,
-      } as never)
-
-      const order = getMockOrder({
-        interestedParties: createInterestedParties({
-          notifyingOrganisation: 'CROWN_COURT',
-        }),
-      })
-
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      const riskInformationSection = sections.find(section => section.name === 'RISK_INFORMATION')
-
-      expect(riskInformationSection?.path).toBe(
-        paths.INSTALLATION_AND_RISK.OFFENCE_NEW_ITEM.replace(':orderId', order.id),
-      )
-
-      jest.restoreAllMocks()
-    })
-
-    it('should navigate to risk at installation page when offence flow is enabled and notifyingOrganisation is HOME_OFFICE', async () => {
-      const mockGet = jest.fn((flag: string) => flag === 'OFFENCE_FLOW_ENABLED')
-      const mockGetValue = jest.fn(() => '')
-      jest.spyOn(FeatureFlags, 'getInstance').mockReturnValue({
-        get: mockGet,
-        getValue: mockGetValue,
-      } as never)
-
-      const order = getMockOrder({
-        interestedParties: createInterestedParties({
-          notifyingOrganisation: 'HOME_OFFICE',
-        }),
-      })
-
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      const sections = await taskListService.getSections(order)
-
-      const riskInformationSection = sections.find(section => section.name === 'RISK_INFORMATION')
-
-      expect(riskInformationSection?.path).toBe(
-        paths.INSTALLATION_AND_RISK.DETAILS_OF_INSTALLATION.replace(':orderId', order.id),
-      )
-
-      jest.restoreAllMocks()
-    })
-
-    it('should mark RISK_INFORMATION section as complete when offence flow is enabled and section is filled in, offence flow', async () => {
-      const mockGet = jest.fn((flag: string) => flag === 'OFFENCE_FLOW_ENABLED')
-      const mockGetValue = jest.fn(() => '')
-      jest.spyOn(FeatureFlags, 'getInstance').mockReturnValue({
-        get: mockGet,
-        getValue: mockGetValue,
-      } as never)
-
-      const order = getMockOrder({
-        interestedParties: createInterestedParties({
-          notifyingOrganisation: 'CROWN_COURT',
-        }),
-        dapoClauses: [],
-        offences: [{ offenceType: 'offenceType', offenceDate: new Date().toISOString() }],
-        detailsOfInstallation: { riskCategory: ['some category'], genderRiskDetails: '', riskDetails: '' },
-        offenceAdditionalDetails: { additionalDetails: 'details' },
-      })
-
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      const riskInformationSection = sections.find(section => section.name === 'RISK_INFORMATION')
-
-      expect(riskInformationSection?.completed).toBe(true)
-
-      jest.restoreAllMocks()
-    })
-
-    it('should mark RISK_INFORMATION section as incomplete when only legacy offence fields are populated, offence flow', async () => {
-      const mockGet = jest.fn((flag: string) => flag === 'OFFENCE_FLOW_ENABLED')
-      const mockGetValue = jest.fn(() => '')
-      jest.spyOn(FeatureFlags, 'getInstance').mockReturnValue({
-        get: mockGet,
-        getValue: mockGetValue,
-      } as never)
-
-      const order = getMockOrder({
-        dataDictionaryVersion: 'DDV6',
-        interestedParties: createInterestedParties({
-          notifyingOrganisation: 'CROWN_COURT',
-        }),
-        installationAndRisk: createInstallationAndRisk({
-          offence: 'SEXUAL_OFFENCES',
-          offenceAdditionalDetails: 'mock offence additional details',
-        }),
-        offences: [],
-        detailsOfInstallation: { riskCategory: ['some category'], genderRiskDetails: '', riskDetails: '' },
-        offenceAdditionalDetails: { additionalDetails: 'details' },
-      })
-
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      const riskInformationSection = sections.find(section => section.name === 'RISK_INFORMATION')
-
-      expect(riskInformationSection?.completed).toBe(false)
-
-      jest.restoreAllMocks()
-    })
-
-    it('should mark RISK_INFORMATION section as complete when offence flow is enabled and section is filled in, dapo flow', async () => {
-      const mockGet = jest.fn((flag: string) => flag === 'OFFENCE_FLOW_ENABLED')
-      const mockGetValue = jest.fn(() => '')
-      jest.spyOn(FeatureFlags, 'getInstance').mockReturnValue({
-        get: mockGet,
-        getValue: mockGetValue,
-      } as never)
-
-      const order = getMockOrder({
-        interestedParties: createInterestedParties({
-          notifyingOrganisation: 'FAMILY_COURT',
-        }),
-        dapoClauses: [{ date: new Date().toISOString(), clause: 'clause' }],
-        detailsOfInstallation: { riskCategory: ['some category'], genderRiskDetails: '', riskDetails: '' },
-      })
-
-      const taskListService = new TaskListService(mockOrderChecklistService)
-
-      // When
-      const sections = await taskListService.getSections(order)
-
-      // Then
-      const riskInformationSection = sections.find(section => section.name === 'RISK_INFORMATION')
-
-      expect(riskInformationSection?.completed).toBe(true)
-
-      jest.restoreAllMocks()
-    })
-
-    it('should not route to the sentencing act page if a prison user has already answered', async () => {
-      const order = getMockOrder({
-        interestedParties: createInterestedParties({
-          responsibleOfficerFirstName: 'mockUser',
-          notifyingOrganisation: 'PRISON',
-        }),
-        isSentencingAct: true,
-      })
-      const taskListService = new TaskListService(mockOrderChecklistService)
-      const sections = await taskListService.getSections(order)
-      const interestedParties = sections.find(
-        section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-      )
-      expect(interestedParties!.path).not.toBe(
-        paths.INTEREST_PARTIES.SENTENCING_ACT_SELECTION.replace(':orderId', order.id),
-      )
-    })
-
-    it('should route to the sentencing act page if a prison user has not answered', async () => {
-      const order = getMockOrder({
-        interestedParties: createInterestedParties({
-          responsibleOfficerFirstName: 'mockUser',
-          notifyingOrganisation: 'PRISON',
-        }),
-        isSentencingAct: null,
-      })
-      const taskListService = new TaskListService(mockOrderChecklistService)
-      const sections = await taskListService.getSections(order)
-      const interestedParties = sections.find(
-        section => section.name === 'ABOUT_THE_NOTIFYING_AND_RESPONSIBLE_ORGANISATIONS',
-      )
-      expect(interestedParties?.completed).toBe(false)
-      expect(interestedParties!.path).toBe(
-        paths.INTEREST_PARTIES.SENTENCING_ACT_SELECTION.replace(':orderId', order.id),
-      )
-    })
-  })
   describe('getNextCheckYourAnswersPage', () => {
     let order: Order
     beforeAll(() => {
@@ -1458,7 +625,7 @@ describe('TaskListService', () => {
     })
 
     it('returns installation and risk CYA if current page is device wearer CYA', () => {
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
 
       const nextPage = taskListService.getNextCheckYourAnswersPage('CHECK_ANSWERS_DEVICE_WEARER', order)
 
@@ -1466,7 +633,7 @@ describe('TaskListService', () => {
     })
 
     it('returns monitoring conditions CYA if current page is risk information CYA', () => {
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
 
       const nextPage = taskListService.getNextCheckYourAnswersPage('CHECK_ANSWERS_INSTALLATION_AND_RISK', order)
 
@@ -1474,7 +641,7 @@ describe('TaskListService', () => {
     })
 
     it('returns the summary page if current page is last CYA page', () => {
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
 
       const nextPage = taskListService.getNextCheckYourAnswersPage('CHECK_ANSWERS_MONITORING_CONDITIONS', order)
 
@@ -1493,7 +660,7 @@ describe('TaskListService', () => {
         completed: true,
       })
 
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
 
       const result = taskListService.getCheckYourAnswersPathForSection(tasks)
 
@@ -1517,7 +684,7 @@ describe('TaskListService', () => {
         completed: true,
       })
 
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
 
       const result = taskListService.getCheckYourAnswersPathForSection(tasks)
 
@@ -1534,7 +701,7 @@ describe('TaskListService', () => {
         completed: true,
       })
 
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
 
       const result = taskListService.getCheckYourAnswersPathForSection(tasks)
 
@@ -1561,7 +728,7 @@ describe('TaskListService', () => {
         completed: false,
       })
 
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
 
       const result = taskListService.getNextTaskPath(tasks, 'mockOrderId')
 
@@ -1578,7 +745,7 @@ describe('TaskListService', () => {
         completed: true,
       })
 
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
 
       const mockOrderId = 'mockOrderId'
       const mockVersionId = 'mockVersionId'
@@ -1610,7 +777,7 @@ describe('TaskListService', () => {
         completed: true,
       })
 
-      const taskListService = new TaskListService(mockOrderChecklistService)
+      const taskListService = new TaskListService()
 
       const mockOrderId = 'mockOrderId'
       const result = taskListService.getNextTaskPath(tasks, mockOrderId)

--- a/server/services/taskListService.ts
+++ b/server/services/taskListService.ts
@@ -3,7 +3,6 @@ import paths from '../constants/paths'
 import { AddressType } from '../models/Address'
 import { convertBooleanToEnum, isNotNullOrEmptyString, isNotNullOrUndefined, isNullOrUndefined } from '../utils/utils'
 import AttachmentType from '../models/AttachmentType'
-import OrderChecklistService from './orderChecklistService'
 import FeatureFlags from '../utils/featureFlags'
 import isVariationType from '../utils/isVariationType'
 import isOrderDataDictionarySameOrAbove from '../utils/dataDictionaryVersionComparer'
@@ -93,14 +92,6 @@ export type Task = {
   completed: boolean
 }
 
-type SectionBlock = {
-  name: Section
-  completed: boolean
-  checked: boolean
-  path: string
-  isReady: boolean
-}
-
 type FormData = Record<string, string | boolean>
 
 export const canBeCompleted = (task: Task): boolean => {
@@ -146,7 +137,7 @@ const isTagAtSourceAvailable = (order: Order): boolean => {
 }
 
 export default class TaskListService {
-  constructor(private readonly checklistService: OrderChecklistService) {}
+  constructor() {}
 
   getTasks(order: Order): Array<Task> {
     const tasks: Array<Task> = []
@@ -660,10 +651,6 @@ export default class TaskListService {
     return tasks.filter(task => task.section === this.getNextSection(tasks, currentPage))
   }
 
-  getSectionCheckYourAnswersPage(sectionTasks: Task[]): Task {
-    return sectionTasks.find(task => task.name.startsWith(CYA_PREFIX))!
-  }
-
   getNextCheckYourAnswersPage(currentPage: Page, order: Order, versionId?: string) {
     const tasks = this.getTasks(order)
 
@@ -690,67 +677,6 @@ export default class TaskListService {
       .slice(this.getCurrentTaskIndex(tasks, currentPage) + 1)
       .find(item => item.name.startsWith('CHECK_ANSWERS'))
     return nextCheckYourAnswersPage ? tasks.findIndex(({ name }) => name === nextCheckYourAnswersPage.name) : -1
-  }
-
-  findTaskBySection(tasks: Task[], section: Section): Task[] {
-    return tasks.filter(task => task.section === section)
-  }
-
-  isSectionComplete(tasks: Task[], order: Order, section: Section): boolean {
-    const tasksCompleted = tasks.every(task => (canBeCompleted(task) ? task.completed : true))
-    if (section === SECTIONS.electronicMonitoringCondition) {
-      const anyConditionCompleted =
-        order.monitoringConditionsAlcohol?.startDate !== undefined ||
-        order.curfewConditions?.startDate !== undefined ||
-        order.monitoringConditionsTrail?.startDate !== undefined ||
-        order.enforcementZoneConditions?.length !== 0 ||
-        order.mandatoryAttendanceConditions?.length !== 0
-      return tasksCompleted && anyConditionCompleted
-    }
-
-    return tasksCompleted
-  }
-
-  isSectionReady(section: Section, tasks: Task[], order: Order): boolean {
-    if (section === SECTIONS.electronicMonitoringCondition) {
-      const deviceWearerTasks = this.findTaskBySection(tasks, SECTIONS.aboutTheDeviceWearer)
-      return this.isSectionComplete(deviceWearerTasks, order, SECTIONS.aboutTheDeviceWearer)
-    }
-    return true
-  }
-
-  async getSections(order: Order, versionId?: string): Promise<SectionBlock[]> {
-    const tasks = this.getTasks(order)
-    const checkList = await this.checklistService.getChecklist(`${order.id}-${order.versionId}`)
-
-    return Object.values(SECTIONS)
-      .filter(section => section !== SECTIONS.variationDetails || isVariationType(order.type))
-      .filter(section => section !== SECTIONS.contactInformation)
-      .map(section => {
-        const sectionsTasks = this.findTaskBySection(tasks, section)
-        const completed = this.isSectionComplete(sectionsTasks, order, section)
-        let path: string
-        if (order.status !== 'IN_PROGRESS' || completed) {
-          path = this.getCheckYourAnswersPathForSection(sectionsTasks)
-        } else {
-          const firstAvailableTask = sectionsTasks.find(task => canBeCompleted(task))
-          path = (firstAvailableTask || sectionsTasks[0]).path
-        }
-
-        path = path.replace(':orderId', order.id)
-
-        if (versionId) {
-          path = path.replace(`order/${order.id}`, `order/${order.id}/version/${versionId}`)
-        }
-
-        return {
-          name: section,
-          completed,
-          checked: checkList[section],
-          path,
-          isReady: this.isSectionReady(section, tasks, order),
-        }
-      })
   }
 
   getCheckYourAnswersPathForSection = (sectionTasks: Task[]) => {

--- a/server/types/i18n/index.ts
+++ b/server/types/i18n/index.ts
@@ -8,6 +8,7 @@ import CurfewConditionsPageContent from './pages/curfewConditions'
 import CurfewReleaseDatePageContent from './pages/curfewReleaseDate'
 import CurfewTimeTablePageContent from './pages/curfewTimeTable'
 import DeviceWearerPageContent from './pages/deviceWearer'
+import DeviceWearerSearchResultsPageContent from './pages/deviceWearerSearchResults'
 import EnforcementZonePageContent from './pages/enforcementZone'
 import HavePhotoPageContent from './pages/havePhoto'
 import IdentityNumbersPageContent from './pages/identityNumbers'
@@ -55,6 +56,7 @@ type I18n = {
     curfewTimetable: CurfewTimeTablePageContent
     deleteConfirm: ConfirmationPageContent
     deviceWearer: DeviceWearerPageContent
+    deviceWearerSearchResults: DeviceWearerSearchResultsPageContent
     editConfirm: ConfirmationPageContent
     exclusionZone: EnforcementZonePageContent
     restrictionZone: EnforcementZonePageContent

--- a/server/types/i18n/pages/deviceWearerSearchResults.ts
+++ b/server/types/i18n/pages/deviceWearerSearchResults.ts
@@ -1,0 +1,18 @@
+type DeviceWearerSearchResultsPageContent = {
+  section: string
+  titleFound: string
+  titleNoResults: string
+  messages: {
+    oneResultFound: string
+    noResultsFound: string
+  }
+  links: {
+    searchAgain: string
+    enterDetailsManually: string
+  }
+  buttons: {
+    useThisDeviceWearer: string
+  }
+}
+
+export default DeviceWearerSearchResultsPageContent

--- a/server/views/pages/order/about-the-device-wearer/device-wearer-search-results.njk
+++ b/server/views/pages/order/about-the-device-wearer/device-wearer-search-results.njk
@@ -1,0 +1,37 @@
+{% extends "../../../partials/form-layout.njk" %}
+
+{% set section = content.pages.deviceWearerSearchResults.section %}
+{% set continueButtonText = content.pages.deviceWearerSearchResults.buttons.useThisDeviceWearer %}
+{% set continueDisabled = not hasMatch %}
+{% set hideContinueButton = not hasMatch %}
+{% set hideCancelButton = not hasMatch %}
+
+{% block formInputs %}
+  <input type="hidden" name="searchedIdentifier" value="{{ searchedIdentifier }}">
+
+  {% if hasMatch %}
+    <p class="govuk-body">
+      {{ content.pages.deviceWearerSearchResults.messages.oneResultFound | replace('{identifier}', searchedIdentifier) | safe }}
+      <a href="{{ searchAgainLink }}" class="govuk-link">{{ content.pages.deviceWearerSearchResults.links.searchAgain }}</a>
+    </p>
+
+    <div class="govuk-inset-text">
+      <p class="govuk-body govuk-!-margin-bottom-1">{{ fullName }}</p>
+      {% if dateOfBirth %}
+        <p class="govuk-body govuk-!-margin-bottom-0">Date of birth - {{ dateOfBirth }}</p>
+      {% endif %}
+    </div>
+  {% else %}
+    <p class="govuk-body">
+      {{ content.pages.deviceWearerSearchResults.messages.noResultsFound | replace('{identifier}', searchedIdentifier) | safe }}
+    </p>
+
+    <p class="govuk-body">
+      <a href="{{ searchAgainLink }}" class="govuk-link">{{ content.pages.deviceWearerSearchResults.links.searchAgain }}</a>
+    </p>
+  {% endif %}
+
+  <p class="govuk-body">
+    <a href="{{ enterDetailsManuallyLink }}" class="govuk-link">{{ content.pages.deviceWearerSearchResults.links.enterDetailsManually }}</a>
+  </p>
+{% endblock %}

--- a/server/views/partials/form-layout.njk
+++ b/server/views/partials/form-layout.njk
@@ -106,11 +106,13 @@
                 disabled: continueDisabled
               }) }}
           {% elseif isOrderEditable %}
-            {{ govukButton({
-                text: "Save and continue" if not continueButtonText else continueButtonText,
-                name: "action",
-                value: "continue"
-            }) }}
+            {% if not hideContinueButton %}
+              {{ govukButton({
+                  text: "Save and continue" if not continueButtonText else continueButtonText,
+                  name: "action",
+                  value: "continue"
+              }) }}
+            {% endif %}
             {% if not hideCancelButton %}
             {{ govukButton({
                 text: "Save as draft" if not backButtonText else backButtonText,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "experimentalDecorators": true,
     "typeRoots": ["./server/@types", "./node_modules/@types"],
     "types": ["node", "jest"],
-    "strict": true
+    "strict": true,
+    "noUnusedLocals": true
   },
   "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "cypress.config.ts", "esbuild"],
   "include": ["**/*.js", "**/*.ts"]


### PR DESCRIPTION
Introduce a new device wearer search results page with route/controller/service/i18n and integration coverage.\n\nRefactor the flow to pass searchedIdentifier as a query parameter, fetch match details via placeholder backend GET, and confirm selection via placeholder backend POST before navigating to personal details.\n\nAlso update the no-result UI to hide action buttons and align tests and scenario flows with the new navigation.

### Context

Ticket: https://dsdmoj.atlassian.net/browse/ELM-5021

